### PR TITLE
Expose metadata

### DIFF
--- a/client.go
+++ b/client.go
@@ -967,11 +967,16 @@ func insertParamsFromArgsAndOptions(args JobArgs, insertOpts *InsertOpts) (*dbad
 		return nil, err
 	}
 
+	metadata := insertOpts.Metadata
+	if len(metadata) == 0 {
+		metadata = []byte("{}")
+	}
+
 	insertParams := &dbadapter.JobInsertParams{
 		EncodedArgs: encodedArgs,
 		Kind:        args.Kind(),
 		MaxAttempts: maxAttempts,
-		Metadata:    []byte("{}"),
+		Metadata:    metadata,
 		Priority:    priority,
 		Queue:       queue,
 		State:       dbsqlc.JobState(JobStateAvailable),

--- a/client_test.go
+++ b/client_test.go
@@ -697,6 +697,7 @@ func Test_Client_Insert(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 0, jobRow.Attempt)
 		require.Equal(t, rivercommon.MaxAttemptsDefault, jobRow.MaxAttempts)
+		require.JSONEq(t, "{}", string(jobRow.Metadata))
 		require.Equal(t, (&noOpArgs{}).Kind(), jobRow.Kind)
 		require.Equal(t, PriorityDefault, jobRow.Priority)
 		require.Equal(t, QueueDefault, jobRow.Queue)
@@ -710,6 +711,7 @@ func Test_Client_Insert(t *testing.T) {
 
 		jobRow, err := client.Insert(ctx, &noOpArgs{}, &InsertOpts{
 			MaxAttempts: 17,
+			Metadata:    []byte(`{"foo": "bar"}`),
 			Priority:    3,
 			Queue:       "custom",
 			Tags:        []string{"custom"},
@@ -718,6 +720,7 @@ func Test_Client_Insert(t *testing.T) {
 		require.Equal(t, 0, jobRow.Attempt)
 		require.Equal(t, 17, jobRow.MaxAttempts)
 		require.Equal(t, (&noOpArgs{}).Kind(), jobRow.Kind)
+		require.JSONEq(t, `{"foo": "bar"}`, string(jobRow.Metadata))
 		require.Equal(t, 3, jobRow.Priority)
 		require.Equal(t, "custom", jobRow.Queue)
 		require.Equal(t, []string{"custom"}, jobRow.Tags)

--- a/insert_opts.go
+++ b/insert_opts.go
@@ -18,6 +18,11 @@ type InsertOpts struct {
 	// discarded.
 	MaxAttempts int
 
+	// Metadata is a JSON object blob of arbitrary data that will be stored with
+	// the job. Users should not overwrite or remove anything stored in this
+	// field by River.
+	Metadata []byte
+
 	// Priority is the priority of the job, with 1 being the highest priority and
 	// 4 being the lowest. When fetching available jobs to work, the highest
 	// priority jobs will always be fetched before any lower priority jobs are

--- a/internal/dbsqlc/river_job_ext.go
+++ b/internal/dbsqlc/river_job_ext.go
@@ -17,13 +17,12 @@ func JobRowFromInternal(internal *RiverJob) *rivertype.JobRow {
 		FinalizedAt: internal.FinalizedAt,
 		Kind:        internal.Kind,
 		MaxAttempts: max(int(internal.MaxAttempts), 0),
+		Metadata:    internal.Metadata,
 		Priority:    max(int(internal.Priority), 0),
 		Queue:       internal.Queue,
 		ScheduledAt: internal.ScheduledAt.UTC(), // TODO(brandur): Very weird this is the only place a UTC conversion happens.
 		State:       rivertype.JobState(internal.State),
 		Tags:        internal.Tags,
-
-		// metadata: internal.Metadata,
 	}
 }
 

--- a/rivertype/job_row.go
+++ b/rivertype/job_row.go
@@ -60,6 +60,11 @@ type JobRow struct {
 	// or from a client's default value.
 	MaxAttempts int
 
+	// Metadata is a field for storing arbitrary metadata on a job. It should
+	// always be a valid JSON object payload, and users should not overwrite or
+	// remove anything stored in this field by River.
+	Metadata []byte
+
 	// Priority is the priority of the job, with 1 being the highest priority and
 	// 4 being the lowest. When fetching available jobs to work, the highest
 	// priority jobs will always be fetched before any lower priority jobs are
@@ -89,11 +94,6 @@ type JobRow struct {
 	// functional behavior and are meant entirely as a user-specified construct
 	// to help group and categorize jobs.
 	Tags []string
-
-	// metadata is a field that'll eventually be used to store arbitrary data on
-	// a job for flexible use and use with plugins. It's currently unexported
-	// until we get a chance to more fully flesh out this feature.
-	// metadata []byte
 }
 
 // JobState is the state of a job. Jobs start as `available` or `scheduled`, and


### PR DESCRIPTION
I'm running into multiple experiments where I'd like to make use of this field, so I think it's time to do so. One of those is job cancellation, where I'd like to write a value to the metadata that can be used by the rescuer to avoid retrying a stuck `running` job that has already been manually cancelled (but never finished or got marked as such). That PR is just about ready, so it seemed like the right time to bring this in.