### PR TITLE
add JobRetry to Client to enable immediate retry of a job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `JobGet` and `JobGetTx` to the `Client` to enable easily fetching a single job row from code for introspection. [PR #186].
+- Added `JobRetry` and `JobRetryTx` to the `Client` to enable a job to be retried immediately, even if it has already completed, been cancelled, or been discarded. [PR #190].
 
 ### Changed
 


### PR DESCRIPTION
JobRetry and JobRetryTx will immediately make a job available to be retried again, regardless of the job's current state. The exception is for `running` jobs which will not be altered. All other jobs will be marked as `available` and with a `scheduled_at` no later than `now()` (jobs with a past `scheduled_at` will keep it to hold their place in the queue).

The job's max attempts field is incremented if necessary.