### PR TITLE
Eager retry for short retry delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Errored jobs that have a very short duration before their next retry (<5 seconds) are set to `available` immediately instead of being made `scheduled` and having to wait for the scheduler to make a pass to make them workable. [PR #105](https://github.com/riverqueue/river/pull/105).
+
 ## [0.0.12] - 2023-12-02
 
 ### Added

--- a/client_test.go
+++ b/client_test.go
@@ -127,6 +127,7 @@ func newTestConfig(t *testing.T, callback callbackFunc) *Config {
 		Queues:            map[string]QueueConfig{QueueDefault: {MaxWorkers: 50}},
 		Workers:           workers,
 		disableSleep:      true,
+		schedulerInterval: riverinternaltest.SchedulerShortInterval,
 	}
 }
 

--- a/example_subscription_test.go
+++ b/example_subscription_test.go
@@ -129,7 +129,7 @@ func Example_subscription() {
 
 	// Output:
 	// Got job with state: completed
-	// Got job with state: retryable
+	// Got job with state: available
 	// Got job with state: cancelled
 	// Client stopped
 	// Channel is closed

--- a/internal/dbadapter/db_adapter.go
+++ b/internal/dbadapter/db_adapter.go
@@ -376,7 +376,11 @@ func JobSetStateDiscarded(id int64, finalizedAt time.Time, errData []byte) *JobS
 	return &JobSetStateIfRunningParams{ID: id, errData: errData, finalizedAt: &finalizedAt, state: dbsqlc.JobStateDiscarded}
 }
 
-func JobSetStateErrored(id int64, scheduledAt time.Time, errData []byte) *JobSetStateIfRunningParams {
+func JobSetStateErrorAvailable(id int64, scheduledAt time.Time, errData []byte) *JobSetStateIfRunningParams {
+	return &JobSetStateIfRunningParams{ID: id, errData: errData, scheduledAt: &scheduledAt, state: dbsqlc.JobStateAvailable}
+}
+
+func JobSetStateErrorRetryable(id int64, scheduledAt time.Time, errData []byte) *JobSetStateIfRunningParams {
 	return &JobSetStateIfRunningParams{ID: id, errData: errData, scheduledAt: &scheduledAt, state: dbsqlc.JobStateRetryable}
 }
 

--- a/internal/dbsqlc/river_job.sql
+++ b/internal/dbsqlc/river_job.sql
@@ -72,6 +72,7 @@ WITH locked_jobs AS (
   WHERE
     state = 'available'::river_job_state
     AND queue = @queue::text
+    AND scheduled_at <= now()
   ORDER BY
     priority ASC,
     scheduled_at ASC,
@@ -84,7 +85,7 @@ UPDATE
 SET
   state = 'running'::river_job_state,
   attempt = river_job.attempt + 1,
-  attempted_at = NOW(),
+  attempted_at = now(),
   attempted_by = array_append(river_job.attempted_by, @worker::text)
 FROM
   locked_jobs

--- a/internal/dbsqlc/river_job.sql.go
+++ b/internal/dbsqlc/river_job.sql.go
@@ -79,6 +79,7 @@ WITH locked_jobs AS (
   WHERE
     state = 'available'::river_job_state
     AND queue = $2::text
+    AND scheduled_at <= now()
   ORDER BY
     priority ASC,
     scheduled_at ASC,
@@ -91,7 +92,7 @@ UPDATE
 SET
   state = 'running'::river_job_state,
   attempt = river_job.attempt + 1,
-  attempted_at = NOW(),
+  attempted_at = now(),
   attempted_by = array_append(river_job.attempted_by, $1::text)
 FROM
   locked_jobs

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -26,6 +26,16 @@ import (
 	"github.com/riverqueue/river/internal/util/valutil"
 )
 
+// SchedulerShortInterval is an artificially short interval for the scheduler
+// that's used in the tests of various components to make sure that errored jobs
+// always end up in a `retryable` state rather than `available`. Normally, the
+// job executor sets `available` if the retry delay is smaller than the
+// scheduler's interval. To simplify things so errors are always `retryable`,
+// this time is picked to be smaller than the any retry delay that the default
+// retry policy will ever produce. It's shared so we can document/explain it all
+// in one place.
+const SchedulerShortInterval = 500 * time.Millisecond
+
 var (
 	dbManager *testdb.Manager //nolint:gochecknoglobals
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/riverqueue/river/internal/dbadapter"
 	"github.com/riverqueue/river/internal/dbsqlc"
 	"github.com/riverqueue/river/internal/jobcompleter"
+	"github.com/riverqueue/river/internal/maintenance"
 	"github.com/riverqueue/river/internal/notifier"
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/riverinternaltest"
@@ -82,6 +83,7 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 		Notifier:          notifier,
 		QueueName:         rivercommon.QueueDefault,
 		RetryPolicy:       &DefaultClientRetryPolicy{},
+		SchedulerInterval: maintenance.SchedulerIntervalDefault,
 		WorkerName:        "fakeWorkerNameTODO",
 		Workers:           workers,
 	}
@@ -181,6 +183,7 @@ func Test_Producer_Run(t *testing.T) {
 			Notifier:          notifier,
 			QueueName:         rivercommon.QueueDefault,
 			RetryPolicy:       &DefaultClientRetryPolicy{},
+			SchedulerInterval: riverinternaltest.SchedulerShortInterval,
 			WorkerName:        "fakeWorkerNameTODO",
 			Workers:           workers,
 		}


### PR DESCRIPTION
An aspect of River that could currently be considered a bug is that
retry delays below five seconds are effectively ignored. This is because
when a job errors it always transitions to `retryable` state, and needs
to wait for the scheduler to run to transition it back to `available`,
and the scheduler run interval is five seconds.

This is in practice a problem because it means that the first retry in a
retry policy isn't actually one second as claimed in docs, etc., but
actually ~5 seconds, and it won't be obvious why.

Here, implement an "eager" retry system such that if we detect that the
retry delay is smaller than the scheduler's run interval, we place the
job immediately into an `available` state, allowing it to be worked
sooner.

To facilitate this we add a predicate on the "get available" query that
checks for `scheduled_at <= now()` so that errored jobs with short
retries can be `available` for a short time without being worked
immediately. Most of the time this should have no effect because this
really only applies to the first retry in any failure (the second is at
16 seconds, which is well above the scheduler's run interval).