### PR TITLE
validate queue name on insert, allow hyphen queue name separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Validate queue name on job insertion. [PR #184](https://github.com/riverqueue/rive/pull/184).
+
 ## [0.0.18] - 2024-01-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Validate queue name on job insertion. [PR #184](https://github.com/riverqueue/rive/pull/184).
+- Validate queue name on job insertion. Allow queue names with hyphen separators in addition to underscore. [PR #184](https://github.com/riverqueue/river/pull/184).
 
 ## [0.0.18] - 2024-01-25
 

--- a/client.go
+++ b/client.go
@@ -1059,6 +1059,10 @@ func insertParamsFromArgsAndOptions(args JobArgs, insertOpts *InsertOpts) (*dbad
 	priority := valutil.FirstNonZero(insertOpts.Priority, jobInsertOpts.Priority, rivercommon.PriorityDefault)
 	queue := valutil.FirstNonZero(insertOpts.Queue, jobInsertOpts.Queue, rivercommon.QueueDefault)
 
+	if err := validateQueueName(queue); err != nil {
+		return nil, err
+	}
+
 	tags := insertOpts.Tags
 	if insertOpts.Tags == nil {
 		tags = jobInsertOpts.Tags
@@ -1298,7 +1302,7 @@ func validateQueueName(queueName string) error {
 		return errors.New("queue name cannot be longer than 64 characters")
 	}
 	if !nameRegex.MatchString(queueName) {
-		return fmt.Errorf("queue name is invalid, see documentation: %q", queueName)
+		return fmt.Errorf("queue name is invalid, expected letters and numbers separated by underscore: %q", queueName)
 	}
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -1292,7 +1292,7 @@ func (c *Client[TTx]) validateJobArgs(args JobArgs) error {
 	return nil
 }
 
-var nameRegex = regexp.MustCompile(`^(?:[a-z0-9])+(?:_?[a-z0-9]+)*$`)
+var nameRegex = regexp.MustCompile(`^(?:[a-z0-9])+(?:[_|\-]?[a-z0-9]+)*$`)
 
 func validateQueueName(queueName string) error {
 	if queueName == "" {
@@ -1302,7 +1302,7 @@ func validateQueueName(queueName string) error {
 		return errors.New("queue name cannot be longer than 64 characters")
 	}
 	if !nameRegex.MatchString(queueName) {
-		return fmt.Errorf("queue name is invalid, expected letters and numbers separated by underscore: %q", queueName)
+		return fmt.Errorf("queue name is invalid, expected letters and numbers separated by underscores or hyphens: %q", queueName)
 	}
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1885,7 +1885,7 @@ func Test_Client_Maintenance(t *testing.T) {
 		// pass before our insertion is complete.
 		ineligibleJob1 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateAvailable})
 		ineligibleJob2 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateRunning})
-		ineligibleJob3 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateCompleted})
+		ineligibleJob3 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateCompleted, FinalizedAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
 
 		jobInPast1 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateScheduled, ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
 		jobInPast2 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateScheduled, ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Minute))})

--- a/client_test.go
+++ b/client_test.go
@@ -891,6 +891,15 @@ func Test_Client_Insert(t *testing.T) {
 		require.WithinDuration(t, time.Now(), jobRow.ScheduledAt, 2*time.Second)
 	})
 
+	t.Run("ErrorsOnInvalidQueueName", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		_, err := client.Insert(ctx, &noOpArgs{}, &InsertOpts{Queue: "invalid-queue"})
+		require.ErrorContains(t, err, "queue name is invalid")
+	})
+
 	t.Run("ErrorsOnDriverWithoutPool", func(t *testing.T) {
 		t.Parallel()
 
@@ -1084,6 +1093,18 @@ func Test_Client_InsertMany(t *testing.T) {
 		require.Len(t, jobs, 1, "Expected to find exactly one job of kind: "+(noOpArgs{}).Kind())
 		jobRow := jobs[0]
 		require.WithinDuration(t, time.Now(), jobRow.ScheduledAt, 2*time.Second)
+	})
+
+	t.Run("ErrorsOnInvalidQueueName", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		count, err := client.InsertMany(ctx, []InsertManyParams{
+			{Args: &noOpArgs{}, InsertOpts: &InsertOpts{Queue: "invalid-queue"}},
+		})
+		require.ErrorContains(t, err, "queue name is invalid")
+		require.Equal(t, int64(0), count)
 	})
 
 	t.Run("ErrorsOnDriverWithoutPool", func(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -896,7 +896,7 @@ func Test_Client_Insert(t *testing.T) {
 
 		client, _ := setup(t)
 
-		_, err := client.Insert(ctx, &noOpArgs{}, &InsertOpts{Queue: "invalid-queue"})
+		_, err := client.Insert(ctx, &noOpArgs{}, &InsertOpts{Queue: "invalid*queue"})
 		require.ErrorContains(t, err, "queue name is invalid")
 	})
 
@@ -1101,7 +1101,7 @@ func Test_Client_InsertMany(t *testing.T) {
 		client, _ := setup(t)
 
 		count, err := client.InsertMany(ctx, []InsertManyParams{
-			{Args: &noOpArgs{}, InsertOpts: &InsertOpts{Queue: "invalid-queue"}},
+			{Args: &noOpArgs{}, InsertOpts: &InsertOpts{Queue: "invalid*queue"}},
 		})
 		require.ErrorContains(t, err, "queue name is invalid")
 		require.Equal(t, int64(0), count)
@@ -2950,16 +2950,22 @@ func Test_NewClient_Validations(t *testing.T) {
 			wantErr: errors.New("queue name cannot be longer than 64 characters"),
 		},
 		{
-			name: "Queues queue names can't have hyphens",
+			name: "Queues queue names can't have asterisks",
 			configFunc: func(config *Config) {
-				config.Queues = map[string]QueueConfig{"no-hyphens": {MaxWorkers: 1}}
+				config.Queues = map[string]QueueConfig{"no*hyphens": {MaxWorkers: 1}}
 			},
-			wantErr: errors.New("queue name is invalid, see documentation: \"no-hyphens\""),
+			wantErr: errors.New("queue name is invalid, expected letters and numbers separated by underscores or hyphens: \"no*hyphens\""),
 		},
 		{
 			name: "Queues queue names can be letters and numbers joined by underscores",
 			configFunc: func(config *Config) {
 				config.Queues = map[string]QueueConfig{"some_awesome_3rd_queue_namezzz": {MaxWorkers: 1}}
+			},
+		},
+		{
+			name: "Queues queue names can be letters and numbers joined by hyphens",
+			configFunc: func(config *Config) {
+				config.Queues = map[string]QueueConfig{"some-awesome-3rd-queue-namezzz": {MaxWorkers: 1}}
 			},
 		},
 		{

--- a/rivertest/rivertest_test.go
+++ b/rivertest/rivertest_test.go
@@ -215,7 +215,7 @@ func TestRequireInsertedTx(t *testing.T) {
 		_, err = riverClient.Insert(ctx, Job2Args{Int: 123}, &river.InsertOpts{
 			MaxAttempts: 78,
 			Priority:    2,
-			Queue:       "another-queue",
+			Queue:       "another_queue",
 			ScheduledAt: testTime,
 			Tags:        []string{"tag1"},
 		})
@@ -224,7 +224,7 @@ func TestRequireInsertedTx(t *testing.T) {
 		_ = requireInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
 			MaxAttempts: 78,
 			Priority:    2,
-			Queue:       "another-queue",
+			Queue:       "another_queue",
 			ScheduledAt: testTime,
 			Tags:        []string{"tag1"},
 		})
@@ -285,7 +285,7 @@ func TestRequireInsertedTx(t *testing.T) {
 		_, err := riverClient.Insert(ctx, Job2Args{Int: 123}, &river.InsertOpts{
 			MaxAttempts: 78,
 			Priority:    2,
-			Queue:       "another-queue",
+			Queue:       "another_queue",
 			ScheduledAt: testTime,
 			Tags:        []string{"tag1"},
 		})
@@ -297,7 +297,7 @@ func TestRequireInsertedTx(t *testing.T) {
 			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
 				MaxAttempts: 77,
 				Priority:    2,
-				Queue:       "another-queue",
+				Queue:       "another_queue",
 				ScheduledAt: testTime,
 				State:       river.JobStateScheduled,
 				Tags:        []string{"tag1"},
@@ -314,7 +314,7 @@ func TestRequireInsertedTx(t *testing.T) {
 			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
 				MaxAttempts: 78,
 				Priority:    3,
-				Queue:       "another-queue",
+				Queue:       "another_queue",
 				ScheduledAt: testTime,
 				State:       river.JobStateScheduled,
 				Tags:        []string{"tag1"},
@@ -338,7 +338,7 @@ func TestRequireInsertedTx(t *testing.T) {
 			})
 			require.True(t, mockT.Failed)
 			require.Equal(t,
-				failureString("Job with kind 'job2' queue 'another-queue' not equal to expected 'wrong-queue'")+"\n",
+				failureString("Job with kind 'job2' queue 'another_queue' not equal to expected 'wrong-queue'")+"\n",
 				mockT.LogOutput())
 		}
 
@@ -348,7 +348,7 @@ func TestRequireInsertedTx(t *testing.T) {
 			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
 				MaxAttempts: 78,
 				Priority:    2,
-				Queue:       "another-queue",
+				Queue:       "another_queue",
 				ScheduledAt: testTime.Add(3*time.Minute + 23*time.Second + 123*time.Microsecond),
 				State:       river.JobStateScheduled,
 				Tags:        []string{"tag1"},
@@ -365,7 +365,7 @@ func TestRequireInsertedTx(t *testing.T) {
 			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
 				MaxAttempts: 78,
 				Priority:    2,
-				Queue:       "another-queue",
+				Queue:       "another_queue",
 				ScheduledAt: testTime,
 				State:       river.JobStateCancelled,
 				Tags:        []string{"tag1"},
@@ -382,7 +382,7 @@ func TestRequireInsertedTx(t *testing.T) {
 			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
 				MaxAttempts: 78,
 				Priority:    2,
-				Queue:       "another-queue",
+				Queue:       "another_queue",
 				ScheduledAt: testTime,
 				State:       river.JobStateScheduled,
 				Tags:        []string{"tag2"},
@@ -629,7 +629,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 		_, err = riverClient.Insert(ctx, Job2Args{Int: 123}, &river.InsertOpts{
 			MaxAttempts: 78,
 			Priority:    2,
-			Queue:       "another-queue",
+			Queue:       "another_queue",
 			ScheduledAt: testTime,
 			Tags:        []string{"tag1"},
 		})
@@ -641,7 +641,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 				Opts: &RequireInsertedOpts{
 					MaxAttempts: 78,
 					Priority:    2,
-					Queue:       "another-queue",
+					Queue:       "another_queue",
 					ScheduledAt: testTime,
 					Tags:        []string{"tag1"},
 				},
@@ -741,7 +741,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 		_, err := riverClient.Insert(ctx, Job2Args{Int: 123}, &river.InsertOpts{
 			MaxAttempts: 78,
 			Priority:    2,
-			Queue:       "another-queue",
+			Queue:       "another_queue",
 			ScheduledAt: testTime,
 			Tags:        []string{"tag1"},
 		})
@@ -756,7 +756,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 					Opts: &RequireInsertedOpts{
 						MaxAttempts: 77,
 						Priority:    2,
-						Queue:       "another-queue",
+						Queue:       "another_queue",
 						ScheduledAt: testTime,
 						State:       river.JobStateScheduled,
 						Tags:        []string{"tag1"},
@@ -778,7 +778,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 					Opts: &RequireInsertedOpts{
 						MaxAttempts: 78,
 						Priority:    3,
-						Queue:       "another-queue",
+						Queue:       "another_queue",
 						ScheduledAt: testTime,
 						State:       river.JobStateScheduled,
 						Tags:        []string{"tag1"},
@@ -809,7 +809,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 			})
 			require.True(t, mockT.Failed)
 			require.Equal(t,
-				failureString("Job with kind 'job2' (expected job slice index 0) queue 'another-queue' not equal to expected 'wrong-queue'")+"\n",
+				failureString("Job with kind 'job2' (expected job slice index 0) queue 'another_queue' not equal to expected 'wrong-queue'")+"\n",
 				mockT.LogOutput())
 		}
 
@@ -822,7 +822,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 					Opts: &RequireInsertedOpts{
 						MaxAttempts: 78,
 						Priority:    2,
-						Queue:       "another-queue",
+						Queue:       "another_queue",
 						ScheduledAt: testTime.Add(3*time.Minute + 23*time.Second + 123*time.Microsecond),
 						State:       river.JobStateScheduled,
 						Tags:        []string{"tag1"},
@@ -844,7 +844,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 					Opts: &RequireInsertedOpts{
 						MaxAttempts: 78,
 						Priority:    2,
-						Queue:       "another-queue",
+						Queue:       "another_queue",
 						State:       river.JobStateCancelled,
 						ScheduledAt: testTime,
 						Tags:        []string{"tag1"},
@@ -866,7 +866,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 					Opts: &RequireInsertedOpts{
 						MaxAttempts: 78,
 						Priority:    2,
-						Queue:       "another-queue",
+						Queue:       "another_queue",
 						ScheduledAt: testTime,
 						State:       river.JobStateScheduled,
 						Tags:        []string{"tag2"},


### PR DESCRIPTION
Validates queue names on `Insert`/`InsertMany` in the same fashion as on client initialization. Also loosens the queue name validation logic to allow hyphen separators in addition to underscore.

Fixes #183.

I thought briefly about implementing a cache to save from re-validating the same queue name many times. We could still do that, but it's a fairly trivial optimization that could be added afterward.