### PR TITLE
A few tiny documentation fixes with regards to development

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -126,7 +126,9 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Work functions] for simplified worker implementation.
 
-See also [developing River].
+# Development
+
+See [developing River].
 
 [`Client`]: https://pkg.go.dev/github.com/riverqueue/river#Client
 [`Client.InsertTx`]: https://pkg.go.dev/github.com/riverqueue/river#Client.InsertTx

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,7 +138,9 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Work functions] for simplified worker implementation.
 
-See also [developing River].
+## Development
+
+See [developing River].
 
 [`Client`]: https://pkg.go.dev/github.com/riverqueue/river#Client
 [`Client.InsertTx`]: https://pkg.go.dev/github.com/riverqueue/river#Client.InsertTx

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,10 +1,6 @@
-# River
+# River development
 
-River is an experimental Postgres queue for Go.
-
-## Development
-
-### Run tests
+## Run tests
 
 Raise test databases:
 
@@ -14,13 +10,13 @@ Run tests:
 
     go test ./... -p 1
 
-### Run lint
+## Run lint
 
 Run the linter and try to autofix:
 
     golangci-lint run --fix
 
-### Generate sqlc
+## Generate sqlc
 
 The project uses sqlc (`brew install sqlc`) to generate Go targets for Postgres
 queries. After changing an sqlc `.sql` file, generate Go with:


### PR DESCRIPTION
Follows up #21 with a few very small documentation fixes:

* Put the link to the development doc into its own section so that it
  looks less strange when following the list of features just before it.

* Promote the "development" header in the `development.md` up to h1
  since it's now a file only for development instructions. Promote all
  the other headers to h2.