### PR TITLE
Get a basic README in place

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-/*
-Package river is a robust high-performance job processing system for Go and
-Postgres.
+# River [![Build Status](https://github.com/riverqueue/river/workflows/CI/badge.svg)](https://github.com/riverqueue/river/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/riverqueue/river.svg)](https://pkg.go.dev/github.com/riverqueue/river)
+
+River is a robust high-performance job processing system for Go and Postgres.
 
 See [homepage], [docs], and [godoc].
 
@@ -11,7 +11,7 @@ avoided. Jobs are guaranteed to be enqueued if their transaction commits, are
 removed if their transaction rolls back, and aren't visible for work _until_
 commit. See [transactional enqueueing] for more background on this philosophy.
 
-# Job args and workers
+## Job args and workers
 
 Jobs are defined in struct pairs, with an implementation of [`JobArgs`] and one
 of [`Worker`].
@@ -20,37 +20,43 @@ Job args contain `json` annotations and define how jobs are serialized to and
 from the database, along with a "kind", a stable string that uniquely identifies
 the job.
 
-	type SortArgs struct {
-		// Strings is a slice of strings to sort.
-		Strings []string `json:"strings"`
-	}
+```go
+type SortArgs struct {
+    // Strings is a slice of strings to sort.
+    Strings []string `json:"strings"`
+}
 
-	func (SortArgs) Kind() string { return "sort" }
+func (SortArgs) Kind() string { return "sort" }
+```
 
 Workers expose a `Work` function that dictates how jobs run.
 
-	type SortWorker struct {
-	    // An embedded WorkerDefaults sets up default methods to fulfill the rest of
-	    // the Worker interface:
-	    river.WorkerDefaults[SortArgs]
-	}
+```go
+type SortWorker struct {
+    // An embedded WorkerDefaults sets up default methods to fulfill the rest of
+    // the Worker interface:
+    river.WorkerDefaults[SortArgs]
+}
 
-	func (w *SortWorker) Work(ctx context.Context, job *river.Job[SortArgs]) error {
-	    sort.Strings(job.Args.Strings)
-	    fmt.Printf("Sorted strings: %+v\n", job.Args.Strings)
-	    return nil
-	}
+func (w *SortWorker) Work(ctx context.Context, job *river.Job[SortArgs]) error {
+    sort.Strings(job.Args.Strings)
+    fmt.Printf("Sorted strings: %+v\n", job.Args.Strings)
+    return nil
+}
+```
 
-# Registering workers
+## Registering workers
 
 Jobs are uniquely identified by their "kind" string. Workers are registered on
 start up so that River knows how to assign jobs to workers:
 
-	workers := river.NewWorkers()
-	// AddWorker panics if the worker is already registered or invalid:
-	river.AddWorker(workers, &SortWorker{})
+```go
+workers := river.NewWorkers()
+// AddWorker panics if the worker is already registered or invalid:
+river.AddWorker(workers, &SortWorker{})
+```
 
-# Starting a client
+## Starting a client
 
 A River [`Client`] provides an interface for job insertion and manages job
 processing and [maintenance services]. A client's created with a database pool,
@@ -58,52 +64,58 @@ processing and [maintenance services]. A client's created with a database pool,
 Here's a client `Client` working one queue (`"default"`) with up to 100 worker
 goroutines at a time:
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-	    Queues: map[string]river.QueueConfig{
-	        river.DefaultQueue: {MaxWorkers: 100},
-	    },
-	    Workers: workers,
-	})
+```go
+riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+    Queues: map[string]river.QueueConfig{
+        river.DefaultQueue: {MaxWorkers: 100},
+    },
+    Workers: workers,
+})
 
-	if err != nil {
-	    panic(err)
-	}
+if err != nil {
+    panic(err)
+}
 
-	// Run the client inline. All executed jobs will inherit from ctx:
-	if err := riverClient.Start(ctx); err != nil {
-	    panic(err)
-	}
+// Run the client inline. All executed jobs will inherit from ctx:
+if err := riverClient.Start(ctx); err != nil {
+    panic(err)
+}
+```
 
-## Stopping
+### Stopping
 
 The client should also be stopped on program shutdown:
 
-	// Stop fetching new work and wait for active jobs to finish.
-	if err := riverClient.Stop(ctx); err != nil {
-	    panic(err)
-	}
+```go
+// Stop fetching new work and wait for active jobs to finish.
+if err := riverClient.Stop(ctx); err != nil {
+    panic(err)
+}
+```
 
 There are some complexities around ensuring clients stop cleanly, but also in a
 timely manner. See [graceful shutdown] for more details on River's stop modes.
 
-# Inserting jobs
+## Inserting jobs
 
 [`Client.InsertTx`] is used in conjunction with an instance of job args to
 insert a job to work on a transaction:
 
-	_, err = riverClient.InsertTx(ctx, tx, SortArgs{
-	    Strings: []string{
-	        "whale", "tiger", "bear",
-	    },
-	}, nil)
+```go
+_, err = riverClient.InsertTx(ctx, tx, SortArgs{
+    Strings: []string{
+        "whale", "tiger", "bear",
+    },
+}, nil)
 
-	if err != nil {
-	    panic(err)
-	}
+if err != nil {
+    panic(err)
+}
+```
 
 See the [`InsertAndWork` example] for complete code.
 
-# Other features
+## Other features
 
   - [Batch job insertion] for efficiently inserting many jobs at once using
     Postgres `COPY FROM`.
@@ -142,13 +154,11 @@ See also [developing River].
 [Transactional job completion]: https://riverqueue.com/docs/transactional-job-completion
 [Unique jobs]: https://riverqueue.com/docs/unique-jobs
 [Work functions]: https://riverqueue.com/docs/work-functions
-[docs]: https://riverqueue.com/docs
 [developing River]: https://github.com/riverqueue/river/blob/master/docs/development.md
+[docs]: https://riverqueue.com/docs
 [driver]: https://riverqueue.com/docs/database-drivers
 [godoc]: https://pkg.go.dev/github.com/riverqueue/river
 [graceful shutdown]: https://riverqueue.com/docs/graceful-shutdown
 [homepage]: https://riverqueue.com
 [maintenance services]: https://riverqueue.com/docs/maintenance-services
 [transactional enqueueing]: https://riverqueue.com/docs/transactional-enqueueing
-*/
-package river

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,7 @@ Raise test databases:
 
 Run tests:
 
-    go test ./...
+    go test ./... -p 1
 
 ### Run lint
 


### PR DESCRIPTION
Alright, so I don't love this, but here, aim to get a basic River README
in place for GitHub friendliness, largely via duplication.

Godoc is odd to say the least. These days it does dump a project README
automatically into godoc if one was present, but it's always a second
class citizen: it's collapsed when the user first visits the doc page,
and doesn't offer some niceties like the TOC that's generated for
`doc.go`. I searched around, and there's no easy compromise that gets
the best of both worlds.

So here:

* Move old README to `docs/development.md`.
* Make edits to `doc.go` so that it's more agnostic as to whether it's
  in godoc or rendered Markdown.
* Streamline the old `doc.go` somewhat for length. Add list of features
  that link out to our docs.
* Copy `doc.go` largely unedited to `docs/README.md`.

The trick with `docs/README.md` is that GitHub will still find a README
there and render it as the top level of a project, but godoc _won't_
find it and dump it into godoc (so we don't accidentally duplicate the
content twice in godoc).

On the way from `doc.go` to `docs/README.md` I made a couple small
tweaks for GitHub friendliness:

* Gave it an h1 of "River".
* Added badges.
* Starts with "River is a" instead of "Package River is a".
* Dedented all the headings. One thing that sucks about godoc is it
  won't render anything except an h1-level heading, but these look way
  too screamy in most Markdown renderings.
* Made all the code blocks Go-formatted. Godoc won't respect the three
  backtick syntax for codeblocks, so we can't use that there, but we
  also can't specify a language _without_ using them for GitHub.

Obviously, this isn't a great situation. I tried the use of the goreadme
tool in #19, but that comes with significant problems that aren't
fixable without issuing them pull requests.

For now, I propose that we duplicate changes manually between the two
documents while making them, and eventually write our own tool to do the
duplication. This is easier than it sounds because we can leverage Go's
internal tool for parsing godoc.