### PR TITLE
Add Makefile list for tests and CLI + lint fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,35 +151,30 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          only-new-issues: true # Optional: show only new issues if it's a pull request. The default value is `false`.
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: .
 
       - name: Lint cmd/river
         uses: golangci/golangci-lint-action@v3
         with:
-          only-new-issues: true # Optional: show only new issues if it's a pull request. The default value is `false`.
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./cmd/river
 
       - name: Lint riverdriver
         uses: golangci/golangci-lint-action@v3
         with:
-          only-new-issues: true # Optional: show only new issues if it's a pull request. The default value is `false`.
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./riverdriver
 
       - name: Lint riverdriver/riverdatabasesql
         uses: golangci/golangci-lint-action@v3
         with:
-          only-new-issues: true # Optional: show only new issues if it's a pull request. The default value is `false`.
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./riverdriver/riverdatabasesql
 
       - name: Lint riverdriver/riverpgxv5
         uses: golangci/golangci-lint-action@v3
         with:
-          only-new-issues: true # Optional: show only new issues if it's a pull request. The default value is `false`.
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./riverdriver/riverpgxv5
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,22 @@ generate/sqlc:
 	cd riverdriver/riverdatabasesql/internal/dbsqlc && sqlc generate
 	cd riverdriver/riverpgxv5/internal/dbsqlc && sqlc generate
 
+.PHONY: lint
+lint:
+	cd . && golangci-lint run --fix
+	# cd cmd/river && golangci-lint run --fix
+	cd riverdriver && golangci-lint run --fix
+	cd riverdriver/riverdatabasesql && golangci-lint run --fix
+	cd riverdriver/riverpgxv5 && golangci-lint run --fix
+
+.PHONY: test
+test:
+	cd . && go test ./... -p 1
+	# cd cmd/river && go test ./...
+	cd riverdriver && go test ./...
+	cd riverdriver/riverdatabasesql && go test ./...
+	cd riverdriver/riverpgxv5 && go test ./...
+
 .PHONY: verify
 verify:
 verify: verify/sqlc

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -81,7 +81,7 @@ func DatabaseConfig(databaseName string) *pgxpool.Config {
 // it may be useful in non-pgx situations like for examples showing the use of
 // `database/sql`.
 func DatabaseURL(databaseName string) string {
-	u, err := url.Parse(valutil.ValOrDefault(
+	parsedURL, err := url.Parse(valutil.ValOrDefault(
 		os.Getenv("TEST_DATABASE_URL"),
 		"postgres://localhost/river_testdb?sslmode=disable"),
 	)
@@ -90,10 +90,10 @@ func DatabaseURL(databaseName string) string {
 	}
 
 	if databaseName != "" {
-		u.Path = databaseName
+		parsedURL.Path = databaseName
 	}
 
-	return u.String()
+	return parsedURL.String()
 }
 
 // DiscardContinuously drains continuously out of the given channel and discards


### PR DESCRIPTION
A side effect of Go submodules in a project is that commands like `go
test ./...` and golangci-lint don't run for the submodules without
`cd`ing into their directory and running those commands explicitly.

Here, add two new Makefile targets for `lint` and `test` that
exhaustively lint and test all submodules in the project. Most of the
time these probably won't be needed as we'll be working inside of the
main River project, but they'll be available in case we're making driver
changes and need something more comprehensive.

Also, fix a lint issue that's been failing on and off for a few days
now.

Lastly, I'm going to propose we remove the `only-new-issues` config
option for golangci-lint in CI. It seems like a useful idea, but it
creates some odd behavior like for the lint problem fixed here in which
lint is in a failing-but-sometimes-not-failing state where it allows
lint to pass in pull requests, but it fails locally and fails the build
when it merges to master. IMO it's better to find out about the problems
sooner rather than later even if it creates a new failure in a pull
request every once in a while.