### PR TITLE
Prepare for release v0.0.20 + update release notes for GitHub releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.20] - 2024-02-14
+
 ### Fixed
 
-- Fix a leadership re-election query bug that would cause past leaders to think they were continuing to win elections. [PR #199].
+- Fix a leadership re-election query bug that would cause past leaders to think they were continuing to win elections. [PR #199](https://github.com/riverqueue/river/pull/199).
 
 ## [0.0.19] - 2024-02-10
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -49,6 +49,8 @@ git tag $VERSION
 git push --tags
 ```
 
+4. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/river/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.
+
 ### Releasing River CLI
 
 The CLI (`./cmd/river`) is different than other River submodules in that it doesn't use any `replace` directives so that it can stay installable with `go install ...@latest`.

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.19
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.19
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.19
+	github.com/riverqueue/river/riverdriver v0.0.20
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.20
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.20
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,7 +7,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.19
+	github.com/riverqueue/river/riverdriver v0.0.20
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -6,7 +6,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.19
+	github.com/riverqueue/river/riverdriver v0.0.20
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Update `go.mod`s and the changelog for version v0.0.20, containing an
election fix #199.

I also updated the release notes indicating to cut a new GitHub release
as requested in #200.