### PR TITLE
Fix grammar that's wrong-by-template in examples

### DIFF
--- a/example_batch_insert_test.go
+++ b/example_batch_insert_test.go
@@ -58,7 +58,7 @@ func Example_batchInsert() {
 		panic(err)
 	}
 
-	// Out of example scope, but used to make wait until a job is worked.
+	// Out of example scope, but used to wait until a job is worked.
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 

--- a/example_cron_job_test.go
+++ b/example_cron_job_test.go
@@ -74,7 +74,7 @@ func Example_cronJob() {
 		panic(err)
 	}
 
-	// Out of example scope, but used to make wait until a job is worked.
+	// Out of example scope, but used to wait until a job is worked.
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 

--- a/example_custom_insert_opts_test.go
+++ b/example_custom_insert_opts_test.go
@@ -83,7 +83,7 @@ func Example_customInsertOpts() {
 		panic(err)
 	}
 
-	// Out of example scope, but used to make wait until a job is worked.
+	// Out of example scope, but used to wait until a job is worked.
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 

--- a/example_insert_and_work_test.go
+++ b/example_insert_and_work_test.go
@@ -61,7 +61,7 @@ func Example_insertAndWork() {
 		panic(err)
 	}
 
-	// Out of example scope, but used to make wait until a job is worked.
+	// Out of example scope, but used to wait until a job is worked.
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 

--- a/example_periodic_job_test.go
+++ b/example_periodic_job_test.go
@@ -67,7 +67,7 @@ func Example_periodicJob() {
 		panic(err)
 	}
 
-	// Out of example scope, but used to make wait until a job is worked.
+	// Out of example scope, but used to wait until a job is worked.
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 

--- a/example_unique_job_test.go
+++ b/example_unique_job_test.go
@@ -89,7 +89,7 @@ func Example_uniqueJob() {
 		panic(err)
 	}
 
-	// Out of example scope, but used to make wait until a job is worked.
+	// Out of example scope, but used to wait until a job is worked.
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 

--- a/example_work_func_test.go
+++ b/example_work_func_test.go
@@ -53,7 +53,7 @@ func Example_workFunc() {
 		panic(err)
 	}
 
-	// Out of example scope, but used to make wait until a job is worked.
+	// Out of example scope, but used to wait until a job is worked.
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 


### PR DESCRIPTION
Small fix to grammar on the comment around the subscribe channel in many
of the example tests.