### PR TITLE
job executor: less redundant and more useful log on panic

### DIFF
--- a/job_executor.go
+++ b/job_executor.go
@@ -133,8 +133,9 @@ func (e *jobExecutor) Execute(ctx context.Context) {
 func (e *jobExecutor) execute(ctx context.Context) {
 	defer func() {
 		if recovery := recover(); recovery != nil {
-			e.Logger.ErrorContext(ctx, e.Name+": jobExecutor panic recovery; possible bug with Worker",
+			e.Logger.ErrorContext(ctx, e.Name+": panic recovery; possible bug with Worker",
 				slog.Int64("job_id", e.JobRow.ID),
+				slog.String("kind", e.JobRow.Kind),
 				slog.String("panic_val", fmt.Sprintf("%v", recovery)),
 			)
 


### PR DESCRIPTION
This change avoids repeating the prefix `jobExecutor` twice and also adds the job kind to the logs to ease debugging. The change turns this log line:

    time=2023-11-28T20:48:18.939-06:00 level=ERROR msg="jobExecutor: jobExecutor panic recovery; possible bug with Worker" job_id=214001 panic_val=panicking

Into this one:

    time=2023-11-28T20:51:24.042-06:00 level=ERROR msg="jobExecutor: panic recovery; possible bug with Worker" job_id=214997 kind=Chaos panic_val=panicking