### PR TITLE
Add JobGet + JobGetTx methods to Client, use within tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `JobGet` and `JobGetTx` to the `Client` to enable easily fetching a single job row from code for introspection. [PR #186].
+
 ### Changed
 
 - Validate queue name on job insertion. Allow queue names with hyphen separators in addition to underscore. [PR #184](https://github.com/riverqueue/river/pull/184).

--- a/client_test.go
+++ b/client_test.go
@@ -942,8 +942,7 @@ func Test_Client_InsertTx(t *testing.T) {
 	ctx := context.Background()
 
 	type testBundle struct {
-		queries *dbsqlc.Queries
-		tx      pgx.Tx
+		tx pgx.Tx
 	}
 
 	setup := func(t *testing.T) (*Client[pgx.Tx], *testBundle) {
@@ -1338,7 +1337,7 @@ func Test_Client_JobGet(t *testing.T) {
 		require.NotNil(t, job)
 
 		require.Equal(t, newJob.ID, job.ID)
-		require.Equal(t, rivertype.JobState(newJob.State), job.State)
+		require.Equal(t, newJob.State, job.State)
 	})
 
 	t.Run("ReturnsErrNotFoundIfJobDoesNotExist", func(t *testing.T) {
@@ -1347,7 +1346,7 @@ func Test_Client_JobGet(t *testing.T) {
 		client, _ := setup(t)
 
 		job, err := client.JobGet(ctx, 999999)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNotFound)
 		require.Nil(t, job)
 	})

--- a/client_test.go
+++ b/client_test.go
@@ -170,7 +170,6 @@ func Test_Client(t *testing.T) {
 	ctx := context.Background()
 
 	type testBundle struct {
-		queries       *dbsqlc.Queries
 		subscribeChan <-chan *Event
 	}
 
@@ -239,9 +238,9 @@ func Test_Client(t *testing.T) {
 		require.Equal(t, JobStateCancelled, event.Job.State)
 		require.WithinDuration(t, time.Now(), *event.Job.FinalizedAt, 2*time.Second)
 
-		updatedJob, err := bundle.queries.JobGetByID(ctx, client.driver.GetDBPool(), insertedJob.ID)
+		updatedJob, err := client.JobGet(ctx, insertedJob.ID)
 		require.NoError(t, err)
-		require.Equal(t, dbsqlc.JobStateCancelled, updatedJob.State)
+		require.Equal(t, rivertype.JobStateCancelled, updatedJob.State)
 		require.WithinDuration(t, time.Now(), *updatedJob.FinalizedAt, 2*time.Second)
 	})
 
@@ -268,9 +267,9 @@ func Test_Client(t *testing.T) {
 		require.Equal(t, JobStateScheduled, event.Job.State)
 		require.WithinDuration(t, time.Now().Add(15*time.Minute), event.Job.ScheduledAt, 2*time.Second)
 
-		updatedJob, err := bundle.queries.JobGetByID(ctx, client.driver.GetDBPool(), insertedJob.ID)
+		updatedJob, err := client.JobGet(ctx, insertedJob.ID)
 		require.NoError(t, err)
-		require.Equal(t, dbsqlc.JobStateScheduled, updatedJob.State)
+		require.Equal(t, rivertype.JobStateScheduled, updatedJob.State)
 		require.WithinDuration(t, time.Now().Add(15*time.Minute), updatedJob.ScheduledAt, 2*time.Second)
 	})
 
@@ -316,9 +315,9 @@ func Test_Client(t *testing.T) {
 		require.Equal(t, JobStateCancelled, event.Job.State)
 		require.WithinDuration(t, time.Now(), *event.Job.FinalizedAt, 2*time.Second)
 
-		jobAfterCancel, err := bundle.queries.JobGetByID(ctx, client.driver.GetDBPool(), insertedJob.ID)
+		jobAfterCancel, err := client.JobGet(ctx, insertedJob.ID)
 		require.NoError(t, err)
-		require.Equal(t, dbsqlc.JobStateCancelled, jobAfterCancel.State)
+		require.Equal(t, rivertype.JobStateCancelled, jobAfterCancel.State)
 		require.WithinDuration(t, time.Now(), *jobAfterCancel.FinalizedAt, 2*time.Second)
 	}
 
@@ -977,8 +976,8 @@ func Test_Client_InsertTx(t *testing.T) {
 		require.Equal(t, []string{}, jobRow.Tags)
 
 		// Job is not visible outside of the transaction.
-		_, err = bundle.queries.JobGetByID(ctx, client.driver.GetDBPool(), jobRow.ID)
-		require.ErrorIs(t, err, pgx.ErrNoRows)
+		_, err = client.JobGet(ctx, jobRow.ID)
+		require.ErrorIs(t, err, ErrNotFound)
 	})
 
 	t.Run("WithInsertOpts", func(t *testing.T) {
@@ -1765,26 +1764,26 @@ func Test_Client_Maintenance(t *testing.T) {
 		jc.TestSignals.DeletedBatch.WaitOrTimeout()
 
 		var err error
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), ineligibleJob1.ID)
-		require.NotErrorIs(t, err, pgx.ErrNoRows) // still there
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), ineligibleJob2.ID)
-		require.NotErrorIs(t, err, pgx.ErrNoRows) // still there
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), ineligibleJob3.ID)
-		require.NotErrorIs(t, err, pgx.ErrNoRows) // still there
+		_, err = client.JobGet(ctx, ineligibleJob1.ID)
+		require.NotErrorIs(t, err, ErrNotFound) // still there
+		_, err = client.JobGet(ctx, ineligibleJob2.ID)
+		require.NotErrorIs(t, err, ErrNotFound) // still there
+		_, err = client.JobGet(ctx, ineligibleJob3.ID)
+		require.NotErrorIs(t, err, ErrNotFound) // still there
 
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), jobBeyondHorizon1.ID)
-		require.ErrorIs(t, err, pgx.ErrNoRows)
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), jobBeyondHorizon2.ID)
-		require.ErrorIs(t, err, pgx.ErrNoRows)
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), jobBeyondHorizon3.ID)
-		require.ErrorIs(t, err, pgx.ErrNoRows)
+		_, err = client.JobGet(ctx, jobBeyondHorizon1.ID)
+		require.ErrorIs(t, err, ErrNotFound)
+		_, err = client.JobGet(ctx, jobBeyondHorizon2.ID)
+		require.ErrorIs(t, err, ErrNotFound)
+		_, err = client.JobGet(ctx, jobBeyondHorizon3.ID)
+		require.ErrorIs(t, err, ErrNotFound)
 
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), jobWithinHorizon1.ID)
-		require.NotErrorIs(t, err, pgx.ErrNoRows) // still there
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), jobWithinHorizon2.ID)
-		require.NotErrorIs(t, err, pgx.ErrNoRows) // still there
-		_, err = queries.JobGetByID(ctx, client.driver.GetDBPool(), jobWithinHorizon3.ID)
-		require.NotErrorIs(t, err, pgx.ErrNoRows) // still there
+		_, err = client.JobGet(ctx, jobWithinHorizon1.ID)
+		require.NotErrorIs(t, err, ErrNotFound) // still there
+		_, err = client.JobGet(ctx, jobWithinHorizon2.ID)
+		require.NotErrorIs(t, err, ErrNotFound) // still there
+		_, err = client.JobGet(ctx, jobWithinHorizon3.ID)
+		require.NotErrorIs(t, err, ErrNotFound) // still there
 	})
 
 	t.Run("PeriodicJobEnqueuerWithOpts", func(t *testing.T) {
@@ -2416,10 +2415,10 @@ func Test_Client_JobCompletion(t *testing.T) {
 		require.Equal(job.ID, event.Job.ID)
 		require.Equal(JobStateCompleted, event.Job.State)
 
-		reloadedJob, err := queries.JobGetByID(ctx, client.driver.GetDBPool(), job.ID)
+		reloadedJob, err := client.JobGet(ctx, job.ID)
 		require.NoError(err)
 
-		require.Equal(dbsqlc.JobStateCompleted, reloadedJob.State)
+		require.Equal(rivertype.JobStateCompleted, reloadedJob.State)
 		require.WithinDuration(time.Now(), *reloadedJob.FinalizedAt, 2*time.Second)
 	})
 
@@ -2450,10 +2449,10 @@ func Test_Client_JobCompletion(t *testing.T) {
 		require.Equal(job.ID, event.Job.ID)
 		require.Equal(JobStateCompleted, event.Job.State)
 
-		reloadedJob, err := queries.JobGetByID(ctx, client.driver.GetDBPool(), job.ID)
+		reloadedJob, err := client.JobGet(ctx, job.ID)
 		require.NoError(err)
 
-		require.Equal(dbsqlc.JobStateCompleted, reloadedJob.State)
+		require.Equal(rivertype.JobStateCompleted, reloadedJob.State)
 		require.WithinDuration(now, *reloadedJob.FinalizedAt, time.Microsecond)
 	})
 
@@ -2474,10 +2473,10 @@ func Test_Client_JobCompletion(t *testing.T) {
 		require.Equal(job.ID, event.Job.ID)
 		require.Equal(JobStateRetryable, event.Job.State)
 
-		reloadedJob, err := queries.JobGetByID(ctx, client.driver.GetDBPool(), job.ID)
+		reloadedJob, err := client.JobGet(ctx, job.ID)
 		require.NoError(err)
 
-		require.Equal(dbsqlc.JobStateRetryable, reloadedJob.State)
+		require.Equal(rivertype.JobStateRetryable, reloadedJob.State)
 		require.WithinDuration(time.Now(), reloadedJob.ScheduledAt, 2*time.Second)
 		require.Nil(reloadedJob.FinalizedAt)
 	})
@@ -2499,10 +2498,10 @@ func Test_Client_JobCompletion(t *testing.T) {
 		require.Equal(job.ID, event.Job.ID)
 		require.Equal(JobStateCancelled, event.Job.State)
 
-		reloadedJob, err := queries.JobGetByID(ctx, client.driver.GetDBPool(), job.ID)
+		reloadedJob, err := client.JobGet(ctx, job.ID)
 		require.NoError(err)
 
-		require.Equal(dbsqlc.JobStateCancelled, reloadedJob.State)
+		require.Equal(rivertype.JobStateCancelled, reloadedJob.State)
 		require.NotNil(reloadedJob.FinalizedAt)
 		require.WithinDuration(time.Now(), *reloadedJob.FinalizedAt, 2*time.Second)
 	})
@@ -2536,10 +2535,10 @@ func Test_Client_JobCompletion(t *testing.T) {
 		require.Equal(job.ID, event.Job.ID)
 		require.Equal(JobStateDiscarded, event.Job.State)
 
-		reloadedJob, err := queries.JobGetByID(ctx, client.driver.GetDBPool(), job.ID)
+		reloadedJob, err := client.JobGet(ctx, job.ID)
 		require.NoError(err)
 
-		require.Equal(dbsqlc.JobStateDiscarded, reloadedJob.State)
+		require.Equal(rivertype.JobStateDiscarded, reloadedJob.State)
 		require.NotNil(reloadedJob.FinalizedAt)
 	})
 
@@ -2582,10 +2581,10 @@ func Test_Client_JobCompletion(t *testing.T) {
 		// updated job inside the txn:
 		require.WithinDuration(*updatedJob.FinalizedAt, *event.Job.FinalizedAt, time.Microsecond)
 
-		reloadedJob, err := queries.JobGetByID(ctx, client.driver.GetDBPool(), job.ID)
+		reloadedJob, err := client.JobGet(ctx, job.ID)
 		require.NoError(err)
 
-		require.Equal(dbsqlc.JobStateCompleted, reloadedJob.State)
+		require.Equal(rivertype.JobStateCompleted, reloadedJob.State)
 		require.Equal(updatedJob.FinalizedAt, reloadedJob.FinalizedAt)
 	})
 }

--- a/internal/dbadapter/db_adapter_test.go
+++ b/internal/dbadapter/db_adapter_test.go
@@ -198,7 +198,7 @@ func Test_StandardAdapter_JobGet(t *testing.T) {
 		adapter, _ := setupTx(t)
 
 		job, err := adapter.JobGet(ctx, 99999)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.ErrorIs(t, err, riverdriver.ErrNoRows)
 		require.Nil(t, job)
 	})

--- a/internal/dbadaptertest/test_adapter.go
+++ b/internal/dbadaptertest/test_adapter.go
@@ -130,6 +130,7 @@ func (ta *TestAdapter) JobGetTx(ctx context.Context, tx pgx.Tx, id int64) (*dbsq
 
 	return ta.fallthroughAdapter.JobGet(ctx, id)
 }
+
 func (ta *TestAdapter) JobGetAvailable(ctx context.Context, queueName string, limit int32) ([]*dbsqlc.RiverJob, error) {
 	ta.atomicSetBoolTrue(&ta.JobGetAvailableCalled)
 


### PR DESCRIPTION
This adds some basic APIs for fetching a single job from the database. I updated all the tests in `client_test.go` to use it, except for some lower level ones that were using dbsqlc types and didn't seem worth converting.