### PR TITLE
Add changelog header for 0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15] - 2023-12-21
+
 ### Fixed
 
 - Ensure `ScheduledAt` is respected on `InsertManyTx`. [PR #121](https://github.com/riverqueue/river/pull/121).


### PR DESCRIPTION
Seems like a good idea to cut a version that includes #121. Here, add a
banner for 0.0.15 to the changelog so we can cut a release.