### PR TITLE
Update `go.mod`s for `v0.0.18` release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/jackc/pgx/v5 v5.5.2
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.17
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.17
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.17
+	github.com/riverqueue/river/riverdriver v0.0.18
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.18
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.18
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,7 +7,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.17
+	github.com/riverqueue/river/riverdriver v0.0.18
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -6,7 +6,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.17
+	github.com/riverqueue/river/riverdriver v0.0.18
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
A small release containing only the fix from #176.