### PR TITLE
tweak graceful shutdown example to exit after soft shutdown

### DIFF
--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -118,10 +118,13 @@ func Example_gracefulShutdown() {
 			}
 		}()
 
-		if err := riverClient.Stop(softStopCtx); err != nil {
-			if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
-				panic(err)
-			}
+		err := riverClient.Stop(softStopCtx)
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+			panic(err)
+		}
+		if err == nil {
+			fmt.Printf("Soft stop succeeded\n")
+			return
 		}
 
 		hardStopCtx, hardStopCtxCancel := context.WithTimeout(ctx, 10*time.Second)


### PR DESCRIPTION
As I was updating the docs to account for #79, I realized I had removed the ability for the graceful shutdown example to cleanly exit _if_ the soft shutdown succeeded. It never will succeed in this example, but for users following the code it seems worth accounting for it with the flow.

This gets a little wonky with the logic and the structuring in a single goroutine, but I _think_ this is correct:

* If we have a non-nil error that's not a context cancellation or timeout, panic because that shouldn't happen.
* If we have a `nil` error, return immediately because that means shutdown was successful.
* Otherwise, carry on because soft shutdown was not successful and we're going to need to try a hard shutdown.