### PR TITLE
Fix leadership reelection query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a leadership re-election query bug that would cause past leaders to think they were continuing to win elections. [PR #199].
+
 ## [0.0.19] - 2024-02-10
 
 ### Added

--- a/internal/dbadapter/db_adapter_test.go
+++ b/internal/dbadapter/db_adapter_test.go
@@ -1289,6 +1289,21 @@ func Test_StandardAdapter_JobSetStateErrored(t *testing.T) {
 	})
 }
 
+func getLeadershipExpiresAt(ctx context.Context, t *testing.T, tx pgx.Tx) time.Time {
+	t.Helper()
+	var expiresAt time.Time
+	err := tx.QueryRow(ctx, "SELECT expires_at FROM river_leader WHERE name = $1", rivercommon.QueueDefault).Scan(&expiresAt)
+	require.NoError(t, err)
+	return expiresAt
+}
+
+func electLeader(ctx context.Context, t *testing.T, adapter *StandardAdapter, name string, ttl time.Duration) {
+	t.Helper()
+	won, err := adapter.LeadershipAttemptElect(ctx, false, rivercommon.QueueDefault, name, ttl)
+	require.NoError(t, err)
+	require.True(t, won)
+}
+
 func Test_StandardAdapter_LeadershipAttemptElect_CannotElectTwiceInARow(t *testing.T) {
 	t.Parallel()
 
@@ -1299,13 +1314,77 @@ func Test_StandardAdapter_LeadershipAttemptElect_CannotElectTwiceInARow(t *testi
 	defer cancel()
 
 	adapter := NewStandardAdapter(riverinternaltest.BaseServiceArchetype(t), testAdapterConfig(tx))
-	won, err := adapter.LeadershipAttemptElect(ctx, false, rivercommon.QueueDefault, "fakeWorker0", 30*time.Second)
-	require.NoError(t, err)
-	require.True(t, won)
+	electLeader(ctx, t, adapter, "fakeWorker0", 10*time.Second)
 
-	won, err = adapter.LeadershipAttemptElect(ctx, false, rivercommon.QueueDefault, "fakeWorker0", 30*time.Second)
+	expiresAt := getLeadershipExpiresAt(ctx, t, tx)
+	require.NotZero(t, expiresAt)
+
+	won, err := adapter.LeadershipAttemptElect(ctx, false, rivercommon.QueueDefault, "fakeWorker1", 30*time.Second)
 	require.NoError(t, err)
 	require.False(t, won)
+
+	// The time should not have changed because we specified that we were not
+	// already elected, and the elect query is a no-op if there's already a
+	// leader:
+	expiresAtAfter := getLeadershipExpiresAt(ctx, t, tx)
+	require.Equal(t, expiresAt, expiresAtAfter)
+}
+
+func Test_StandardAdapter_LeadershipAttemptElect_SuccessfullyReElectsSameLeader(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tx := riverinternaltest.TestTx(ctx, t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	adapter := NewStandardAdapter(riverinternaltest.BaseServiceArchetype(t), testAdapterConfig(tx))
+	electLeader(ctx, t, adapter, "fakeWorker0", 10*time.Second)
+
+	expiresAt := getLeadershipExpiresAt(ctx, t, tx)
+	require.NotZero(t, expiresAt)
+
+	// Re-elect the same leader. Use a larger TTL to see if time is updated,
+	// because we are in a test transaction and the time is frozen at the start of
+	// the transaction.
+	won, err := adapter.LeadershipAttemptElect(ctx, true, rivercommon.QueueDefault, "fakeWorker0", 30*time.Second)
+	require.NoError(t, err)
+	require.True(t, won) // won re-election
+
+	// expires_at should be incremented because this is the same leader that won
+	// previously and we specified that we're already elected:
+	expiresAtAfter := getLeadershipExpiresAt(ctx, t, tx)
+	require.Greater(t, expiresAtAfter, expiresAt)
+}
+
+func Test_StandardAdapter_LeadershipAttemptReelect_CannotReElectNonLeader(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tx := riverinternaltest.TestTx(ctx, t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	adapter := NewStandardAdapter(riverinternaltest.BaseServiceArchetype(t), testAdapterConfig(tx))
+	electLeader(ctx, t, adapter, "fakeWorker0", 10*time.Second)
+
+	// read the expiration time from the database to make sure it's set to the
+	// future and won't be changed by the next LeadershipAttemptElect:
+	expiresAt := getLeadershipExpiresAt(ctx, t, tx)
+	require.NotZero(t, expiresAt)
+
+	// Attempt to re-elect a *different* leader. Use a larger TTL to see if time
+	// is updated, because we are in a test transaction and the time is frozen at
+	// the start of the transaction.
+	won, err := adapter.LeadershipAttemptElect(ctx, true, rivercommon.QueueDefault, "fakeWorker1", 30*time.Second)
+	require.NoError(t, err)
+	require.False(t, won)
+
+	// The time should not be altered because this was a different leader:
+	expiresAtAfter := getLeadershipExpiresAt(ctx, t, tx)
+	require.Equal(t, expiresAt, expiresAtAfter)
 }
 
 func Benchmark_StandardAdapter_Insert(b *testing.B) {

--- a/internal/dbadapter/db_adapter_test.go
+++ b/internal/dbadapter/db_adapter_test.go
@@ -566,10 +566,17 @@ func Test_StandardAdapter_JobInsert(t *testing.T) {
 			dbsqlc.JobStateRetryable,
 			dbsqlc.JobStateScheduled,
 		} {
+			var finalizedAt *time.Time
+			if defaultState == dbsqlc.JobStateCompleted {
+				finalizedAt = ptrutil.Ptr(bundle.baselineTime)
+			}
+
 			_, err = adapter.queries.JobUpdate(ctx, bundle.ex, dbsqlc.JobUpdateParams{
-				ID:            res0.Job.ID,
-				StateDoUpdate: true,
-				State:         defaultState,
+				ID:                  res0.Job.ID,
+				FinalizedAt:         finalizedAt,
+				FinalizedAtDoUpdate: true,
+				StateDoUpdate:       true,
+				State:               defaultState,
 			})
 			require.NoError(t, err)
 
@@ -581,9 +588,11 @@ func Test_StandardAdapter_JobInsert(t *testing.T) {
 		}
 
 		_, err = adapter.queries.JobUpdate(ctx, bundle.ex, dbsqlc.JobUpdateParams{
-			ID:            res0.Job.ID,
-			StateDoUpdate: true,
-			State:         dbsqlc.JobStateDiscarded,
+			ID:                  res0.Job.ID,
+			FinalizedAt:         ptrutil.Ptr(bundle.baselineTime),
+			FinalizedAtDoUpdate: true,
+			StateDoUpdate:       true,
+			State:               dbsqlc.JobStateDiscarded,
 		})
 		require.NoError(t, err)
 

--- a/internal/dbsqlc/river_leader.sql
+++ b/internal/dbsqlc/river_leader.sql
@@ -20,7 +20,7 @@ ON CONFLICT (name)
   DO UPDATE SET
     expires_at = now() + @ttl::interval
   WHERE
-    EXCLUDED.leader_id = @leader_id::text;
+    river_leader.leader_id = @leader_id::text;
 
 -- name: LeadershipDeleteExpired :exec
 DELETE FROM river_leader

--- a/internal/dbsqlc/river_leader.sql.go
+++ b/internal/dbsqlc/river_leader.sql.go
@@ -39,7 +39,7 @@ ON CONFLICT (name)
   DO UPDATE SET
     expires_at = now() + $3::interval
   WHERE
-    EXCLUDED.leader_id = $2::text
+    river_leader.leader_id = $2::text
 `
 
 type LeadershipAttemptReelectParams struct {


### PR DESCRIPTION
This adds thorough test cases around leadership election queries, including one which demonstrates the issue reported in #197. Not only does this bug mean that the timestamp would be updated even when a non-leader attempts to re-elect itself, but also that non leader would have been tricked into thinking it was still the leader (due to the rows altered count being >0).

`EXCLUDED` refers specifically to the params we _attempted_ to insert before hitting a conflict, so this condition was always evaluating to true.

Fixes #197. Thank you @joshchoo 🙏🏻