### PR TITLE
More fixes for golangci-lint upgrade

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,11 @@ linters-settings:
       rules:
         json: snake
 
+  testifylint:
+    enable-all: true
+    disable:
+      - go-require
+
   varnamelen:
     ignore-names:
       - db

--- a/client.go
+++ b/client.go
@@ -171,13 +171,13 @@ type Config struct {
 
 func (c *Config) validate() error {
 	if c.CancelledJobRetentionPeriod < 0 {
-		return fmt.Errorf("CancelledJobRetentionPeriod time cannot be less than zero")
+		return errors.New("CancelledJobRetentionPeriod time cannot be less than zero")
 	}
 	if c.CompletedJobRetentionPeriod < 0 {
-		return fmt.Errorf("CompletedJobRetentionPeriod cannot be less than zero")
+		return errors.New("CompletedJobRetentionPeriod cannot be less than zero")
 	}
 	if c.DiscardedJobRetentionPeriod < 0 {
-		return fmt.Errorf("DiscardedJobRetentionPeriod cannot be less than zero")
+		return errors.New("DiscardedJobRetentionPeriod cannot be less than zero")
 	}
 	if c.FetchCooldown < FetchCooldownMin {
 		return fmt.Errorf("FetchCooldown must be at least %s", FetchCooldownMin)
@@ -549,7 +549,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 // using StopAndCancel, there's no need to also call Stop.
 func (c *Client[TTx]) Start(ctx context.Context) error {
 	if !c.config.willExecuteJobs() {
-		return fmt.Errorf("client Queues and Workers must be configured for a client to start working")
+		return errors.New("client Queues and Workers must be configured for a client to start working")
 	}
 	if c.config.Workers != nil && len(c.config.Workers.workersMap) < 1 {
 		return errors.New("at least one Worker must be added to the Workers bundle")
@@ -986,7 +986,7 @@ func insertParamsFromArgsAndOptions(args JobArgs, insertOpts *InsertOpts) (*dbad
 	return insertParams, nil
 }
 
-var errInsertNoDriverDBPool = fmt.Errorf("driver must have non-nil database pool to use Insert and InsertMany (try InsertTx or InsertManyTx instead")
+var errInsertNoDriverDBPool = errors.New("driver must have non-nil database pool to use Insert and InsertMany (try InsertTx or InsertManyTx instead")
 
 // Insert inserts a new job with the provided args. Job opts can be used to
 // override any defaults that may have been provided by an implementation of

--- a/cmd/river/main.go
+++ b/cmd/river/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -136,7 +137,7 @@ type migrateDownOpts struct {
 
 func (o *migrateDownOpts) validate() error {
 	if o.DatabaseURL == "" {
-		return fmt.Errorf("database URL cannot be empty")
+		return errors.New("database URL cannot be empty")
 	}
 
 	return nil
@@ -170,7 +171,7 @@ type migrateUpOpts struct {
 
 func (o *migrateUpOpts) validate() error {
 	if o.DatabaseURL == "" {
-		return fmt.Errorf("database URL cannot be empty")
+		return errors.New("database URL cannot be empty")
 	}
 
 	return nil

--- a/example_error_handler_test.go
+++ b/example_error_handler_test.go
@@ -2,6 +2,7 @@ package river_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -48,7 +49,7 @@ type ErroringWorker struct {
 func (w *ErroringWorker) Work(ctx context.Context, job *river.Job[ErroringArgs]) error {
 	switch {
 	case job.Args.ShouldError:
-		return fmt.Errorf("this job errored")
+		return errors.New("this job errored")
 	case job.Args.ShouldPanic:
 		panic("this job panicked")
 	}

--- a/example_job_cancel_test.go
+++ b/example_job_cancel_test.go
@@ -2,6 +2,7 @@ package river_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -26,7 +27,7 @@ type CancellingWorker struct {
 func (w *CancellingWorker) Work(ctx context.Context, job *river.Job[CancellingArgs]) error {
 	if job.Args.ShouldCancel {
 		fmt.Println("cancelling job")
-		return river.JobCancel(fmt.Errorf("this wrapped error message will be persisted to DB"))
+		return river.JobCancel(errors.New("this wrapped error message will be persisted to DB"))
 	}
 	return nil
 }

--- a/example_subscription_test.go
+++ b/example_subscription_test.go
@@ -2,6 +2,7 @@ package river_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -29,9 +30,9 @@ type SubscriptionWorker struct {
 func (w *SubscriptionWorker) Work(ctx context.Context, job *river.Job[SubscriptionArgs]) error {
 	switch {
 	case job.Args.Cancel:
-		return river.JobCancel(fmt.Errorf("cancelling job"))
+		return river.JobCancel(errors.New("cancelling job"))
 	case job.Args.Fail:
-		return fmt.Errorf("failing job")
+		return errors.New("failing job")
 	}
 	return nil
 }

--- a/insert_opts.go
+++ b/insert_opts.go
@@ -1,6 +1,7 @@
 package river
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -133,7 +134,7 @@ func (o *UniqueOpts) validate() error {
 	}
 
 	if o.ByPeriod != time.Duration(0) && o.ByPeriod < 1*time.Second {
-		return fmt.Errorf("JobUniqueOpts.ByPeriod should not be less than 1 second")
+		return errors.New("JobUniqueOpts.ByPeriod should not be less than 1 second")
 	}
 
 	// Job states are typed, but since the underlying type is a string, users

--- a/internal/cmd/testdbman/create.go
+++ b/internal/cmd/testdbman/create.go
@@ -45,7 +45,7 @@ runtime.NumCPU() (a choice that comes from pgx's default connection pool size).
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			if _, err := mgmtConn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", dbName)); err != nil {
+			if _, err := mgmtConn.Exec(ctx, "CREATE DATABASE "+dbName); err != nil {
 				return fmt.Errorf("error running `CREATE DATABASE %s`: %w", dbName, err)
 			}
 			fmt.Printf("Created database %s.\n", dbName)
@@ -93,5 +93,5 @@ func dbURL(dbName string) string {
 	if dbName == "" {
 		return "postgres:///postgres"
 	}
-	return fmt.Sprintf("postgres:///%s", dbName)
+	return "postgres:///" + dbName
 }

--- a/internal/cmd/testdbman/drop.go
+++ b/internal/cmd/testdbman/drop.go
@@ -37,7 +37,7 @@ func attemptDropDB(ctx context.Context, mgmtConn *pgx.Conn, dbNameToDelete strin
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	if _, err := mgmtConn.Exec(ctx, fmt.Sprintf("DROP DATABASE %s", dbNameToDelete)); err != nil {
+	if _, err := mgmtConn.Exec(ctx, "DROP DATABASE "+dbNameToDelete); err != nil {
 		if ignoreNonExistent && strings.Contains(err.Error(), fmt.Sprintf("database %q does not exist", dbNameToDelete)) {
 			fmt.Printf("Database %s does not exist, ignoring reset\n", dbNameToDelete)
 			return nil

--- a/internal/jobcompleter/job_completer_test.go
+++ b/internal/jobcompleter/job_completer_test.go
@@ -3,7 +3,6 @@ package jobcompleter
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ func TestInlineJobCompleter_Complete(t *testing.T) {
 	t.Parallel()
 
 	var attempt int
-	expectedErr := fmt.Errorf("an error from the completer")
+	expectedErr := errors.New("an error from the completer")
 	adapter := &dbadaptertest.TestAdapter{
 		JobSetCompletedIfRunningFunc: func(ctx context.Context, job dbadapter.JobToComplete) (*dbsqlc.RiverJob, error) {
 			require.Equal(t, int64(1), job.ID)
@@ -69,7 +68,7 @@ func TestAsyncJobCompleter_Complete(t *testing.T) {
 	inputCh := make(chan jobInput)
 	resultCh := make(chan error)
 
-	expectedErr := fmt.Errorf("an error from the completer")
+	expectedErr := errors.New("an error from the completer")
 
 	go func() {
 		riverinternaltest.WaitOrTimeout(t, inputCh)

--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -201,7 +200,7 @@ func (e *Elector) keepLeadership(ctx context.Context, leadershipNotificationChan
 				continue
 			}
 			if !reelected {
-				return fmt.Errorf("lost leadership with no error")
+				return errors.New("lost leadership with no error")
 			}
 			reelectionErrCount = 0
 		}

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -3,7 +3,6 @@ package maintenance
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -146,7 +145,7 @@ func (s *Reindexer) reindexOne(ctx context.Context, indexName string) error {
 	ctx, cancel := context.WithTimeout(ctx, s.Config.Timeout)
 	defer cancel()
 
-	_, err := s.dbExecutor.Exec(ctx, fmt.Sprintf("REINDEX INDEX CONCURRENTLY %s", indexName))
+	_, err := s.dbExecutor.Exec(ctx, "REINDEX INDEX CONCURRENTLY "+indexName)
 	if err != nil {
 		return err
 	}

--- a/job_executor.go
+++ b/job_executor.go
@@ -27,7 +27,7 @@ type UnknownJobKindError struct {
 
 // Error returns the error string.
 func (e *UnknownJobKindError) Error() string {
-	return fmt.Sprintf("job kind is not registered in the client's Workers bundle: %s", e.Kind)
+	return "job kind is not registered in the client's Workers bundle: " + e.Kind
 }
 
 // Is implements the interface used by errors.Is to determine if errors are
@@ -54,7 +54,7 @@ type jobCancelError struct {
 
 func (e *jobCancelError) Error() string {
 	// should not ever be called, but add a prefix just in case:
-	return fmt.Sprintf("jobCancelError: %s", e.err.Error())
+	return "jobCancelError: " + e.err.Error()
 }
 
 func (e *jobCancelError) Is(target error) bool {

--- a/job_executor_test.go
+++ b/job_executor_test.go
@@ -232,7 +232,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		baselineTime := riverinternaltest.StubTime(&executor.Archetype, time.Now())
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 
 		executor.Execute(ctx)
@@ -256,7 +256,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		bundle.jobRow.Attempt = 2
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 
 		executor.Execute(ctx)
@@ -275,7 +275,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		bundle.jobRow.Attempt = bundle.jobRow.MaxAttempts
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 
 		executor.Execute(ctx)
@@ -295,7 +295,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 		// ensure we still have remaining attempts:
 		require.Greater(t, bundle.jobRow.MaxAttempts, bundle.jobRow.Attempt)
 
-		cancelErr := JobCancel(fmt.Errorf("throw away this job"))
+		cancelErr := JobCancel(errors.New("throw away this job"))
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return cancelErr }, nil).MakeUnit(bundle.jobRow)
 
 		executor.Execute(ctx)
@@ -338,7 +338,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 		executor, bundle := setup(t)
 		executor.ClientRetryPolicy = &retryPolicyCustom{}
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 
 		executor.Execute(ctx)
@@ -355,7 +355,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		executor, bundle := setup(t)
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		nextRetryAt := time.Now().Add(1 * time.Hour).UTC()
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, func() time.Time {
 			return nextRetryAt
@@ -376,7 +376,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 		executor, bundle := setup(t)
 		executor.ClientRetryPolicy = &retryPolicyInvalid{}
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 
 		executor.Execute(ctx)
@@ -393,7 +393,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		executor, bundle := setup(t)
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 		bundle.errorHandler.HandleErrorFunc = func(ctx context.Context, job *rivertype.JobRow, err error) *ErrorHandlerResult {
 			require.Equal(t, workerErr, err)
@@ -415,7 +415,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		executor, bundle := setup(t)
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 		bundle.errorHandler.HandleErrorFunc = func(ctx context.Context, job *rivertype.JobRow, err error) *ErrorHandlerResult {
 			return &ErrorHandlerResult{SetCancelled: true}
@@ -436,7 +436,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		executor, bundle := setup(t)
 
-		workerErr := fmt.Errorf("job error")
+		workerErr := errors.New("job error")
 		executor.WorkUnit = newWorkUnitFactoryWithCustomRetry(func() error { return workerErr }, nil).MakeUnit(bundle.jobRow)
 		bundle.errorHandler.HandleErrorFunc = func(ctx context.Context, job *rivertype.JobRow, err error) *ErrorHandlerResult {
 			panic("error handled panicked!")
@@ -588,7 +588,7 @@ func TestUnknownJobKindError_As(t *testing.T) {
 		t.Parallel()
 
 		var err *UnknownJobKindError
-		require.False(t, errors.As(fmt.Errorf("some other error"), &err))
+		require.False(t, errors.As(errors.New("some other error"), &err))
 	})
 }
 
@@ -606,7 +606,7 @@ func TestUnknownJobKindError_Is(t *testing.T) {
 		t.Parallel()
 
 		err1 := &UnknownJobKindError{Kind: "MyJobArgs"}
-		require.NotErrorIs(t, err1, fmt.Errorf("some other error"))
+		require.NotErrorIs(t, err1, errors.New("some other error"))
 	})
 }
 


### PR DESCRIPTION
So after #93 came in I ran my own `brew upgrade golangci-lint`, and I
guess I got a new point release, because I got a whole bunch of new lint
problems. I wish it was clearer which version I even got, but apparently
golangci-lint is releasing HEAD versions to Homebrew:

    $ golangci-lint --version
    golangci-lint has version HEAD-185b2c7 built with go1.21.4 from 185b2c7 on 2023-11-29T17:26:42Z

I fixed most of the problems, but I ended up disabling one of the
features of `testifylint` that disallows uses of testify functions in
goroutines, which would've required some very significant changes, and
which in our project produces a false positive rate (of actual problems)
of 100.0% as far as I can tell. See the description of this feature
here:

https://github.com/Antonboom/testifylint#go-require

    $ golangci-lint run --fix
    client_test.go:378:6: go-require: require must only be used in the goroutine running the test function (testifylint)
                                            require.NoError(t, err)
                                            ^
    internal/baseservice/base_service_test.go:40:4: go-require: require must only be used in the goroutine running the test function (testifylint)
                            require.FailNow(t, "Test case took too long to run (sleep statements should return immediately)")
                            ^
    internal/dbadapter/db_adapter_test.go:409:6: go-require: require must only be used in the goroutine running the test function (testifylint)
                                            require.NoError(t, err)
                                            ^
    internal/riverinternaltest/riverinternaltest_test.go:78:8: go-require: TestTx contains assertions that must only be used in the goroutine running the test function (testifylint)
                            _ = TestTx(ctx, t)