### PR TITLE
Fix development instructions for releasing `riverdriver`

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ queries. After changing an sqlc `.sql` file, generate Go with:
 git checkout master && git pull --rebase
 VERSION=v0.0.x
 git tag cmd/river/$VERSION -m "release cmd/river/$VERSION"
-git tag riverdriver/VERSION -m "release riverdriver/VERSION"
+git tag riverdriver/$VERSION -m "release riverdriver/$VERSION"
 git tag riverdriver/riverpgxv5/$VERSION -m "release riverdriver/riverpgxv5/$VERSION"
 git tag riverdriver/riverdatabasesql/$VERSION -m "release riverdriver/riverdatabasesql/$VERSION"
 git tag $VERSION


### PR DESCRIPTION
Have no idea how my copy/paste skills failed so badly here, but I
somehow managed to add release instructions for `riverdriver` (and only
`riverdriver`) that release new versions at `VERSION` (a non-variable)
instead of `$VERSION`. This caused attempted updates requiring the
driver to fail.

I already removed the bad tag and pushed a new one, but here, update the
instructions to fix future releases.