### PR TITLE
Respect job uniqueness when inserting periodic jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed incorrect default value handling for `ScheduledAt` option with `InsertMany` / `InsertManyTx`. [PR #149](https://github.com/riverqueue/river/pull/149).
+- Fixed problem where job uniqueness wasn't being respected when used in conjuction with periodic jobs. [PR #168](https://github.com/riverqueue/river/pull/168).
 
 ### Fixed
 


### PR DESCRIPTION
As reported in #161, unique jobs combined with periodic jobs doesn't
work as expected. This is because the periodic job enqueueing service
inserts jobs in bulk as an optimization in case many periodic jobs need
inserting, and bulk insertion doesn't support uniqueness.

Here, check for job uniqueness and make sure to use the single job
insertion path when a periodic job is unique. I left the bulk job
insertion path in as well, for use when job uniqueness isn't required.
The optimization still feels like a reasonable trade off to me because
it doesn't make the code that much harder to read, and I expect
non-unique periodic jobs to be the common case.

Fixes #161.