### PR TITLE
Link up scheduled job docs from README and Godoc + changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10] - 2023-11-26
+
+### Added
+
+- Added `Example_scheduledJob`, demonstrating how to schedule a job to be run in the future.
+
 ### Fixed
 
 - Fixed a panic in the periodic job enqueuer caused by sometimes trying to reset a `time.Ticker` with a negative or zero duration. Fixed in PR #73.

--- a/doc.go
+++ b/doc.go
@@ -114,6 +114,9 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Periodic and cron jobs].
 
+  - [Scheduled jobs] that run automatically at their scheduled time in the
+    future.
+
   - [Snoozing jobs] from inside a work function.
 
   - [Subscriptions] to queue activity and statistics, providing easy hooks for
@@ -139,6 +142,7 @@ See [developing River].
 [Cancelling jobs]: https://riverqueue.com/docs/cancelling-jobs
 [Error and panic handling]: https://riverqueue.com/docs/error-handling
 [Periodic and cron jobs]: https://riverqueue.com/docs/periodic-jobs
+[Scheduled jobs]: https://riverqueue.com/docs/scheduled-jobs
 [Snoozing jobs]: https://riverqueue.com/docs/snoozing-jobs
 [Subscriptions]: https://riverqueue.com/docs/subscriptions
 [Transactional job completion]: https://riverqueue.com/docs/transactional-job-completion

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,9 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Periodic and cron jobs].
 
+  - [Scheduled jobs] that run automatically at their scheduled time in the
+    future.
+
   - [Snoozing jobs] from inside a work function.
 
   - [Subscriptions] to queue activity and statistics, providing easy hooks for
@@ -161,6 +164,7 @@ Thank you for driving the software ecosystem forward.
 [Cancelling jobs]: https://riverqueue.com/docs/cancelling-jobs
 [Error and panic handling]: https://riverqueue.com/docs/error-handling
 [Periodic and cron jobs]: https://riverqueue.com/docs/periodic-jobs
+[Scheduled jobs]: https://riverqueue.com/docs/scheduled-jobs
 [Snoozing jobs]: https://riverqueue.com/docs/snoozing-jobs
 [Subscriptions]: https://riverqueue.com/docs/subscriptions
 [Transactional job completion]: https://riverqueue.com/docs/transactional-job-completion


### PR DESCRIPTION
Small follow up to #70 in which we add a link to scheduled jobs from the
features list in the README and Godoc (making it really easy to find by
scanning in either place), along with a changelog entry for the new
example.