### PR TITLE
cleaner Client type name in logs

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"reflect"
 	"regexp"
 	"sync"
 	"time"
@@ -438,7 +437,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 	}
 
 	baseservice.Init(archetype, &client.baseService)
-	client.baseService.Name = reflect.TypeOf(Client[TTx]{}).Name() // Have to correct the name because base service isn't embedded like it usually is
+	client.baseService.Name = "Client" // Have to correct the name because base service isn't embedded like it usually is
 
 	// There are a number of internal components that are only needed/desired if
 	// we're actually going to be working jobs (as opposed to just enqueueing

--- a/client_test.go
+++ b/client_test.go
@@ -2626,6 +2626,16 @@ func Test_Client_Start_Error(t *testing.T) {
 	})
 }
 
+func Test_NewClient_BaseServiceName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	client := newTestClient(ctx, t, newTestConfig(t, nil))
+	// Ensure we get the clean name "Client" instead of the fully qualified name
+	// with generic type param:
+	require.Equal(t, "Client", client.baseService.Name)
+}
+
 func Test_NewClient_ClientIDWrittenToJobAttemptedByWhenFetched(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)


### PR DESCRIPTION
We would prefer that this type is logged as `Client` instead of the verbose `Client[github.com/jackc/pgx/v5.Tx]`.

Fixes #153.