### PR TITLE
Update changelog to prepare for 0.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4] - 2023-11-17
+
+### Changed
+
+- Allow River clients to be created with a driver with `nil` database pool for use in testing.
+- Update River test helpers API to use River drivers like `riverdriver/riverpgxv5` to make them agnostic to the third party database package in use.
+- Document `Config.JobTimeout`'s default value.
+- Functionally disable the `Reindexer` queue maintenance service. It'd previously only operated on currently unused indexes anyway, indexes probably do _not_ need to be rebuilt except under fairly rare circumstances, and it needs more work to make sure it's shored up against edge cases like indexes that fail to rebuild before a clien restart.
+
 ## [0.0.3] - 2023-11-13
 
 ### Changed
 
-- Fix license detection issues with riverdriver/riverpgxv5 submodule.
-- Ensure that river requires the riverpgxv5 module with the same version.
+- Fix license detection issues with `riverdriver/riverpgxv5` submodule.
+- Ensure that river requires the `riverpgxv5` module with the same version.
 
 ## [0.0.2] - 2023-11-13
 
 ### Changed
 
-- Pin own riverpgxv5 dependency to v0.0.1 and make it a direct locally-replaced dependency. This should allow projects to import versioned deps of both river and riverpgxv5.
+- Pin own `riverpgxv5` dependency to v0.0.1 and make it a direct locally-replaced dependency. This should allow projects to import versioned deps of both river and `riverpgxv5`.
 
 ## [0.0.1] - 2023-11-12
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.3
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.4
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Add the changes in #29 and #30 to the changelog so that we can cut a
0.0.4 release. For brevity and to keep signal high, I didn't include
changes that came in which aren't user facing.