### PR TITLE
Add context to error handler's `HandleError` and `HandlePanic`

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -871,7 +871,7 @@ func Test_Client_ErrorHandler(t *testing.T) {
 
 		var errorHandlerCalled bool
 		config.ErrorHandler = &testErrorHandler{
-			HandleErrorFunc: func(job *JobRow, err error) *ErrorHandlerResult {
+			HandleErrorFunc: func(ctx context.Context, job *JobRow, err error) *ErrorHandlerResult {
 				require.Equal(t, handlerErr, err)
 				errorHandlerCalled = true
 				return &ErrorHandlerResult{}
@@ -893,7 +893,7 @@ func Test_Client_ErrorHandler(t *testing.T) {
 
 		var errorHandlerCalled bool
 		config.ErrorHandler = &testErrorHandler{
-			HandleErrorFunc: func(job *JobRow, err error) *ErrorHandlerResult {
+			HandleErrorFunc: func(ctx context.Context, job *JobRow, err error) *ErrorHandlerResult {
 				var unknownJobKindErr *UnknownJobKindError
 				require.ErrorAs(t, err, &unknownJobKindErr)
 				require.Equal(t, *unknownJobKindErr, UnknownJobKindError{Kind: "RandomWorkerNameThatIsNeverRegistered"})
@@ -925,7 +925,7 @@ func Test_Client_ErrorHandler(t *testing.T) {
 
 		var panicHandlerCalled bool
 		config.ErrorHandler = &testErrorHandler{
-			HandlePanicFunc: func(job *JobRow, panicVal any) *ErrorHandlerResult {
+			HandlePanicFunc: func(ctx context.Context, job *JobRow, panicVal any) *ErrorHandlerResult {
 				require.Equal(t, "panic val", panicVal)
 				panicHandlerCalled = true
 				return &ErrorHandlerResult{}

--- a/error_handler.go
+++ b/error_handler.go
@@ -1,14 +1,22 @@
 package river
 
+import "context"
+
 // ErrorHandler provides an interface that will be invoked in case of an error
 // or panic occurring in the job. This is often useful for logging and exception
 // tracking, but can also be used to customize retry behavior.
 type ErrorHandler interface {
 	// HandleError is invoked in case of an error occurring in a job.
-	HandleError(job *JobRow, err error) *ErrorHandlerResult
+	//
+	// Context is descended from the one used to start the River client that
+	// worked the job.
+	HandleError(ctx context.Context, job *JobRow, err error) *ErrorHandlerResult
 
 	// HandlePanic is invoked in case of a panic occurring in a job.
-	HandlePanic(job *JobRow, panicVal any) *ErrorHandlerResult
+	//
+	// Context is descended from the one used to start the River client that
+	// worked the job.
+	HandlePanic(ctx context.Context, job *JobRow, panicVal any) *ErrorHandlerResult
 }
 
 type ErrorHandlerResult struct {

--- a/job_executor.go
+++ b/job_executor.go
@@ -232,7 +232,7 @@ func (e *jobExecutor) reportError(ctx context.Context) {
 		if e.ErrorHandler != nil {
 			fnName = "HandleError"
 			errorHandler = func() *ErrorHandlerResult {
-				return e.ErrorHandler.HandleError(e.JobRow, e.result.Err)
+				return e.ErrorHandler.HandleError(ctx, e.JobRow, e.result.Err)
 			}
 		}
 
@@ -243,7 +243,7 @@ func (e *jobExecutor) reportError(ctx context.Context) {
 		if e.ErrorHandler != nil {
 			fnName = "HandlePanic"
 			errorHandler = func() *ErrorHandlerResult {
-				return e.ErrorHandler.HandlePanic(e.JobRow, e.result.PanicVal)
+				return e.ErrorHandler.HandlePanic(ctx, e.JobRow, e.result.PanicVal)
 			}
 		}
 	}


### PR DESCRIPTION
As I was writing the documentation for `ErrorHandler` I realized that
it'd probably be desirable for its `HandleError` and `HandlePanic`
functions to take a context. The user might, for example, have a logger
embedded in context which they'd extract and use the log the error or
panic. This could also be done with a member field on implementing
struct of course, but it feels like making context available doesn't
really have a downside and its presence would likely be expected by some
users.

Another benefit is that in case someone is doing some heavy lifting in
one of these (they probably shouldn't be, but just in case), their
handlers could respond to the context cancellation caused by a client
`StopAndCancel` shutdown. Currently, the handlers are immune to
cancellation and could conceivably cause a shutdown to be stuck.