### PR TITLE
move DefaultClientRetryPolicy to the correct changelog version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a panic in the periodic job enqueuer caused by sometimes trying to reset a `time.Ticker` with a negative or zero duration. Fixed in PR #73.
 
+### Changed
+
+- `DefaultClientRetryPolicy`: calculate the next attempt based on the current time instead of the time the prior attempt began.
+
 ## [0.0.9] - 2023-11-23
 
 ### Fixed
 
 - **DATABASE MIGRATION**: Database schema v3 was introduced in v0.0.8 and contained an obvious flaw preventing it from running against existing tables. This migration was altered to execute the migration in multiple steps.
-
-### Changed
-
-- `DefaultClientRetryPolicy`: calculate the next attempt based on the current time instead of the time the prior attempt began.
 
 ## [0.0.8] - 2023-11-21
 


### PR DESCRIPTION
This was changed in #74, but the changelog entry was added to an existing version instead of the new/unreleased one. This change is actually part of v0.0.10