### PR TITLE
Error on batch insert if `InsertOpts.UniqueOpts` is specified

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -722,6 +722,18 @@ func Test_Client_InsertMany(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+
+	t.Run("ErrorsOnInsertOptsUniqueOpts", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		count, err := client.InsertMany(ctx, []InsertManyParams{
+			{Args: noOpArgs{}, InsertOpts: &InsertOpts{UniqueOpts: UniqueOpts{ByArgs: true}}},
+		})
+		require.EqualError(t, err, "UniqueOpts are not supported for batch inserts")
+		require.Equal(t, int64(0), count)
+	})
 }
 
 func Test_Client_InsertManyTx(t *testing.T) {
@@ -808,6 +820,18 @@ func Test_Client_InsertManyTx(t *testing.T) {
 			{Args: unregisteredJobArgs{}},
 		})
 		require.NoError(t, err)
+	})
+
+	t.Run("ErrorsOnInsertOptsUniqueOpts", func(t *testing.T) {
+		t.Parallel()
+
+		client, bundle := setup(t)
+
+		count, err := client.InsertManyTx(ctx, bundle.tx, []InsertManyParams{
+			{Args: noOpArgs{}, InsertOpts: &InsertOpts{UniqueOpts: UniqueOpts{ByArgs: true}}},
+		})
+		require.EqualError(t, err, "UniqueOpts are not supported for batch inserts")
+		require.Equal(t, int64(0), count)
 	})
 }
 


### PR DESCRIPTION
As I was writing docs for batch insertion today [1], I remembered that
we don't support job uniqueness on batch inserts because the mechanism
uses PG advisory locks, and holding many locks at once could easily lead
to contention and deadlocks.

We may remove this limitation in the future, but I figure that in the
meantime, it might not be the worst idea to error if they're specified
on batch insert so as not to mislead the user that what they expected to
happen happened. That's what this change does.

[1] https://riverqueue.com/docs/batch-job-insertion