### PR TITLE
respect provided context in Stop + StopAndCancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Stop` and `StopAndCancel` have been changed to respect the provided context argument. When that context is cancelled or times out, those methods will now immediately return with the context's error, even if the Client's shutdown has not yet completed. Apps may need to adjust their graceful shutdown logic to account for this. PR #79.
+
 ## [0.0.10] - 2023-11-26
 
 ### Added

--- a/client_test.go
+++ b/client_test.go
@@ -437,8 +437,8 @@ func Test_Client_Stop(t *testing.T) {
 
 		select {
 		case <-jobDoneChan:
+			require.FailNow(t, "Expected Stop to return before job was done")
 		default:
-			require.FailNow(t, "Expected job to be done before stop returns")
 		}
 	})
 


### PR DESCRIPTION
An earlier refactor caused these graceful shutdown routines to stop respecting the provided context. No matter what happened with the provided context, they would continue blocking, though they would ultimately return the context's error upon return.

With this change, both stop methods will return early if the provided context is cancelled or timed out _prior_ to the clean shutdown completing. This makes it straightforward to implement a shutdown flow which first calls `Stop` with a context that expires after 5 seconds, and after that call `StopAndCancel`. If the shutdown _still_ isn't complete, the user can choose to exit anyway.

Partially fixes #78. cc @vito