### PR TITLE
Remove debug statement in periodic job enqueuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.18] - 2024-01-25
+
+### Fixed
+
+- Remove a debug statement from periodic job enqueuer that was accidentally left in. [PR #176](https://github.com/riverqueue/river/pull/176).
+
 ## [0.0.17] - 2024-01-22
 
 ### Added

--- a/client_test.go
+++ b/client_test.go
@@ -2229,11 +2229,6 @@ func Test_Client_Subscribe(t *testing.T) {
 		startClient(ctx, t, client)
 
 		wg.Wait()
-
-		// for i := 0; i < subscribeChanSize+1; i++ {
-		// 	x := riverinternaltest.WaitOrTimeout(t, subscribeChan)
-		// 	fmt.Printf("--- received: %+v\n\n", string(x.Job.EncodedArgs))
-		// }
 	})
 
 	t.Run("PanicOnUnknownKind", func(t *testing.T) {

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -3,7 +3,6 @@ package maintenance
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/riverqueue/river/internal/baseservice"
@@ -208,8 +207,6 @@ func (s *PeriodicJobEnqueuer) insertBatch(ctx context.Context, insertParamsMany,
 	// aren't inserting any unique jobs periodically (which we expect is most).
 	if len(insertParamsUnique) > 0 {
 		for _, insertParams := range insertParamsUnique {
-			fmt.Printf("--- %+v\n\n", "inserting unique")
-
 			if _, err := s.dbAdapter.JobInsert(ctx, insertParams); err != nil {
 				s.Logger.ErrorContext(ctx, s.Name+": Error inserting unique periodic job",
 					"error", err.Error(), "kind", insertParams.Kind)


### PR DESCRIPTION
This one's my fault -- left a debug statement in #168 as part of the
periodic job enqueuer. Here, remove it.

Also remove a similar, unused commented out debug statement in
`client_test.go`.