### PR TITLE
Small `ci.yml` clean up to remove `BIN_PATH`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ env:
   # Database to connect to that can create other databases with `CREATE DATABASE`.
   ADMIN_DATABASE_URL: postgres://postgres:postgres@localhost:5432
 
-  # Just a common place for steps to put binaries they need and which is added
-  # to GITHUB_PATH/PATH.
-  BIN_PATH: /home/runner/bin
-
   # A suitable URL for non-test database.
   DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/river_dev?sslmode=disable
 


### PR DESCRIPTION
A small clean up in `ci.yml` to remove the `BIN_PATH` variable, which
was previously used for sqlc before #82 moved that to a GitHub Action.

It's not a particular problem that `BIN_PATH` is there, but the comment
above it that it's added to `PATH` is no longer true, so probably best
to remove it for accuracy's sake.