### PR TITLE
Bump major versions of GitHub Actions to suppress warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -102,13 +102,13 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "stable"
           check-latest: true
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build CLI
         run: go build .
@@ -147,13 +147,13 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "stable"
           check-latest: true
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3
@@ -203,10 +203,10 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "stable"
           check-latest: true
@@ -244,7 +244,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup sqlc
         uses: sqlc-dev/setup-sqlc@v4


### PR DESCRIPTION
Here, bump `checkout` to `v4` and `setup-go` to `v5`. Not much changes
on these new versions, but the nice part is that they new ones don't use
Node.js 16, which means that we don't have so many warnings show up on a
normal run (e.g. [1]).

[1] https://github.com/riverqueue/river/actions/runs/7750996180