### PR TITLE
replace log with slog

### DIFF
--- a/client.go
+++ b/client.go
@@ -448,7 +448,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		// we'll need to add a config for this.
 		instanceName := "default"
 
-		client.notifier = notifier.New(archetype, driver.GetDBPool().Config().ConnConfig, client.monitor.SetNotifierStatus)
+		client.notifier = notifier.New(archetype, driver.GetDBPool().Config().ConnConfig, client.monitor.SetNotifierStatus, logger)
 		var err error
 		client.elector, err = leadership.NewElector(client.adapter, client.notifier, instanceName, client.id, 5*time.Second, logger)
 		if err != nil {

--- a/internal/maintenance/scheduler_test.go
+++ b/internal/maintenance/scheduler_test.go
@@ -3,7 +3,6 @@ package maintenance
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"sort"
 	"testing"
 	"time"
@@ -17,7 +16,6 @@ import (
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/util/dbutil"
 	"github.com/riverqueue/river/internal/util/ptrutil"
-	"github.com/riverqueue/river/internal/util/slogutil"
 	"github.com/riverqueue/river/internal/util/valutil"
 )
 
@@ -267,7 +265,7 @@ func TestScheduler(t *testing.T) {
 		statusUpdate := func(status componentstatus.Status) {
 			statusUpdateCh <- status
 		}
-		notify := notifier.New(&scheduler.Archetype, dbPool.Config().ConnConfig, statusUpdate, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
+		notify := notifier.New(&scheduler.Archetype, dbPool.Config().ConnConfig, statusUpdate, riverinternaltest.Logger(t))
 
 		// Scope in so we can reuse ctx without the cancel embedded.
 		{

--- a/internal/maintenance/scheduler_test.go
+++ b/internal/maintenance/scheduler_test.go
@@ -3,6 +3,7 @@ package maintenance
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"sort"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/util/dbutil"
 	"github.com/riverqueue/river/internal/util/ptrutil"
+	"github.com/riverqueue/river/internal/util/slogutil"
 	"github.com/riverqueue/river/internal/util/valutil"
 )
 
@@ -265,7 +267,7 @@ func TestScheduler(t *testing.T) {
 		statusUpdate := func(status componentstatus.Status) {
 			statusUpdateCh <- status
 		}
-		notify := notifier.New(&scheduler.Archetype, dbPool.Config().ConnConfig, statusUpdate)
+		notify := notifier.New(&scheduler.Archetype, dbPool.Config().ConnConfig, statusUpdate, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
 
 		// Scope in so we can reuse ctx without the cancel embedded.
 		{

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"sync"
 	"time"
@@ -53,6 +53,7 @@ type Notifier struct {
 	connConfig       *pgx.ConnConfig
 	notificationBuf  chan *pgconn.Notification
 	statusChangeFunc func(componentstatus.Status)
+	logger           *slog.Logger
 
 	mu           sync.Mutex
 	isConnActive bool
@@ -60,7 +61,7 @@ type Notifier struct {
 	subChangeCh  chan *subscriptionChange
 }
 
-func New(archetype *baseservice.Archetype, connConfig *pgx.ConnConfig, statusChangeFunc func(componentstatus.Status)) *Notifier {
+func New(archetype *baseservice.Archetype, connConfig *pgx.ConnConfig, statusChangeFunc func(componentstatus.Status), logger *slog.Logger) *Notifier {
 	copiedConfig := connConfig.Copy()
 	// Rely on an overall statement timeout instead of setting identical context timeouts on every query:
 	copiedConfig.RuntimeParams["statement_timeout"] = strconv.Itoa(int(statementTimeout.Milliseconds()))
@@ -68,6 +69,7 @@ func New(archetype *baseservice.Archetype, connConfig *pgx.ConnConfig, statusCha
 		connConfig:       copiedConfig,
 		notificationBuf:  make(chan *pgconn.Notification, 1000),
 		statusChangeFunc: statusChangeFunc,
+		logger:           logger.WithGroup("notifier"),
 
 		subs:        make(map[NotificationTopic][]*Subscription),
 		subChangeCh: make(chan *subscriptionChange, 1000),
@@ -135,7 +137,7 @@ func (n *Notifier) getConnAndRun(ctx context.Context) {
 		if errors.Is(err, context.Canceled) {
 			return
 		}
-		log.Printf("error establishing connection from pool: %v", err)
+		slog.Error("error establishing connection from pool", "err", err)
 		return
 	}
 	defer func() {
@@ -198,7 +200,7 @@ func (n *Notifier) runOnce(ctx context.Context, conn *pgx.Conn) error {
 		err := <-errCh
 		if err != nil && !errors.Is(err, context.Canceled) {
 			// A non-cancel error means something went wrong with the conn, so we should bail.
-			log.Printf("error on draining notification wait: %v", err)
+			slog.Error("error on draining notification wait", "err", err)
 			return err
 		}
 		// If we got a context cancellation error, it means we successfully
@@ -230,7 +232,7 @@ func (n *Notifier) runOnce(ctx context.Context, conn *pgx.Conn) error {
 			return nil
 		}
 		if err != nil {
-			log.Printf("error from notification wait: %v", err)
+			slog.Error("error from notification wait", "err", err)
 			return err
 		}
 	case subChange := <-n.subChangeCh:
@@ -300,7 +302,7 @@ func (n *Notifier) handleNotification(conn *pgconn.PgConn, notification *pgconn.
 	select {
 	case n.notificationBuf <- notification:
 	default:
-		log.Printf("dropping notification due to full buffer: %s", notification.Payload)
+		slog.Warn("dropping notification due to full buffer", "payload", notification.Payload)
 	}
 }
 

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -137,7 +137,7 @@ func (n *Notifier) getConnAndRun(ctx context.Context) {
 		if errors.Is(err, context.Canceled) {
 			return
 		}
-		slog.Error("error establishing connection from pool", "err", err)
+		n.logger.Error("error establishing connection from pool", "err", err)
 		return
 	}
 	defer func() {
@@ -200,7 +200,7 @@ func (n *Notifier) runOnce(ctx context.Context, conn *pgx.Conn) error {
 		err := <-errCh
 		if err != nil && !errors.Is(err, context.Canceled) {
 			// A non-cancel error means something went wrong with the conn, so we should bail.
-			slog.Error("error on draining notification wait", "err", err)
+			n.logger.Error("error on draining notification wait", "err", err)
 			return err
 		}
 		// If we got a context cancellation error, it means we successfully
@@ -232,7 +232,7 @@ func (n *Notifier) runOnce(ctx context.Context, conn *pgx.Conn) error {
 			return nil
 		}
 		if err != nil {
-			slog.Error("error from notification wait", "err", err)
+			n.logger.Error("error from notification wait", "err", err)
 			return err
 		}
 	case subChange := <-n.subChangeCh:
@@ -302,7 +302,7 @@ func (n *Notifier) handleNotification(conn *pgconn.PgConn, notification *pgconn.
 	select {
 	case n.notificationBuf <- notification:
 	default:
-		slog.Warn("dropping notification due to full buffer", "payload", notification.Payload)
+		n.logger.Warn("dropping notification due to full buffer", "payload", notification.Payload)
 	}
 }
 

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -2,7 +2,6 @@ package notifier
 
 import (
 	"context"
-	"log/slog"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/riverqueue/river/internal/componentstatus"
 	"github.com/riverqueue/river/internal/dbsqlc"
 	"github.com/riverqueue/river/internal/riverinternaltest"
-	"github.com/riverqueue/river/internal/util/slogutil"
 )
 
 func expectReceiveStatus(t *testing.T, statusCh <-chan componentstatus.Status, expected componentstatus.Status) {
@@ -36,7 +34,7 @@ func TestNotifierReceivesNotification(t *testing.T) {
 		statusUpdateCh <- status
 	}
 
-	notifier := New(riverinternaltest.BaseServiceArchetype(t), db.Config().ConnConfig, statusUpdate, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
+	notifier := New(riverinternaltest.BaseServiceArchetype(t), db.Config().ConnConfig, statusUpdate, riverinternaltest.Logger(t))
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/riverqueue/river/internal/componentstatus"
 	"github.com/riverqueue/river/internal/dbsqlc"
 	"github.com/riverqueue/river/internal/riverinternaltest"
+	"github.com/riverqueue/river/internal/util/slogutil"
 )
 
 func expectReceiveStatus(t *testing.T, statusCh <-chan componentstatus.Status, expected componentstatus.Status) {
@@ -34,7 +36,7 @@ func TestNotifierReceivesNotification(t *testing.T) {
 		statusUpdateCh <- status
 	}
 
-	notifier := New(riverinternaltest.BaseServiceArchetype(t), db.Config().ConnConfig, statusUpdate)
+	notifier := New(riverinternaltest.BaseServiceArchetype(t), db.Config().ConnConfig, statusUpdate, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
 
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/internal/testdb/manager.go
+++ b/internal/testdb/manager.go
@@ -87,7 +87,7 @@ func (m *Manager) allocatePool(ctx context.Context) (*poolWithDBName, error) {
 	nextDBNum := m.getNextDBNum()
 	dbName := fmt.Sprintf("%s_%d", m.baseConfig.ConnConfig.Database, nextDBNum)
 
-	slog.Debug("Using test database", "name", dbName)
+	m.logger.Debug("Using test database", "name", dbName)
 
 	newPoolConfig := m.baseConfig.Copy()
 	newPoolConfig.ConnConfig.Database = dbName

--- a/internal/testdb/manager.go
+++ b/internal/testdb/manager.go
@@ -3,7 +3,6 @@ package testdb
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"sync"
@@ -88,7 +87,7 @@ func (m *Manager) allocatePool(ctx context.Context) (*poolWithDBName, error) {
 	nextDBNum := m.getNextDBNum()
 	dbName := fmt.Sprintf("%s_%d", m.baseConfig.ConnConfig.Database, nextDBNum)
 
-	log.Printf("Using test database: %s", dbName)
+	slog.Debug("Using test database", "name", dbName)
 
 	newPoolConfig := m.baseConfig.Copy()
 	newPoolConfig.ConnConfig.Database = dbName

--- a/producer_test.go
+++ b/producer_test.go
@@ -73,7 +73,7 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 	}))
 
 	ignoreNotifierStatusUpdates := func(componentstatus.Status) {}
-	notifier := notifier.New(archetype, dbPool.Config().ConnConfig, ignoreNotifierStatusUpdates, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
+	notifier := notifier.New(archetype, dbPool.Config().ConnConfig, ignoreNotifierStatusUpdates, riverinternaltest.Logger(t))
 
 	config := &producerConfig{
 		ErrorHandler: newTestErrorHandler(),

--- a/producer_test.go
+++ b/producer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sync"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/riverqueue/river/internal/notifier"
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/riverinternaltest"
+	"github.com/riverqueue/river/internal/util/slogutil"
 )
 
 func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
@@ -71,7 +73,7 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 	}))
 
 	ignoreNotifierStatusUpdates := func(componentstatus.Status) {}
-	notifier := notifier.New(archetype, dbPool.Config().ConnConfig, ignoreNotifierStatusUpdates)
+	notifier := notifier.New(archetype, dbPool.Config().ConnConfig, ignoreNotifierStatusUpdates, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
 
 	config := &producerConfig{
 		ErrorHandler: newTestErrorHandler(),
@@ -172,7 +174,7 @@ func Test_Producer_Run(t *testing.T) {
 
 		workers := NewWorkers()
 
-		notifier := notifier.New(archetype, dbPool.Config().ConnConfig, func(componentstatus.Status) {})
+		notifier := notifier.New(archetype, dbPool.Config().ConnConfig, func(componentstatus.Status) {}, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
 
 		config := &producerConfig{
 			ErrorHandler:      newTestErrorHandler(),

--- a/producer_test.go
+++ b/producer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"slices"
 	"sync"
 	"testing"
@@ -20,7 +19,6 @@ import (
 	"github.com/riverqueue/river/internal/notifier"
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/riverinternaltest"
-	"github.com/riverqueue/river/internal/util/slogutil"
 )
 
 func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
@@ -174,7 +172,7 @@ func Test_Producer_Run(t *testing.T) {
 
 		workers := NewWorkers()
 
-		notifier := notifier.New(archetype, dbPool.Config().ConnConfig, func(componentstatus.Status) {}, slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}))
+		notifier := notifier.New(archetype, dbPool.Config().ConnConfig, func(componentstatus.Status) {}, riverinternaltest.Logger(t))
 
 		config := &producerConfig{
 			ErrorHandler:      newTestErrorHandler(),


### PR DESCRIPTION
found a few more places where `log` is used instead of `slog`