### PR TITLE
Test against Go 1.22 + 1.21, specify minimum version 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         postgres-version: [16, 15, 14]
         go-version:
+          - "1.22"
           - "1.21"
       fail-fast: false
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        postgres-version: [16, 15, 14]
         go-version:
           - "1.22"
           - "1.21"
+        postgres-version: [16, 15, 14]
       fail-fast: false
     timeout-minutes: 5
 

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -2,6 +2,8 @@ module github.com/riverqueue/river/cmd/river
 
 go 1.21.4
 
+toolchain go1.21.6
+
 // replace github.com/riverqueue/river => ../..
 
 // replace github.com/riverqueue/river/riverdriver => ../../riverdriver

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -2,8 +2,6 @@ module github.com/riverqueue/river/cmd/river
 
 go 1.21.4
 
-toolchain go1.21.6
-
 // replace github.com/riverqueue/river => ../..
 
 // replace github.com/riverqueue/river/riverdriver => ../../riverdriver

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/riverqueue/river
 
-go 1.21.4
+go 1.21
 
 replace github.com/riverqueue/river/riverdriver => ./riverdriver
 

--- a/internal/cmd/update-submodule-versions/main_test.go
+++ b/internal/cmd/update-submodule-versions/main_test.go
@@ -12,7 +12,7 @@ import (
 
 const sampleGoMod = `module github.com/riverqueue/river
 
-go 1.21.4
+go 1.21.0
 
 replace github.com/riverqueue/river/riverdriver => ./riverdriver
 

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -1,6 +1,6 @@
 module github.com/riverqueue/river/riverdriver
 
-go 1.21.4
+go 1.21
 
 require github.com/jackc/pgx/v5 v5.5.0
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -1,6 +1,6 @@
 module github.com/riverqueue/river/riverdriver/riverdatabasesql
 
-go 1.21.4
+go 1.21
 
 replace github.com/riverqueue/river/riverdriver => ../
 
@@ -16,8 +16,9 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.12 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	golang.org/x/crypto v0.15.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/riverdriver/riverdatabasesql/go.sum
+++ b/riverdriver/riverdatabasesql/go.sum
@@ -1,3 +1,4 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -17,8 +18,6 @@ github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.12 h1:mcDBnqwzEXY9WDOwbkd8xmFdSr/H6oHb1F3NCNCmLDY=
-github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.12/go.mod h1:k6hsPkW9Fl3qURzyLHbvxUCqWDpit0WrZ3oEaKezD3E=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -1,6 +1,6 @@
 module github.com/riverqueue/river/riverdriver/riverpgxv5
 
-go 1.21.4
+go 1.21
 
 replace github.com/riverqueue/river/riverdriver => ../
 


### PR DESCRIPTION
Go 1.22 [has now been released](https://go.dev/doc/go1.22), so we can begin our intended "2 latest major go versions" support policy inline with Go's own policy. We don't foresee any reason for River itself to require anything from Go 1.22 anyway (although the opt-in for loop semantics are going to be ✨).

This PR begins running CI against both 1.22 and 1.21. It also alters the Go version specifier in all our `go.mod` files from `1.21.4` to `1.21.0`, because we don't have any reason to require a specific patch release.