### PR TITLE
Preparations for 0.0.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.13] - 2023-12-12
+
 ### Added
 
 - Added `riverdriver/riverdatabasesql` driver to enable River Go migrations through Go's built in `database/sql` package. [PR #98](https://github.com/riverqueue/river/pull/98).

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -2,18 +2,18 @@ module github.com/riverqueue/river/cmd/river
 
 go 1.21.4
 
-replace github.com/riverqueue/river => ../..
+// replace github.com/riverqueue/river => ../..
 
-replace github.com/riverqueue/river/riverdriver => ../../riverdriver
+// replace github.com/riverqueue/river/riverdriver => ../../riverdriver
 
-replace github.com/riverqueue/river/riverdriver/riverdatabasesql => ../../riverdriver/riverdatabasesql
+// replace github.com/riverqueue/river/riverdriver/riverdatabasesql => ../../riverdriver/riverdatabasesql
 
-replace github.com/riverqueue/river/riverdriver/riverpgxv5 => ../../riverdriver/riverpgxv5
+// replace github.com/riverqueue/river/riverdriver/riverpgxv5 => ../../riverdriver/riverpgxv5
 
 require (
 	github.com/jackc/pgx/v5 v5.5.1
-	github.com/riverqueue/river v0.0.12
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.12
+	github.com/riverqueue/river v0.0.13
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.13
 	github.com/spf13/cobra v1.8.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.0-00010101000000-000000000000
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.12
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.0-00010101000000-000000000000
+	github.com/riverqueue/river/riverdriver v0.0.13
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.13
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.13
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,7 +7,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.0-00010101000000-000000000000
+	github.com/riverqueue/river/riverdriver v0.0.13
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -6,7 +6,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.0-00010101000000-000000000000
+	github.com/riverqueue/river/riverdriver v0.0.13
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Here, tee up the necessary changes for an upcoming 0.0.13 release that
I'll cut immediately after this is merged.

We update each submodule's `go.mod` to point to 0.0.13, which doesn't
actually exist yet, but it will very soon. This will leave the repo very
temporarily in an invalid state, but I tried the same change out in a
test project and as soon as the Go module proxy's cache busts, it works.

We comment out all the `replace`'s in `./cmd/river` so that it continues
to be installable with `go install ...@latest`. The `replace`'s are
still in there but commented out so that we can test future CLI changes
without too much trouble.

Finally, update the changelog to add the new section for 0.0.13.