### PR TITLE
fix InsertMany with unspecified ScheduledAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `Cancel` and `CancelTx` to the `Client` to enable cancellation of jobs. [PR #141](https://github.com/riverqueue/river/pull/141).
 - Added `ClientFromContext` and `ClientWithContextSafely` helpers to extract the `Client` from the worker's context where it is now available to workers. This simplifies making the River client available within your workers for i.e. enqueueing additional jobs. [PR #145](https://github.com/riverqueue/river/pull/145).
+- Add `JobList` API for listing jobs. [PR #117](https://github.com/riverqueue/river/pull/117).
+
+### Fixed
+
+- Fixed incorrect default value handling for `ScheduledAt` option with `InsertMany` / `InsertManyTx`. [PR #149](https://github.com/riverqueue/river/pull/149).
 
 ## [0.0.16] - 2024-01-06
 

--- a/internal/dbadapter/db_adapter.go
+++ b/internal/dbadapter/db_adapter.go
@@ -348,6 +348,8 @@ func (a *StandardAdapter) JobInsertManyTx(ctx context.Context, tx pgx.Tx, params
 
 	insertJobsParams := make([]dbsqlc.JobInsertManyParams, len(params))
 
+	now := a.TimeNowUTC()
+
 	for i := 0; i < len(params); i++ {
 		params := params[i]
 
@@ -360,6 +362,11 @@ func (a *StandardAdapter) JobInsertManyTx(ctx context.Context, tx pgx.Tx, params
 		if tags == nil {
 			tags = []string{}
 		}
+		scheduledAt := now
+		if !params.ScheduledAt.IsZero() {
+			scheduledAt = params.ScheduledAt.UTC()
+		}
+
 		insertJobsParams[i] = dbsqlc.JobInsertManyParams{
 			Args:        params.EncodedArgs,
 			Kind:        params.Kind,
@@ -368,7 +375,7 @@ func (a *StandardAdapter) JobInsertManyTx(ctx context.Context, tx pgx.Tx, params
 			Priority:    int16(min(params.Priority, math.MaxInt16)),
 			Queue:       params.Queue,
 			State:       params.State,
-			ScheduledAt: params.ScheduledAt,
+			ScheduledAt: scheduledAt,
 			Tags:        tags,
 		}
 	}


### PR DESCRIPTION
Due to a missing `IsZero()` check, `InsertMany` was inserting the Go zero time into the database, resulting in `ScheduledAt` times in the distant past. This didn't impact single inserts because that code path had a check of this sort and also relies on insertion-time coalescing & defaults.