### PR TITLE
add Client to work context, helpers to extract it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `ClientFromContext` and `ClientWithContextSafely` helpers to extract the `Client` from the worker's context where it is now available to workers. This simplifies making the River client available within your workers for i.e. enqueueing additional jobs. [PR #145](https://github.com/riverqueue/river/pull/145).
+
 ## [0.0.16] - 2024-01-06
 
 ### Changed

--- a/client.go
+++ b/client.go
@@ -567,7 +567,7 @@ func (c *Client[TTx]) Start(ctx context.Context) error {
 	// cancelled a more aggressive stop will be initiated.
 	fetchNewWorkCtx, fetchNewWorkCancel := context.WithCancel(ctx)
 	c.fetchNewWorkCancel = fetchNewWorkCancel
-	workCtx, workCancel := context.WithCancel(ctx)
+	workCtx, workCancel := context.WithCancel(withClient[TTx](ctx, c))
 	c.workCancel = workCancel
 
 	// Before doing anything else, make an initial connection to the database to

--- a/context.go
+++ b/context.go
@@ -1,0 +1,46 @@
+package river
+
+import (
+	"context"
+	"errors"
+)
+
+type ctxKey int
+
+const (
+	ctxKeyClient ctxKey = iota
+)
+
+var errClientNotInContext = errors.New("river: client not found in context, can only be used in a Worker")
+
+func withClient[TTx any](ctx context.Context, client *Client[TTx]) context.Context {
+	return context.WithValue(ctx, ctxKeyClient, client)
+}
+
+// ClientFromContext returns the Client from the context. This function can
+// only be used within a Worker's Work() method because that is the only place
+// River sets the Client on the context.
+//
+// It panics if the context does not contain a Client, which will never happen
+// from the context provided to a Worker's Work() method.
+func ClientFromContext[TTx any](ctx context.Context) *Client[TTx] {
+	client, err := ClientFromContextSafely[TTx](ctx)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// ClientFromContext returns the Client from the context. This function can
+// only be used within a Worker's Work() method because that is the only place
+// River sets the Client on the context.
+//
+// It returns an error if the context does not contain a Client, which will
+// never happen from the context provided to a Worker's Work() method.
+func ClientFromContextSafely[TTx any](ctx context.Context) (*Client[TTx], error) {
+	client, exists := ctx.Value(ctxKeyClient).(*Client[TTx])
+	if !exists || client == nil {
+		return nil, errClientNotInContext
+	}
+	return client, nil
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,31 @@
+package river
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientFromContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := &Client[pgx.Tx]{}
+	ctx = withClient(ctx, client)
+
+	require.Equal(t, client, ClientFromContext[pgx.Tx](ctx))
+
+	result, err := ClientFromContextSafely[pgx.Tx](ctx)
+	require.NoError(t, err)
+	require.Equal(t, client, result)
+
+	require.PanicsWithError(t, errClientNotInContext.Error(), func() {
+		ClientFromContext[pgx.Tx](context.Background())
+	})
+
+	result, err = ClientFromContextSafely[pgx.Tx](context.Background())
+	require.ErrorIs(t, err, errClientNotInContext)
+	require.Nil(t, result)
+}


### PR DESCRIPTION
This change adds the `*Client` to an unexported context key within the work context when the Client is started, making it available to the context for every job that's worked by that Client.

Additionally, two new helper functions are added to retrieve the Client from the context within a Worker: `ClientFromContext` and `ClientFromContextSafely`. The only difference between these is that the first variant panics if the client isn't found in the context, whereas the latter returns an error. However if these are used on the context provided to a Worker's `Work()` method (or one derived from it) they should never panic/error.

Inspired by #87 and https://github.com/riverqueue/river/discussions/144.

If we want to move forward with this, it still needs:
* [x] A changelog entry
* [ ] Website documentation