### PR TITLE
Documentation fix for the `UniqueOpts.ByState` parameter

### DIFF
--- a/insert_opts.go
+++ b/insert_opts.go
@@ -98,7 +98,7 @@ type UniqueOpts struct {
 	// Unlike other unique options, ByState gets a default when it's not set for
 	// user convenience. The default is equivalent to:
 	//
-	// 	ByState: []river.JobState{river.JobStateAvailable, river.JobStateRunning, river.JobStateRetryable, river.JobStateScheduled}
+	// 	ByState: []river.JobState{river.JobStateAvailable, river.JobStateCompleted, river.JobStateRunning, river.JobStateRetryable, river.JobStateScheduled}
 	//
 	// With this setting, any jobs of the same kind that have been completed or
 	// discarded, but not yet cleaned out by the system, won't count towards the


### PR DESCRIPTION
A few weeks back we ended up changing the default set of states for the
`UniqueOpts.ByState` property -- previously, it hadn't included completed
jobs, but it was changed so that it did.

I thought I'd fixed the documentation as I was bringing that in, but
apparently I forgot. Here, update the Godoc for `UniqueOpts.ByState` to
also include completed jobs.