### PR TITLE
Tee up `go.mod` and `CHANGELOG.md` for version 0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.17] - 2024-01-22
+
 ### Added
 
 - Added `JobCancel` and `JobCancelTx` to the `Client` to enable cancellation of jobs. [PR #141](https://github.com/riverqueue/river/pull/141) and [PR #152](https://github.com/riverqueue/river/pull/152).

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/jackc/pgx/v5 v5.5.2
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.15
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.15
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.15
+	github.com/riverqueue/river/riverdriver v0.0.17
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.17
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.17
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,7 +7,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.15
+	github.com/riverqueue/river/riverdriver v0.0.17
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -6,7 +6,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.15
+	github.com/riverqueue/river/riverdriver v0.0.17
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Here, as proposed by the new release instructions in #169, tee up some
changes for 0.0.17, updating `CHANGELOG.md` with the new section and
modifying `go.mod` files to point to the new release.

Unfortunate note no. 1: the `go.mod` files change from 0.0.15 to 0.0.17
instead of starting at 0.0.16 because I accidentally botched the last
release by not pushing the `go.mod` changes. Hopefully this new process
will correct that so it doesn't happen again.

Unfortunate note no. 2: As noted in #169, we expect the build to fail
here because `go.mod` files point to a version that doesn't have a tag
yet.

The new `river validate` is included here (#170) so I'm also going to
try a two-phase release by tagging all submodules except for
`./cmd/river` with 0.0.17 first, then modifying that submodule to point
to the new 0.0.17 in other modules, then do a cut and release for it
separately. Kind of a pain, but as discussed at length before, this
seems to be the least bad of a bunch of suboptimal options.