### PR TITLE
CI: don't fail-fast on matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         postgres-version: [16, 15, 14]
         go-version:
           - "1.21"
+      fail-fast: false
     timeout-minutes: 5
 
     services:


### PR DESCRIPTION
If one of the postgres versions fails, don't instantly cancel the other ones. This makes retrying quite painful, as I experienced in [this build](https://github.com/riverqueue/river/actions/runs/6938941263/job/18875459395) after one node appears to have had some transient load issues.