### PR TITLE
pin to riverpgxv5@v0.0.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,9 @@ linters-settings:
       - Default
       - Prefix(github.com/riverqueue)
 
+  gomoddirectives:
+    replace-local: true
+
   gosec:
     excludes:
       - G404 # use of non-crypto random; overly broad for our use case

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,14 @@ module github.com/riverqueue/river
 
 go 1.21.0
 
+replace github.com/riverqueue/river/riverdriver/riverpgxv5 => ./riverdriver/riverpgxv5
+
 require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
@@ -22,7 +25,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.0-20231110014757-1a7176abdf3c // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNs
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.0-20231110014757-1a7176abdf3c h1:UXvKR9qb10Rp/CQ29I5VqnvnGdATjS5MiGv03KUMDHo=
-github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.0-20231110014757-1a7176abdf3c/go.mod h1:Ocq2VuaKmczYSFUpbxr+o3l2hux0gjdg7qsfcIaNrjw=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=


### PR DESCRIPTION
To make this work, also set up a replace directive to use the local riverpgxv5 from within the river package's go.mod.

I tested this locally from our riverdemo test app and confirmed that I was able to import riverpgxv5@v0.0.1, and then even tested with a locally tagged river@v0.0.2 and was able to use that at the same time.

The [gomoddirectives](https://github.com/ldez/gomoddirectives/blob/master/gomoddirectives_test.go) linter does not allow any `replace` directives by default, but we can customize that to allow this one replace if you think this seems sane.