### PR TITLE
Tee up version `v0.0.19`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.19] - 2024-02-10
+
 ### Added
 
 - Added `JobGet` and `JobGetTx` to the `Client` to enable easily fetching a single job row from code for introspection. [PR #186].

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.18
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.18
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.18
+	github.com/riverqueue/river/riverdriver v0.0.19
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.19
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.19
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,7 +7,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.18
+	github.com/riverqueue/river/riverdriver v0.0.19
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -6,7 +6,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.18
+	github.com/riverqueue/river/riverdriver v0.0.19
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
It's been two weeks since our last release and we have a couple nice
features in `master` like a job retrieval API (#186) and a job retry API
(#190). Let's keep the releases rolling. Here, prep `v0.0.19`.