### PR TITLE
Refactor `reportError` function in job executor for readability

### DIFF
--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -172,5 +172,5 @@ func Example_gracefulShutdown() {
 	// Received SIGINT/SIGTERM; initiating soft stop (try to wait for jobs to finish)
 	// Received SIGINT/SIGTERM again; initiating hard stop (cancel everything)
 	// Job cancelled
-	// jobExecutor: Job failed
+	// jobExecutor: Job errored
 }

--- a/job_executor_test.go
+++ b/job_executor_test.go
@@ -308,7 +308,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 		require.Len(t, job.Errors, 1)
 		require.WithinDuration(t, time.Now(), job.Errors[0].At, 2*time.Second)
 		require.Equal(t, uint16(1), job.Errors[0].Attempt)
-		require.Equal(t, "throw away this job", job.Errors[0].Error)
+		require.Equal(t, "jobCancelError: throw away this job", job.Errors[0].Error)
 		require.Equal(t, "", job.Errors[0].Trace)
 	})
 


### PR DESCRIPTION
So the impetus here is that I've been finding the `reportError` function
in the job executor to be quite hard to read for some time now. A lot of
logic gets intertwined (e.g. logging, error handler reporting), and
verbose log lines pollute the visual space and make things hard to read.

Here, I take a stab at refactoring the function. Primary changes:

* Instead of the executor encapsulating a `result` on its structure,
  it's instead returned by `execute` and passed as a parameter to
  subsequent functions that need it.

* A new `invokeErrorHandler` function is broken out of `reportError` so
  that all logic relating to `ErrorHandler` is in one place (which turns
  out to be somewhat substantial due to the need for its own panic
  recovery logic).

* Cut down on verbose logging by wrapping up a set of common log
  attributes and then injecting those into any specific slog call.

* Reworked the error handler code somewhat so we use an inner function
  that handles a panic. Feels a little better because we're tracking
  less state across the function, and you see a more direct relationship
  from where an error result is coming from to what's returned.

It may not be perfect still, but I think helps to cut down on a lot of
cruft and make the function easier to grok. I didn't add any tests
because the executor and client at a global level are pretty well tested
already.