### PR TITLE
Comment out `replace` directive for `riverpgxv5`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,9 +64,6 @@ linters-settings:
       - Default
       - Prefix(github.com/riverqueue)
 
-  gomoddirectives:
-    replace-local: true
-
   gosec:
     excludes:
       - G404 # use of non-crypto random; overly broad for our use case

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/river
 
 go 1.21.0
 
-replace github.com/riverqueue/river/riverdriver/riverpgxv5 => ./riverdriver/riverpgxv5
+// replace github.com/riverqueue/river/riverdriver/riverpgxv5 => ./riverdriver/riverpgxv5
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNs
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.4 h1:336o1gbjpsSe1I9Es0eoJkBagXTmkXdzZ1M8j9kwLUU=
+github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.4/go.mod h1:k6hsPkW9Fl3qURzyLHbvxUCqWDpit0WrZ3oEaKezD3E=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=


### PR DESCRIPTION
I was trying to get CI working for the River demo project [1] and found
that it's not currently possible to install the River CLI to another Go
project:

    Run go install github.com/riverqueue/river/cmd/river@latest

    go: downloading github.com/riverqueue/river v0.0.4
    go: github.com/riverqueue/river/cmd/river@latest (in github.com/riverqueue/river@v0.0.4):
            The go.mod file for the module providing named packages contains one or
            more replace directives. It must not contain directives that would cause
            it to be interpreted differently than if it were the main module.
    Error: Process completed with exit code 1.

This is roughly consistent with what I'd previously understood for
`replace`. It's useful for debugging problems during development, but I
don't think it's meant to be a permanent decoration on a project. A
decent compromise is to keep it commented out, but available in case
it's needed to debug something, which is what I've done here.

Also, probably goes to show why it's important to keep a demo app
maintained so we can notice problems of this sort.

[1] https://github.com/bgentry/riverdemo/pull/7