### PR TITLE
Have GitHub Actions status badge show `master` branch status only

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# River [![Build Status](https://github.com/riverqueue/river/workflows/CI/badge.svg)](https://github.com/riverqueue/river/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/riverqueue/river.svg)](https://pkg.go.dev/github.com/riverqueue/river)
+# River [![Build Status](https://github.com/riverqueue/river/workflows/CI/badge.svg?branch=master)](https://github.com/riverqueue/river/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/riverqueue/river.svg)](https://pkg.go.dev/github.com/riverqueue/river)
 
 River is a robust high-performance job processing system for Go and Postgres.
 


### PR DESCRIPTION
I just happened to notice while looking at the repo today that the
GitHub Actions status badge reads "failing" if the last Actions run
failed, even if that run was not on the `master` branch. This gives a
somewhat misleading view of the project, implying that the master build
is broken when it's actually not.

Here, scope the badge to the `master` branch only to fix the problem.
The status of non-master branch can easily be viewed from pull requests
or the GitHub Actions runs list.

<img width="482" alt="image" src="https://github.com/riverqueue/river/assets/96890/2b0db154-26bf-42d5-81e7-8a1df52cfdc2">

<img width="981" alt="image" src="https://github.com/riverqueue/river/assets/96890/4afade90-4fba-4c3d-94e4-d7d061735c7e">
