### PR TITLE
expose Client.Stopped() to simplify waiting on graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `Example_scheduledJob`, demonstrating how to schedule a job to be run in the future.
+- Added `Stopped` method to `Client` to make it easier to wait for graceful shutdown to complete.
 
 ### Fixed
 

--- a/client.go
+++ b/client.go
@@ -705,6 +705,14 @@ func (c *Client[TTx]) StopAndCancel(ctx context.Context) error {
 	return c.awaitStop(ctx)
 }
 
+// Stopped returns a channel that will be closed when the Client has stopped.
+// It can be used to wait for a graceful shutdown to complete.
+//
+// It is not affected by any contexts passed to Stop or StopAndCancel.
+func (c *Client[TTx]) Stopped() <-chan struct{} {
+	return c.stopComplete
+}
+
 // Subscribe subscribes to the provided kinds of events that occur within the
 // client, like EventKindJobCompleted for when a job completes.
 //


### PR DESCRIPTION
This follows [some discussion](https://github.com/riverqueue/river/pull/80#issuecomment-1837261256) in #80 about how this would be a small improvement because it eliminates the need for users to make their own channel for the same purpose.