### PR TITLE
Drop client `Schema` configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,6 @@ const (
 	DefaultMaxAttempts = rivercommon.DefaultMaxAttempts
 	DefaultQueue       = rivercommon.DefaultQueue
 	DefaultPriority    = rivercommon.DefaultPriority
-	DefaultSchema      = "public"
 )
 
 // Config is the configuration for a Client.
@@ -154,10 +153,6 @@ type Config struct {
 	//
 	// Defaults to DefaultRetryPolicy.
 	RetryPolicy ClientRetryPolicy
-
-	// Schema is the name of the database schema to use for this Client. If
-	// unspecified, it defaults to DefaultSchema.
-	Schema string
 
 	// Workers is a bundle of registered job workers.
 	//
@@ -391,7 +386,6 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		ReindexerSchedule:           config.ReindexerSchedule,
 		RescueStuckJobsAfter:        valutil.ValOrDefault(config.RescueStuckJobsAfter, rescueAfter),
 		RetryPolicy:                 retryPolicy,
-		Schema:                      valutil.ValOrDefault(config.Schema, DefaultSchema),
 		Workers:                     config.Workers,
 		disableSleep:                config.disableSleep,
 	}

--- a/worker_test.go
+++ b/worker_test.go
@@ -87,7 +87,7 @@ func TestWorkFunc(t *testing.T) {
 		t.Helper()
 
 		client := newTestClient(ctx, t, newTestConfig(t, nil))
-		runClient(ctx, t, client)
+		startClient(ctx, t, client)
 
 		return client, &testBundle{}
 	}


### PR DESCRIPTION
As discussed in #15, the `Schema` configuration parameter doesn't
actually do anything, and we realized that it's possible to support this
feature by using an alternate configuration for pgxpool in `search_path`.

Here, drop `Schema` and add a test that verifies that this technique
works. So as to not have to create and migrate an alternate schema, we
cheat a little bit by repointing the schema and then just verifying that
we can't find a `river_job` table there.

I'm finding the test hierarchy in `client_test.go` to be pretty
confusing in determining on what best practice is for what should go
where, so I'm starting out with a new `Test_Client` which I'm hoping we
can start using as a base for most of the general tests in here in a
more reusable way. I leverage `JobArgsReflectKind` and `WorkFunc` in its
subtests so that it's not dependent on our various global job args that
are defined all over the place. Instead, args and the work routine are
colocated right inside the test.

Configuring an alternate schema is definitely going to need its own
documentation page somewhere because it's not obvious, but that'll come
separately.

Fixes #15.