### PR TITLE
effectively disable reindexer

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1310,6 +1310,7 @@ func Test_Client_Maintenance(t *testing.T) {
 
 	t.Run("Reindexer", func(t *testing.T) {
 		t.Parallel()
+		t.Skip("Reindexer is disabled for further development")
 
 		config := newTestConfig(t, nil)
 		config.ReindexerSchedule = cron.Every(time.Second)

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -19,7 +19,7 @@ const (
 	DefaultTimeout           = 15 * time.Second
 )
 
-var defaultIndexNames = []string{"river_job_metadata_index", "river_job_args_index"} //nolint:gochecknoglobals
+var defaultIndexNames = []string{} //nolint:gochecknoglobals
 
 // Test-only properties.
 type ReindexerTestSignals struct {
@@ -43,9 +43,6 @@ type ReindexerConfig struct {
 }
 
 func (c *ReindexerConfig) mustValidate() *ReindexerConfig {
-	if len(c.IndexNames) < 1 {
-		panic("ReindexerConfig.IndexNames must have at least one entry")
-	}
 	if c.ScheduleFunc == nil {
 		panic("ReindexerConfig.ScheduleFunc must be set")
 	}


### PR DESCRIPTION
At this time, we're not sure we want to have a reindexer process automatically running. It could be a net negative for many use cases and we may want to do further work to avoid its potential downsides. For now, disable it by simply removing all the indexes from its default index list.