### PR TITLE
add UniqueSkippedAsDuplicate field to JobRow

### DIFF
--- a/client.go
+++ b/client.go
@@ -1066,7 +1066,9 @@ func (c *Client[TTx]) InsertTx(ctx context.Context, tx TTx, args JobArgs, opts *
 		return nil, err
 	}
 
-	return dbsqlc.JobRowFromInternal(res.Job), nil
+	jobRow := dbsqlc.JobRowFromInternal(res.Job)
+	jobRow.UniqueSkippedAsDuplicate = res.UniqueSkippedAsDuplicate
+	return jobRow, nil
 }
 
 // InsertManyParams encapsulates a single job combined with insert options for

--- a/rivertype/job_row.go
+++ b/rivertype/job_row.go
@@ -94,6 +94,11 @@ type JobRow struct {
 	// functional behavior and are meant entirely as a user-specified construct
 	// to help group and categorize jobs.
 	Tags []string
+
+	// UniqueSkippedAsDuplicate indicates that the insert didn't occur because
+	// it was a unique job, and another unique job within the unique parameters
+	// was already in the database.
+	UniqueSkippedAsDuplicate bool
 }
 
 // JobState is the state of a job. Jobs start as `available` or `scheduled`, and


### PR DESCRIPTION
When inserting a job, the insert may be rejected because the configured uniqueness constraints for the job are not met.
With the current API, this happens silently and without a way for the caller to check for this condition.

Since we already record the UniqueSkippedAsDuplicate in the internal dbadapter.JobInsertResult, we just have to propagate this value to the external client API.

Callers can now check the UniqueSkippedAsDuplicate field of JobRow to check for the condition described above.

---

This is an RFC PR to keep the discussion on #86 going. I am pretty sure this is the "least breaking" API change possible to implement this.

@bgentry @brandur please advise if you like this approach or if you have other suggestions.