### PR TITLE
Remove pg 15 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         go-version:
           - "1.22"
           - "1.21"
-        postgres-version: [16, 15, 14]
+        postgres-version: [16, 14]
       fail-fast: false
     timeout-minutes: 5
 
@@ -206,7 +206,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: "stable"


### PR DESCRIPTION
Shoot, forgot I had automerge on in #192. This alters the CI matrix to only test the latest Postgres and the one from 2 versions ago, which I feel like gives us sufficient coverage on the "does it still work with 3 major PG versions" question.

Feel free to merge if it looks good.