### PR TITLE
Consistently prefer `job` param name to `j`

### DIFF
--- a/example_error_handler_test.go
+++ b/example_error_handler_test.go
@@ -45,11 +45,11 @@ type ErroringWorker struct {
 	river.WorkerDefaults[ErroringArgs]
 }
 
-func (w *ErroringWorker) Work(ctx context.Context, j *river.Job[ErroringArgs]) error {
+func (w *ErroringWorker) Work(ctx context.Context, job *river.Job[ErroringArgs]) error {
 	switch {
-	case j.Args.ShouldError:
+	case job.Args.ShouldError:
 		return fmt.Errorf("this job errored")
-	case j.Args.ShouldPanic:
+	case job.Args.ShouldPanic:
 		panic("this job panicked")
 	}
 	return nil

--- a/example_job_cancel_test.go
+++ b/example_job_cancel_test.go
@@ -23,8 +23,8 @@ type CancellingWorker struct {
 	river.WorkerDefaults[CancellingArgs]
 }
 
-func (w *CancellingWorker) Work(ctx context.Context, j *river.Job[CancellingArgs]) error {
-	if j.Args.ShouldCancel {
+func (w *CancellingWorker) Work(ctx context.Context, job *river.Job[CancellingArgs]) error {
+	if job.Args.ShouldCancel {
 		fmt.Println("cancelling job")
 		return river.JobCancel(fmt.Errorf("this wrapped error message will be persisted to DB"))
 	}

--- a/example_job_snooze_test.go
+++ b/example_job_snooze_test.go
@@ -24,8 +24,8 @@ type SnoozingWorker struct {
 	river.WorkerDefaults[SnoozingArgs]
 }
 
-func (w *SnoozingWorker) Work(ctx context.Context, j *river.Job[SnoozingArgs]) error {
-	if j.Args.ShouldSnooze {
+func (w *SnoozingWorker) Work(ctx context.Context, job *river.Job[SnoozingArgs]) error {
+	if job.Args.ShouldSnooze {
 		fmt.Println("snoozing job for 5 minutes")
 		return river.JobSnooze(5 * time.Minute)
 	}

--- a/example_work_func_test.go
+++ b/example_work_func_test.go
@@ -37,8 +37,8 @@ func Example_workFunc() {
 	}
 
 	workers := river.NewWorkers()
-	river.AddWorker(workers, river.WorkFunc(func(ctx context.Context, j *river.Job[WorkFuncArgs]) error {
-		fmt.Printf("Message: %s", j.Args.Message)
+	river.AddWorker(workers, river.WorkFunc(func(ctx context.Context, job *river.Job[WorkFuncArgs]) error {
+		fmt.Printf("Message: %s", job.Args.Message)
 		return nil
 	}))
 

--- a/internal/cmd/producersample/main.go
+++ b/internal/cmd/producersample/main.go
@@ -214,10 +214,10 @@ type MyJobWorker struct {
 	logger        *slog.Logger
 }
 
-func (w *MyJobWorker) Work(ctx context.Context, j *river.Job[MyJobArgs]) error {
+func (w *MyJobWorker) Work(ctx context.Context, job *river.Job[MyJobArgs]) error {
 	atomic.AddUint64(&w.jobsPerformed, 1)
-	// fmt.Printf("performing job %d with args %+v\n", j.ID, j.Args)
-	if j.ID%1000 == 0 {
+	// fmt.Printf("performing job %d with args %+v\n", job.ID, job.Args)
+	if job.ID%1000 == 0 {
 		w.logger.Info("simulating stalled job, blocked on ctx.Done()")
 		<-ctx.Done()
 		w.logger.Info("stalled job exiting")

--- a/job_args_reflect_kind_test.go
+++ b/job_args_reflect_kind_test.go
@@ -13,7 +13,7 @@ import "reflect"
 //		Message `json:"message"`
 //	}
 //
-//	AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, j *Job[WorkFuncArgs]) error {
+//	AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, job *Job[WorkFuncArgs]) error {
 //		...
 //
 // Its major downside compared to a normal JobArgs implementation is that it's

--- a/job_executor_test.go
+++ b/job_executor_test.go
@@ -35,7 +35,7 @@ func (w *customRetryPolicyWorker) NextRetry(job *Job[callbackArgs]) time.Time {
 	return time.Time{}
 }
 
-func (w *customRetryPolicyWorker) Work(ctx context.Context, j *Job[callbackArgs]) error {
+func (w *customRetryPolicyWorker) Work(ctx context.Context, job *Job[callbackArgs]) error {
 	return w.f()
 }
 

--- a/rivertest/rivertest_test.go
+++ b/rivertest/rivertest_test.go
@@ -29,7 +29,7 @@ type Job1Worker struct {
 	river.WorkerDefaults[Job1Args]
 }
 
-func (w *Job1Worker) Work(ctx context.Context, j *river.Job[Job1Args]) error { return nil }
+func (w *Job1Worker) Work(ctx context.Context, job *river.Job[Job1Args]) error { return nil }
 
 type Job2Args struct {
 	Int int `json:"int"`
@@ -41,7 +41,7 @@ type Job2Worker struct {
 	river.WorkerDefaults[Job2Args]
 }
 
-func (w *Job2Worker) Work(ctx context.Context, j *river.Job[Job2Args]) error { return nil }
+func (w *Job2Worker) Work(ctx context.Context, job *river.Job[Job2Args]) error { return nil }
 
 // The tests for this function are quite minimal because it uses the same
 // implementation as the `*Tx` variant, so most of the test happens below.

--- a/worker.go
+++ b/worker.go
@@ -172,8 +172,8 @@ func (wf *workFunc[T]) Work(ctx context.Context, job *Job[T]) error {
 //
 // For example:
 //
-//	river.AddWorker(workers, river.WorkFunc(func(ctx context.Context, j *river.Job[WorkFuncArgs]) error {
-//		fmt.Printf("Message: %s", j.Args.Message)
+//	river.AddWorker(workers, river.WorkFunc(func(ctx context.Context, job *river.Job[WorkFuncArgs]) error {
+//		fmt.Printf("Message: %s", job.Args.Message)
 //		return nil
 //	}))
 func WorkFunc[T JobArgs](f func(context.Context, *Job[T]) error) Worker[T] {

--- a/worker_test.go
+++ b/worker_test.go
@@ -22,7 +22,7 @@ func TestWork(t *testing.T) {
 		AddWorker(workers, &noOpWorker{})
 	})
 
-	fn := func(ctx context.Context, j *Job[callbackArgs]) error { return nil }
+	fn := func(ctx context.Context, job *Job[callbackArgs]) error { return nil }
 	ch := callbackWorker{fn: fn}
 
 	// function worker
@@ -43,7 +43,7 @@ type configurableWorker struct {
 	WorkerDefaults[configurableArgs]
 }
 
-func (w *configurableWorker) Work(ctx context.Context, j *Job[configurableArgs]) error {
+func (w *configurableWorker) Work(ctx context.Context, job *Job[configurableArgs]) error {
 	return nil
 }
 
@@ -71,7 +71,7 @@ type StructWithFunc struct {
 	WorkChan chan struct{}
 }
 
-func (s *StructWithFunc) Work(ctx context.Context, j *Job[WorkFuncArgs]) error {
+func (s *StructWithFunc) Work(ctx context.Context, job *Job[WorkFuncArgs]) error {
 	s.WorkChan <- struct{}{}
 	return nil
 }
@@ -98,7 +98,7 @@ func TestWorkFunc(t *testing.T) {
 		client, _ := setup(t)
 
 		workChan := make(chan struct{})
-		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, j *Job[WorkFuncArgs]) error {
+		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, job *Job[WorkFuncArgs]) error {
 			workChan <- struct{}{}
 			return nil
 		}))
@@ -136,7 +136,7 @@ func TestWorkFunc(t *testing.T) {
 		}
 
 		workChan := make(chan struct{})
-		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, j *Job[InFuncWorkFuncArgs]) error {
+		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, job *Job[InFuncWorkFuncArgs]) error {
 			workChan <- struct{}{}
 			return nil
 		}))


### PR DESCRIPTION
When using a job parameter name for a worker, we weren't consistent
about whether to use `j` or `job` and have mixed convention all over the
place:

    func (w *Worker) Work(ctx context.Context, j *river.Job[ErroringArgs]) error {
    func (w *Worker) Work(ctx context.Context, job *river.Job[ErroringArgs]) error {

Generally in non-core-team Go, a convention of more than single
character variable names is preferred except in specific cases (e.g.
`i`), so here, move everything over to use the more explicit `job`.