### PR TITLE
Bump comments in the unique job example

### DIFF
--- a/example_unique_job_test.go
+++ b/example_unique_job_test.go
@@ -97,13 +97,15 @@ func Example_uniqueJob() {
 		panic(err)
 	}
 
+	// First job insertion for account 1.
 	_, err = riverClient.Insert(ctx, ReconcileAccountArgs{AccountID: 1}, nil)
 	if err != nil {
 		panic(err)
 	}
 
 	// Job is inserted a second time, but it doesn't matter because its unique
-	// args ensure that it'll only run once per account per 24 hour period.
+	// args cause the insertion to be skipped because it's meant to only run
+	// once per account per 24 hour period.
 	_, err = riverClient.Insert(ctx, ReconcileAccountArgs{AccountID: 1}, nil)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
An incredibly trivial change to bump a few comments in the unique job
example in accordance to how they're written in our documentation. I
realized one of the comments implied that the job would be worked
exactly once which isn't a guarantee that we can actually make. Say that
insertion will be skipped instead.