### PR TITLE
run CI with 3 latest major Postgres versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        postgres-version: [16, 15, 14]
         go-version:
           - "1.21"
     timeout-minutes: 5
 
     services:
       postgres:
-        image: postgres
+        image: postgres:${{ matrix.postgres-version }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-


### PR DESCRIPTION
Partially addresses #49. Since we're running this in a public repo, we aren't subject to the same limits on GitHub Actions minutes that we would hit in private.

I figured that testing against the 3 latest Postgres versions is sufficient for now. Others can do additional validation against older versions if they like but this should be suitable guideline for us during development.