### PR TITLE
Consolidate on one set state query + adapter/completer function [boilerplate reduction]

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1952,7 +1952,12 @@ func Test_Client_JobCompletion(t *testing.T) {
 		var dbPool *pgxpool.Pool
 		now := time.Now().UTC()
 		config := newTestConfig(t, func(ctx context.Context, job *Job[callbackArgs]) error {
-			_, err := queries.JobSetCompleted(ctx, dbPool, dbsqlc.JobSetCompletedParams{ID: job.ID, FinalizedAt: now})
+			_, err := queries.JobSetState(ctx, dbPool, dbsqlc.JobSetStateParams{
+				ID:                  job.ID,
+				FinalizedAtDoUpdate: true,
+				FinalizedAt:         &now,
+				State:               dbsqlc.JobStateCompleted,
+			})
 			require.NoError(err)
 			return nil
 		})
@@ -2031,10 +2036,13 @@ func Test_Client_JobCompletion(t *testing.T) {
 		var dbPool *pgxpool.Pool
 		now := time.Now().UTC()
 		config := newTestConfig(t, func(ctx context.Context, job *Job[callbackArgs]) error {
-			_, err := queries.JobSetDiscarded(ctx, dbPool, dbsqlc.JobSetDiscardedParams{
-				ID:          job.ID,
-				Error:       []byte("{\"error\": \"oops\"}"),
-				FinalizedAt: now,
+			_, err := queries.JobSetState(ctx, dbPool, dbsqlc.JobSetStateParams{
+				ID:                  job.ID,
+				ErrorDoUpdate:       true,
+				Error:               []byte("{\"error\": \"oops\"}"),
+				FinalizedAtDoUpdate: true,
+				FinalizedAt:         &now,
+				State:               dbsqlc.JobStateDiscarded,
 			})
 			require.NoError(err)
 			return errors.New("oops")

--- a/internal/util/ptrutil/ptr_util.go
+++ b/internal/util/ptrutil/ptr_util.go
@@ -4,3 +4,21 @@ package ptrutil
 func Ptr[T any](v T) *T {
 	return &v
 }
+
+// ValOrDefault returns the value of the given pointer as long as it's non-nil,
+// and the specified default value otherwise.
+func ValOrDefault[T any](ptr *T, defaultVal T) T {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultVal
+}
+
+// ValOrDefaultFunc returns the value of the given pointer as long as it's
+// non-nil, or invokes the given function to produce a default value otherwise.
+func ValOrDefaultFunc[T any](ptr *T, defaultFunc func() T) T {
+	if ptr != nil {
+		return *ptr
+	}
+	return defaultFunc()
+}

--- a/internal/util/ptrutil/ptr_util_test.go
+++ b/internal/util/ptrutil/ptr_util_test.go
@@ -19,3 +19,19 @@ func TestPtr(t *testing.T) {
 		require.Equal(t, &v, Ptr(7))
 	}
 }
+
+func TestValOrDefault(t *testing.T) {
+	t.Parallel()
+
+	val := "val"
+	require.Equal(t, val, ValOrDefault(&val, "default"))
+	require.Equal(t, "default", ValOrDefault((*string)(nil), "default"))
+}
+
+func TestValOrDefaultFunc(t *testing.T) {
+	t.Parallel()
+
+	val := "val"
+	require.Equal(t, val, ValOrDefaultFunc(&val, func() string { return "default" }))
+	require.Equal(t, "default", ValOrDefaultFunc((*string)(nil), func() string { return "default" }))
+}

--- a/job.go
+++ b/job.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/riverqueue/river/internal/dbsqlc"
+	"github.com/riverqueue/river/internal/util/ptrutil"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -59,7 +60,12 @@ func JobCompleteTx[TDriver riverdriver.Driver[TTx], TTx any, TArgs JobArgs](ctx 
 		queries = &dbsqlc.Queries{}
 	)
 
-	internal, err := queries.JobSetCompleted(ctx, driver.UnwrapTx(tx), dbsqlc.JobSetCompletedParams{ID: job.ID, FinalizedAt: time.Now()})
+	internal, err := queries.JobSetState(ctx, driver.UnwrapTx(tx), dbsqlc.JobSetStateParams{
+		ID:                  job.ID,
+		FinalizedAtDoUpdate: true,
+		FinalizedAt:         ptrutil.Ptr(time.Now()),
+		State:               dbsqlc.JobStateCompleted,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This one's a clean up aimed at doing a massive boilerplate reduction in
our sqlc queries, the adapter, and the completer(s). We have a few
current problems:

* Every "set state" query like `JobCompleteIfRunning`, `JobErrorIfRunning`,
  etc. are all separate sqlc queries, and worse yet, all very long ones
  that are all practically identical with very minor but important
  differences that are hard to spot without examining them character by
  character.

* Every one of these queries get exposed through the adapter as a
  separate function that's implemented in the interface, `StandardAdapter`,
  and the mock `TestAdapter`, requiring lots of LOC.

* They're all exposed yet again in the `Completer` interface, along with
  both implementations of `Completer`. Which again, is a lot of LOC.

Here, we show that with some fairly minor tweaks, we can consolidate all
of this state updating into a single query that's no longer than any one
of the originals, and then simplify both the adapter and completer to
model access to it as a general `JobSetState` function with a number of
params constructors that function to produce the necessary parameters
for each type of state of update (complete, error, snooze, etc.).

Total LOCs are reduced by *a lot*. `river_job.sql` just by itself has
40% fewer lines, and with many more removed in the adapters and
completers. This has the effect of a lot less noise, but also makes
refactoring easier because there's less that has to change. Furthermore,
I don't believe there's any significant reduction in API ergonomics or
safety.

It's still not perfect -- there's still way too much scaffolding in the
completers in particular for example, but more improvements to come.