### PR TITLE
add Cancel API to cancel a running job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Cancel` and `CancelTx` to the `Client` to enable cancellation of jobs. [PR #141](https://github.com/riverqueue/river/pull/141).
 - Added `ClientFromContext` and `ClientWithContextSafely` helpers to extract the `Client` from the worker's context where it is now available to workers. This simplifies making the River client available within your workers for i.e. enqueueing additional jobs. [PR #145](https://github.com/riverqueue/river/pull/145).
 
 ## [0.0.16] - 2024-01-06

--- a/client.go
+++ b/client.go
@@ -965,8 +965,8 @@ func (c *Client[TTx]) runProducers(fetchNewWorkCtx, workCtx context.Context) {
 // usual.
 //
 // In the event the running job finishes executing _before_ the cancellation
-// signal is received but _after_ this update was made, the behavior depends
-// on which state the job is being transitioned into:
+// signal is received but _after_ this update was made, the behavior depends on
+// which state the job is being transitioned into (based on its return error):
 //
 //   - If the job completed successfully, was cancelled from within, or was
 //     discarded due to exceeding its max attempts, the job will be updated as
@@ -1017,8 +1017,8 @@ func (c *Client[TTx]) Cancel(ctx context.Context, jobID int64) (*rivertype.JobRo
 // usual.
 //
 // In the event the running job finishes executing _before_ the cancellation
-// signal is received but _after_ this update was made, the behavior depends
-// on which state the job is being transitioned into:
+// signal is received but _after_ this update was made, the behavior depends on
+// which state the job is being transitioned into (based on its return error):
 //
 //   - If the job completed successfully, was cancelled from within, or was
 //     discarded due to exceeding its max attempts, the job will be updated as

--- a/client_test.go
+++ b/client_test.go
@@ -293,7 +293,9 @@ func Test_Client(t *testing.T) {
 			return ctx.Err()
 		}))
 
+		statusUpdateCh := client.monitor.RegisterUpdates()
 		startClient(ctx, t, client)
+		waitForClientHealthy(ctx, t, statusUpdateCh)
 
 		insertedJob, err := client.Insert(ctx, &JobArgs{}, nil)
 		require.NoError(t, err)

--- a/example_cancel_from_client_test.go
+++ b/example_cancel_from_client_test.go
@@ -1,0 +1,102 @@
+package river_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/internal/riverinternaltest"
+	"github.com/riverqueue/river/internal/util/slogutil"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+)
+
+type SleepingArgs struct{}
+
+func (args SleepingArgs) Kind() string { return "SleepingWorker" }
+
+type SleepingWorker struct {
+	river.WorkerDefaults[CancellingArgs]
+	jobChan chan int64
+}
+
+func (w *SleepingWorker) Work(ctx context.Context, job *river.Job[CancellingArgs]) error {
+	w.jobChan <- job.ID
+	select {
+	case <-ctx.Done():
+	case <-time.After(5 * time.Second):
+		return errors.New("sleeping worker timed out")
+	}
+	return ctx.Err()
+}
+
+// Example_cancelJobFromClient demonstrates how to permanently cancel a job from
+// any Client using Cancel.
+func Example_cancelJobFromClient() {
+	ctx := context.Background()
+
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	if err != nil {
+		panic(err)
+	}
+	defer dbPool.Close()
+
+	// Required for the purpose of this test, but not necessary in real usage.
+	if err := riverinternaltest.TruncateRiverTables(ctx, dbPool); err != nil {
+		panic(err)
+	}
+
+	jobChan := make(chan int64)
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &SleepingWorker{jobChan: jobChan})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 10},
+		},
+		Workers: workers,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Not strictly needed, but used to help this test wait until job is worked.
+	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCancelled)
+	defer subscribeCancel()
+
+	if err := riverClient.Start(ctx); err != nil {
+		panic(err)
+	}
+	job, err := riverClient.Insert(ctx, CancellingArgs{ShouldCancel: true}, nil)
+	if err != nil {
+		panic(err)
+	}
+	select {
+	case <-jobChan:
+	case <-time.After(2 * time.Second):
+		panic("no jobChan signal received")
+	}
+
+	// There is presently no way to wait for the client to be 100% ready, so we
+	// sleep for a bit to give it time to start up. This is only needed in this
+	// example because we need the notifier to be ready for it to receive the
+	// cancellation signal.
+	time.Sleep(500 * time.Millisecond)
+
+	if _, err = riverClient.Cancel(ctx, job.ID); err != nil {
+		panic(err)
+	}
+	waitForNJobs(subscribeChan, 1)
+
+	if err := riverClient.Stop(ctx); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// jobExecutor: job cancelled remotely
+}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -23,6 +23,7 @@ type NotificationTopic string
 const (
 	NotificationTopicInsert     NotificationTopic = "river_insert"
 	NotificationTopicLeadership NotificationTopic = "river_leadership"
+	NotificationTopicJobControl NotificationTopic = "river_job_control"
 )
 
 type NotifyFunc func(topic NotificationTopic, payload string)


### PR DESCRIPTION
This adds a new `Client` method `Cancel` which can cancel a running job. It has these behaviors:

* Jobs which are still scheduled, retryable, or available are immediately cancelled and will not be run again.
* Jobs that are already finalized (completed, cancelled, or discarded) are not touched.
* Jobs that are actively running are marked for cancellation, and cancellation is attempted using a `LISTEN`/`NOTIFY` pubsub message which is picked up by the client and producer running that job.

Because Go offers no way to interrupt a running goroutine, actively running jobs cannot be immediately halted and cancelled, so we can only cancel the job's context. Once the cancellation signal is received by the client running the job, any error returned by that job will result in it being cancelled permanently and not retried. However if the job returns no error, it will be completed as usual.

In the event the running job finishes executing _before_ the cancellation signal is received, the job will be completed or retried as usual without regard to the cancellation. @brandur Realized as I was writing this that it was solvable, do you think we should try to fix this with a smarter completion query that uses the metadata value we set as part of the `Cancel` query?

Additional documentation to follow once we're satisfied with the shape and behavior of this API.