### PR TITLE
fix v003 migration: set default + update rows before set not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9] - 2023-11-23
+
+### Fixed
+
+- **DATABASE MIGRATION**: Database schema v3 was introduced in v0.0.8 and contained an obvious flaw preventing it from running against existing tables. This migration was altered to execute the migration in multiple steps.
+
 ## [0.0.8] - 2023-11-21
 
 ### Changed

--- a/internal/dbmigrate/003_river_job_tags_non_null.up.sql
+++ b/internal/dbmigrate/003_river_job_tags_non_null.up.sql
@@ -1,2 +1,3 @@
-ALTER TABLE river_job ALTER COLUMN tags SET NOT NULL,
-                      ALTER COLUMN tags SET DEFAULT '{}';
+ALTER TABLE river_job ALTER COLUMN tags SET DEFAULT '{}';
+UPDATE river_job SET tags = '{}' WHERE tags IS NULL;
+ALTER TABLE river_job ALTER COLUMN tags SET NOT NULL;


### PR DESCRIPTION
The migration introduced in #53 / c5bd949 was flawed because it attempted to set a default and also set not null on an existing field all in one statement. This of course won't work if there are any existing rows in the table, because those need to be updated to be non-null before adding the not null constraint.

This change is made in place on the existing migration (rather than a new one) because it fixes the fact that the migration simply can't succeed on existing installs.

Note that there is still a chance of this failing on an existing system with a high write throughput. In the future @brandur we may need a different strategy to make this safe, such as splitting the change into multiple migrations. Hopefully we don't need to add any additional not null constraints though. 🤞

Fixes #63.