### PR TITLE
Move check on zero workers from client constructor to `Start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `NewClient` no longer errors if it was provided a workers bundle with zero workers. Instead, that check's been moved to `Client.Start` instead. This allows adding workers to a bundle that'd like to reference a River client by letting `AddWorker` be invoked after a client reference is available from `NewClient`. PR #87.
 - `Stop` and `StopAndCancel` have been changed to respect the provided context argument. When that context is cancelled or times out, those methods will now immediately return with the context's error, even if the Client's shutdown has not yet completed. Apps may need to adjust their graceful shutdown logic to account for this. PR #79.
 
 ## [0.0.10] - 2023-11-26

--- a/client.go
+++ b/client.go
@@ -210,9 +210,6 @@ func (c *Config) validate() error {
 	if c.Workers == nil && c.Queues != nil {
 		return errors.New("Workers must be set if Queues is set")
 	}
-	if c.Workers != nil && len(c.Workers.workersMap) < 1 {
-		return errors.New("at least one Worker must be added to the Workers bundle")
-	}
 
 	return nil
 }
@@ -553,6 +550,9 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 func (c *Client[TTx]) Start(ctx context.Context) error {
 	if !c.config.willExecuteJobs() {
 		return fmt.Errorf("client Queues and Workers must be configured for a client to start working")
+	}
+	if c.config.Workers != nil && len(c.config.Workers.workersMap) < 1 {
+		return errors.New("at least one Worker must be added to the Workers bundle")
 	}
 
 	// We use separate contexts for fetching and working to allow for a graceful

--- a/client_test.go
+++ b/client_test.go
@@ -2121,6 +2121,17 @@ func Test_Client_Start_Error(t *testing.T) {
 		require.EqualError(t, err, "client Queues and Workers must be configured for a client to start working")
 	})
 
+	t.Run("NoRegisteredWorkers", func(t *testing.T) {
+		t.Parallel()
+
+		config := newTestConfig(t, nil)
+		config.Workers = NewWorkers() // initialized, but empty
+
+		client := newTestClient(ctx, t, config)
+		err := client.Start(ctx)
+		require.EqualError(t, err, "at least one Worker must be added to the Workers bundle")
+	})
+
 	t.Run("DatabaseError", func(t *testing.T) {
 		t.Parallel()
 
@@ -2465,18 +2476,17 @@ func Test_NewClient_Validations(t *testing.T) {
 			},
 		},
 		{
+			name: "Workers can be empty", // but notably, not allowed to be empty if started
+			configFunc: func(config *Config) {
+				config.Workers = NewWorkers()
+			},
+		},
+		{
 			name: "Workers cannot be empty if Queues is set",
 			configFunc: func(config *Config) {
 				config.Workers = nil
 			},
 			wantErr: errors.New("Workers must be set if Queues is set"),
-		},
-		{
-			name: "Workers must contain at least one worker",
-			configFunc: func(config *Config) {
-				config.Workers = NewWorkers()
-			},
-			wantErr: errors.New("at least one Worker must be added to the Workers bundle"),
 		},
 	}
 


### PR DESCRIPTION
This one's in pursuit of trying to solve #87, where it's difficult to
inject a River client into a worker because trying to initialize a
client with the workers bundle empty is an error, creating a chicken and
egg problem.

There's no real reason to disallow a zero worker bundle from the
constructor, and in fact a lot of our tests already add additional
workers after the client was originally initialized (although
`newTestClient` injects a default worker, which is why there's no
error). If it's a useful pattern for us, it's probably useful for other
users too.

Here, move the zero workers check from the constructor over to the
`Start` function instead. While it seems okay to initialize a client
without workers, starting it without any does seem like a potential
problem that we'd want to keep an eye out for.

Fixes #87.