### PR TITLE
golangci-lint version upgrade + fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
 
-          version: v1.54.2
+          version: v1.55.2
 
   producer_sample:
     runs-on: ubuntu-latest
@@ -201,7 +201,7 @@ jobs:
       - name: Setup sqlc
         uses: sqlc-dev/setup-sqlc@v4
         with:
-          sqlc-version: '1.22.0'
+          sqlc-version: "1.22.0"
 
       - name: Run sqlc diff
         working-directory: ./internal/dbsqlc

--- a/client_monitor_test.go
+++ b/client_monitor_test.go
@@ -63,7 +63,7 @@ func Test_Monitor(t *testing.T) {
 
 		monitor.SetElectorStatus(componentstatus.ElectorLeader)
 		update := awaitSnapshot(t, snapshotCh)
-		require.Len(update.Producers, 0)
+		require.Empty(update.Producers)
 		require.Equal(componentstatus.ElectorLeader, update.Elector)
 		require.Equal(componentstatus.Uninitialized, update.Notifier)
 
@@ -79,7 +79,7 @@ func Test_Monitor(t *testing.T) {
 
 		monitor.SetNotifierStatus(componentstatus.Initializing)
 		update := awaitSnapshot(t, snapshotCh)
-		require.Len(update.Producers, 0)
+		require.Empty(update.Producers)
 		require.Equal(componentstatus.ElectorNonLeader, update.Elector)
 		require.Equal(componentstatus.Initializing, update.Notifier)
 

--- a/client_test.go
+++ b/client_test.go
@@ -1146,7 +1146,7 @@ func Test_Client_ErrorHandler(t *testing.T) {
 			HandleErrorFunc: func(ctx context.Context, job *rivertype.JobRow, err error) *ErrorHandlerResult {
 				var unknownJobKindErr *UnknownJobKindError
 				require.ErrorAs(t, err, &unknownJobKindErr)
-				require.Equal(t, *unknownJobKindErr, UnknownJobKindError{Kind: "RandomWorkerNameThatIsNeverRegistered"})
+				require.Equal(t, UnknownJobKindError{Kind: "RandomWorkerNameThatIsNeverRegistered"}, *unknownJobKindErr)
 				errorHandlerCalled = true
 				return &ErrorHandlerResult{}
 			},
@@ -1348,7 +1348,7 @@ func Test_Client_Maintenance(t *testing.T) {
 		// No jobs yet because the RunOnStart option was not specified.
 		jobs, err := queries.JobGetByKind(ctx, client.driver.GetDBPool(), (periodicJobArgs{}).Kind())
 		require.NoError(t, err)
-		require.Len(t, jobs, 0)
+		require.Empty(t, jobs)
 	})
 
 	t.Run("Reindexer", func(t *testing.T) {
@@ -2133,7 +2133,7 @@ func Test_Client_UnknownJobKindErrorsTheJob(t *testing.T) {
 
 	event := riverinternaltest.WaitOrTimeout(t, subscribeChan)
 	require.Equal(insertRes.Job.ID, event.Job.ID)
-	require.Equal(insertRes.Job.Kind, "RandomWorkerNameThatIsNeverRegistered")
+	require.Equal("RandomWorkerNameThatIsNeverRegistered", insertRes.Job.Kind)
 	require.Len(event.Job.Errors, 1)
 	require.Equal((&UnknownJobKindError{Kind: "RandomWorkerNameThatIsNeverRegistered"}).Error(), event.Job.Errors[0].Error)
 	require.Equal(JobStateRetryable, event.Job.State)
@@ -2552,7 +2552,7 @@ func Test_NewClient_Validations(t *testing.T) {
 
 			client, err := NewClient(riverpgxv5.New(dbPool), config)
 			if tt.wantErr != nil {
-				require.NotNil(err)
+				require.Error(err)
 				require.ErrorContains(err, tt.wantErr.Error())
 				return
 			}

--- a/internal/dbadapter/db_adapter_test.go
+++ b/internal/dbadapter/db_adapter_test.go
@@ -447,7 +447,7 @@ func Test_Adapter_JobInsertMany(t *testing.T) {
 
 	count, err := adapter.JobInsertMany(ctx, insertParams)
 	require.NoError(t, err)
-	require.Equal(t, len(insertParams), int(count))
+	require.Len(t, insertParams, int(count))
 
 	jobsAfter, err := adapter.JobGetAvailable(ctx, rivercommon.QueueDefault, int32(len(insertParams)))
 	require.NoError(t, err)

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -111,8 +111,8 @@ func (s *JobCleaner) Start(ctx context.Context) error { //nolint:dupl
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+": Run loop started")
-		defer s.Logger.InfoContext(ctx, s.Name+": Run loop stopped")
+		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		ticker := timeutil.NewTickerWithInitialTick(ctx, s.Config.Interval)
 		for {
@@ -130,7 +130,7 @@ func (s *JobCleaner) Start(ctx context.Context) error { //nolint:dupl
 				continue
 			}
 
-			s.Logger.InfoContext(ctx, s.Name+": Ran successfully",
+			s.Logger.InfoContext(ctx, s.Name+logPrefixRanSuccessfully,
 				slog.Int64("num_jobs_deleted", res.NumJobsDeleted),
 			)
 		}

--- a/internal/maintenance/job_cleaner_test.go
+++ b/internal/maintenance/job_cleaner_test.go
@@ -77,10 +77,10 @@ func TestJobCleaner(t *testing.T) {
 
 		cleaner := NewJobCleaner(riverinternaltest.BaseServiceArchetype(t), &JobCleanerConfig{}, nil)
 
-		require.Equal(t, cleaner.Config.CancelledJobRetentionPeriod, CancelledJobRetentionPeriodDefault)
-		require.Equal(t, cleaner.Config.CompletedJobRetentionPeriod, CompletedJobRetentionPeriodDefault)
-		require.Equal(t, cleaner.Config.DiscardedJobRetentionPeriod, DiscardedJobRetentionPeriodDefault)
-		require.Equal(t, cleaner.Config.Interval, JobCleanerIntervalDefault)
+		require.Equal(t, CancelledJobRetentionPeriodDefault, cleaner.Config.CancelledJobRetentionPeriod)
+		require.Equal(t, CompletedJobRetentionPeriodDefault, cleaner.Config.CompletedJobRetentionPeriod)
+		require.Equal(t, DiscardedJobRetentionPeriodDefault, cleaner.Config.DiscardedJobRetentionPeriod)
+		require.Equal(t, JobCleanerIntervalDefault, cleaner.Config.Interval)
 	})
 
 	t.Run("StartStopStress", func(t *testing.T) {

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -101,8 +101,8 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+": Run loop started")
-		defer s.Logger.InfoContext(ctx, s.Name+": Run loop stopped")
+		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		// An initial loop to assign next runs for every configured job and
 		// queues any jobs that should run immediately.

--- a/internal/maintenance/queue_maintainer.go
+++ b/internal/maintenance/queue_maintainer.go
@@ -28,6 +28,10 @@ const (
 
 	JitterMin = 0 * time.Second
 	JitterMax = 1 * time.Second
+
+	logPrefixRanSuccessfully = ": Ran successfully"
+	logPrefixRunLoopStarted  = ": Run loop started"
+	logPrefixRunLoopStopped  = ": Run loop stopped"
 )
 
 // QueueMaintainer runs regular maintenance operations against job queues, like

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -105,8 +105,8 @@ func (s *Reindexer) Start(ctx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+": Run loop started")
-		defer s.Logger.InfoContext(ctx, s.Name+": Run loop stopped")
+		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		// On each run, we calculate the new schedule based on the previous run's
 		// start time. This ensures that we don't accidentally skip a run as time
@@ -135,7 +135,7 @@ func (s *Reindexer) Start(ctx context.Context) error {
 				s.TestSignals.Reindexed.Signal(struct{}{})
 			}
 			// TODO: maybe we should log differently if some of these fail?
-			s.Logger.InfoContext(ctx, s.Name+": Ran successfully", slog.Int("num_reindexes_initiated", len(s.Config.IndexNames)))
+			s.Logger.InfoContext(ctx, s.Name+logPrefixRanSuccessfully, slog.Int("num_reindexes_initiated", len(s.Config.IndexNames)))
 		}
 	}()
 

--- a/internal/maintenance/rescuer.go
+++ b/internal/maintenance/rescuer.go
@@ -112,8 +112,8 @@ func (s *Rescuer) Start(ctx context.Context) error {
 	s.CancellableSleepRandomBetween(ctx, JitterMin, JitterMax)
 
 	go func() {
-		s.Logger.InfoContext(ctx, s.Name+": Run loop started")
-		defer s.Logger.InfoContext(ctx, s.Name+": Run loop stopped")
+		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		defer close(stopped)
 
@@ -133,7 +133,7 @@ func (s *Rescuer) Start(ctx context.Context) error {
 				continue
 			}
 
-			s.Logger.InfoContext(ctx, s.Name+": Ran successfully",
+			s.Logger.InfoContext(ctx, s.Name+logPrefixRanSuccessfully,
 				slog.Int64("num_jobs_discarded", res.NumJobsDiscarded),
 				slog.Int64("num_jobs_retry_scheduled", res.NumJobsRetried),
 			)

--- a/internal/maintenance/rescuer_test.go
+++ b/internal/maintenance/rescuer_test.go
@@ -123,8 +123,8 @@ func TestRescuer(t *testing.T) {
 			nil,
 		)
 
-		require.Equal(t, cleaner.Config.RescueAfter, RescueAfterDefault)
-		require.Equal(t, cleaner.Config.Interval, RescuerIntervalDefault)
+		require.Equal(t, RescueAfterDefault, cleaner.Config.RescueAfter)
+		require.Equal(t, RescuerIntervalDefault, cleaner.Config.Interval)
 	})
 
 	t.Run("StartStopStress", func(t *testing.T) {

--- a/internal/maintenance/scheduler.go
+++ b/internal/maintenance/scheduler.go
@@ -98,8 +98,8 @@ func (s *Scheduler) Start(ctx context.Context) error { //nolint:dupl
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+": Run loop started")
-		defer s.Logger.InfoContext(ctx, s.Name+": Run loop stopped")
+		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		ticker := timeutil.NewTickerWithInitialTick(ctx, s.config.Interval)
 		for {
@@ -116,7 +116,7 @@ func (s *Scheduler) Start(ctx context.Context) error { //nolint:dupl
 				}
 				continue
 			}
-			s.Logger.InfoContext(ctx, s.Name+": Ran successfully",
+			s.Logger.InfoContext(ctx, s.Name+logPrefixRanSuccessfully,
 				slog.Int64("num_jobs_scheduled", res.NumCompletedJobsScheduled),
 			)
 		}

--- a/internal/maintenance/scheduler_test.go
+++ b/internal/maintenance/scheduler_test.go
@@ -95,8 +95,8 @@ func TestScheduler(t *testing.T) {
 
 		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t), &SchedulerConfig{}, nil)
 
-		require.Equal(t, scheduler.config.Interval, SchedulerIntervalDefault)
-		require.Equal(t, scheduler.config.Limit, SchedulerLimitDefault)
+		require.Equal(t, SchedulerIntervalDefault, scheduler.config.Interval)
+		require.Equal(t, SchedulerLimitDefault, scheduler.config.Limit)
 	})
 
 	t.Run("StartStopStress", func(t *testing.T) {

--- a/internal/riverinternaltest/riverinternaltest_test.go
+++ b/internal/riverinternaltest/riverinternaltest_test.go
@@ -16,7 +16,7 @@ import (
 // `riverinternaltest_test`, except that the test below uses internal variables
 // like `dbPool`.
 type Executor interface {
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
+	Exec(ctx context.Context, query string, args ...interface{}) (pgconn.CommandTag, error)
 }
 
 func TestTestTx(t *testing.T) {

--- a/internal/util/maputil/map_util_test.go
+++ b/internal/util/maputil/map_util_test.go
@@ -15,7 +15,7 @@ func TestKeys(t *testing.T) {
 	r1 := Keys(map[string]int{"foo": 1, "bar": 2})
 	sort.Strings(r1)
 
-	is.Equal(r1, []string{"bar", "foo"})
+	is.Equal([]string{"bar", "foo"}, r1)
 }
 
 func TestValues(t *testing.T) {
@@ -26,5 +26,5 @@ func TestValues(t *testing.T) {
 	r1 := Values(map[string]int{"foo": 1, "bar": 2})
 	sort.Ints(r1)
 
-	is.Equal(r1, []int{1, 2})
+	is.Equal([]int{1, 2}, r1)
 }

--- a/internal/util/sliceutil/slice_util_test.go
+++ b/internal/util/sliceutil/slice_util_test.go
@@ -15,12 +15,12 @@ func TestGroupBy(t *testing.T) {
 		return i % 3
 	})
 
-	require.Equal(t, len(result1), 3)
-	require.Equal(t, result1, map[int][]int{
+	require.Len(t, result1, 3)
+	require.Equal(t, map[int][]int{
 		0: {0, 3},
 		1: {1, 4},
 		2: {2, 5},
-	})
+	}, result1)
 }
 
 func TestKeyBy(t *testing.T) {
@@ -70,8 +70,8 @@ func TestMap(t *testing.T) {
 		return strconv.FormatInt(x, 10)
 	})
 
-	require.Equal(t, len(result1), 4)
-	require.Equal(t, len(result2), 4)
-	require.Equal(t, result1, []string{"Hello", "Hello", "Hello", "Hello"})
-	require.Equal(t, result2, []string{"1", "2", "3", "4"})
+	require.Len(t, result1, 4)
+	require.Len(t, result2, 4)
+	require.Equal(t, []string{"Hello", "Hello", "Hello", "Hello"}, result1)
+	require.Equal(t, []string{"1", "2", "3", "4"}, result2)
 }

--- a/periodic.go
+++ b/periodic.go
@@ -10,7 +10,7 @@ import (
 type PeriodicSchedule interface {
 	// Next returns the next time at which the job should be run given the
 	// current time.
-	Next(time.Time) time.Time
+	Next(current time.Time) time.Time
 }
 
 // PeriodicJobConstructor is a function that gets called each time the paired

--- a/rivertest/rivertest.go
+++ b/rivertest/rivertest.go
@@ -25,9 +25,9 @@ import (
 // common implementation that takes one of these.
 type dbtx interface {
 	CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error)
-	Exec(context.Context, string, ...interface{}) (pgconn.CommandTag, error)
-	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
-	QueryRow(context.Context, string, ...interface{}) pgx.Row
+	Exec(ctx context.Context, query string, args ...interface{}) (pgconn.CommandTag, error)
+	Query(ctx context.Context, query string, args ...interface{}) (pgx.Rows, error)
+	QueryRow(ctx context.Context, query string, args ...interface{}) pgx.Row
 }
 
 // testingT is an interface wrapper around *testing.T that's implemented by all


### PR DESCRIPTION
Upgrades golangci-lint and fixes the many issues that popped up in the process. Most of them seem unequivocally good, though a few of the constant ones are questionable. I decided to just take the advice rather than adding a bunch of `nolint` comments though.