### PR TITLE
Expose LISTEN pubsub functionality

### DIFF
--- a/client.go
+++ b/client.go
@@ -647,6 +647,11 @@ func (c *Client[TTx]) Start(ctx context.Context) error {
 
 		c.wg.Add(2)
 		go func() {
+			// TODO(bgentry): is this the wrong context? Should the notifier actually
+			// use the `workCtx` so that it doesn't get shut down before existing jobs
+			// have finished / had their contexts cancelled? This would preserve the
+			// ability to cancel an individual job's context during the initial
+			// shutdown phase.
 			c.notifier.Run(fetchNewWorkCtx)
 			c.wg.Done()
 		}()

--- a/listen_subscription.go
+++ b/listen_subscription.go
@@ -1,0 +1,18 @@
+package river
+
+import "github.com/riverqueue/river/internal/notifier"
+
+// ListenSubscription is a subscription returned from the Client's Listen method.
+type ListenSubscription struct {
+	*notifier.Subscription
+}
+
+// Unlisten stops listening to this particular subscription.
+func (sub *ListenSubscription) Unlisten() {
+	sub.Subscription.Unlisten()
+}
+
+// NotifyFunc is a function that will be called any time a Postgres notification
+// payload is receiverd on the specified topic. It must not block, or messages
+// will be dropped (including those important to River's internal operation).
+type NotifyFunc func(topic string, payload string)


### PR DESCRIPTION
We already have a robust LISTEN/NOTIFY implementation internally. It would potentially be useful for a variety of user-space coordination activities.

Expose it by wrapping our internal notifier package in a minimal public API. Ensure that we validate topic names in the process.

TODO: add test coverage