### PR TITLE
Add the job timeout default to the godoc for `Config.JobTimeout`

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ const (
 	DefaultFetchPollInterval = 1 * time.Second
 	MinFetchPollInterval     = 1 * time.Millisecond
 
-	DefaultJobTimeout = time.Minute
+	DefaultJobTimeout = 1 * time.Minute
 
 	DefaultMaxAttempts = rivercommon.DefaultMaxAttempts
 	DefaultQueue       = rivercommon.DefaultQueue
@@ -106,6 +106,8 @@ type Config struct {
 	// context is cancelled. A timeout of zero means DefaultJobTimeout will be
 	// used, whereas a value of -1 means the job's context will not be cancelled
 	// unless the Client is shutting down.
+	//
+	// Defaults to 1 minute.
 	JobTimeout time.Duration
 
 	// Logger is the structured logger to use for logging purposes. If none is


### PR DESCRIPTION
A very small change to add the job timeout default in words to the
godoc for `Config.JobTimeout` so that it's easily visible in
documentation, and so that a user doesn't have to go chasing around for
the value in code.

There is some nominal doc rot risk in case we change this number, but
probably it's worth it for added convenience. We're also living in that
world already because ~all of the other configuration properties
document their defaults.