### PR TITLE
return error when calling stop without first calling start

### DIFF
--- a/client.go
+++ b/client.go
@@ -681,7 +681,7 @@ func (c *Client[TTx]) signalStopComplete(ctx context.Context) {
 // There's no need to call this method if a hard stop has already been initiated
 // by cancelling the context passed to Start or by calling StopAndCancel.
 func (c *Client[TTx]) Stop(ctx context.Context) error {
-	if c.fetchNewWorkCancel != nil {
+	if c.fetchNewWorkCancel == nil {
 		return errors.New("client not started")
 	}
 

--- a/client.go
+++ b/client.go
@@ -681,11 +681,11 @@ func (c *Client[TTx]) signalStopComplete(ctx context.Context) {
 // There's no need to call this method if a hard stop has already been initiated
 // by cancelling the context passed to Start or by calling StopAndCancel.
 func (c *Client[TTx]) Stop(ctx context.Context) error {
-	c.baseService.Logger.InfoContext(ctx, c.baseService.Name+": Stop started")
 	if c.fetchNewWorkCancel != nil {
 		return errors.New("client not started")
 	}
 
+	c.baseService.Logger.InfoContext(ctx, c.baseService.Name+": Stop started")
 	c.fetchNewWorkCancel()
 	return c.awaitStop(ctx)
 }

--- a/client.go
+++ b/client.go
@@ -682,6 +682,10 @@ func (c *Client[TTx]) signalStopComplete(ctx context.Context) {
 // by cancelling the context passed to Start or by calling StopAndCancel.
 func (c *Client[TTx]) Stop(ctx context.Context) error {
 	c.baseService.Logger.InfoContext(ctx, c.baseService.Name+": Stop started")
+	if c.fetchNewWorkCancel != nil {
+		return errors.New("client not started")
+	}
+
 	c.fetchNewWorkCancel()
 	return c.awaitStop(ctx)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/internal/componentstatus"
@@ -388,6 +389,15 @@ func Test_Client_Stop(t *testing.T) {
 			wg.Wait()
 		}
 	}
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+		client := newTestClient(ctx, t, newTestConfig(t, nil))
+
+		err := client.Stop(ctx)
+		require.Error(t, err)
+		assert.Equal(t, "client not started", err.Error())
+	})
 
 	t.Run("no jobs in progress", func(t *testing.T) {
 		t.Parallel()

--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/robfig/cron/v3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/internal/componentstatus"
@@ -396,7 +395,7 @@ func Test_Client_Stop(t *testing.T) {
 
 		err := client.Stop(ctx)
 		require.Error(t, err)
-		assert.Equal(t, "client not started", err.Error())
+		require.Equal(t, "client not started", err.Error())
 	})
 
 	t.Run("no jobs in progress", func(t *testing.T) {


### PR DESCRIPTION
If you call `Stop()` without first calling `Start()` you get a null pointer panic. Returning an error is much more user friendly.