### PR TITLE
Add instructions on using `NewClient` in its Godoc docblock

### DIFF
--- a/client.go
+++ b/client.go
@@ -321,8 +321,30 @@ var (
 // NewClient creates a new Client with the given database driver and
 // configuration.
 //
-// Currently only one driver is supported, which is Pgx V5. See package
+// Currently only one driver is supported, which is Pgx v5. See package
 // riverpgxv5.
+//
+// The function takes a generic parameter TTx representing a transaction type,
+// but it can be omitted because it'll generally always be inferred from the
+// driver. For example:
+//
+//	import "github.com/riverqueue/river"
+//	import "github.com/riverqueue/river/riverdriver/riverpgxv5"
+//
+//	...
+//
+//	dbPool, err := pgxpool.New(ctx, os.Getenv("DATABASE_URL"))
+//	if err != nil {
+//		// handle error
+//	}
+//	defer dbPool.Close()
+//
+//	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+//		...
+//	})
+//	if err != nil {
+//		// handle error
+//	}
 func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client[TTx], error) {
 	if driver == nil {
 		return nil, errMissingDriver


### PR DESCRIPTION
There's an example at the top of the River package demonstrating the use
of `NewClient`, but as I was reading the docs today, I realized that
since `NewClient` is somewhat non-trivial to invoke because it requires
a generic parameter, it'd be a good idea to also have an example of its
use right in `NewClient`'s docblock. That way, if a user is viewing this
function they don't need to go hunt around for examples to try and
figure out how to use it.