### PR TITLE
Fix wrong example link to `InsertAndWork`

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -132,7 +132,7 @@ See [developing River].
 
 [`Client`]: https://pkg.go.dev/github.com/riverqueue/river#Client
 [`Client.InsertTx`]: https://pkg.go.dev/github.com/riverqueue/river#Client.InsertTx
-[`InsertAndWork` example]: https://pkg.go.dev/github.com/riverqueue/river#example-package-CustomInsertOpts
+[`InsertAndWork` example]: https://pkg.go.dev/github.com/riverqueue/river#example-package-InsertAndWork
 [`JobArgs`]: https://pkg.go.dev/github.com/riverqueue/river#JobArgs
 [`Worker`]: https://pkg.go.dev/github.com/riverqueue/river#Worker
 [Batch job insertion]: https://riverqueue.com/docs/batch-job-insertion

--- a/docs/README.md
+++ b/docs/README.md
@@ -144,7 +144,7 @@ See [developing River].
 
 [`Client`]: https://pkg.go.dev/github.com/riverqueue/river#Client
 [`Client.InsertTx`]: https://pkg.go.dev/github.com/riverqueue/river#Client.InsertTx
-[`InsertAndWork` example]: https://pkg.go.dev/github.com/riverqueue/river#example-package-CustomInsertOpts
+[`InsertAndWork` example]: https://pkg.go.dev/github.com/riverqueue/river#example-package-InsertAndWork
 [`JobArgs`]: https://pkg.go.dev/github.com/riverqueue/river#JobArgs
 [`Worker`]: https://pkg.go.dev/github.com/riverqueue/river#Worker
 [Batch job insertion]: https://riverqueue.com/docs/batch-job-insertion


### PR DESCRIPTION
I noticed by accident that the link to the `InsertAndWork` example from
the README/godoc was linking to `CustomInsertOpts` instead. Probably a
copy/pasta problem. Here, correct it.