### PR TITLE
expose client ID in config and on client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.20] - 2024-02-14
 
+### Added
+
+- Added an `ID` setting to the `Client` `Config` type to allow users to override client IDs with their own naming convention. Expose the client ID programatically (in case it's generated) in a new `Client.ID()` method. [PR #206](https://github.com/riverqueue/river/pull/206).
+
 ### Fixed
 
 - Fix a leadership re-election query bug that would cause past leaders to think they were continuing to win elections. [PR #199](https://github.com/riverqueue/river/pull/199).

--- a/client.go
+++ b/client.go
@@ -101,13 +101,20 @@ type Config struct {
 	// Defaults to 1 second.
 	FetchPollInterval time.Duration
 
-	// ID is the unique identifier for this client. If not set, a random ULID will
-	// be generated.
+	// ID is the unique identifier for this client. If not set, a random
+	// identifier will be generated.
 	//
 	// This is used to identify the client in job attempts and for leader election.
 	// This value must be unique across all clients in the same database and
 	// schema and there must not be more than one process running with the same
 	// ID at the same time.
+	//
+	// A client ID should differ between different programs and must be unique
+	// across all clients in the same database and schema. There must not be more
+	// than one process running with the same ID at the same time.  However, the
+	// client ID is shared by all executors within any given client. (i.e.
+	// different Go processes have different IDs, but IDs are shared within any
+	// given process.)
 	ID string
 
 	// JobTimeout is the maximum amount of time a job is allowed to run before its

--- a/rivertype/job_row.go
+++ b/rivertype/job_row.go
@@ -25,11 +25,7 @@ type JobRow struct {
 	// on a new insert.
 	AttemptedAt *time.Time
 
-	// AttemptedBy is the set of worker IDs that have worked this job. A worker
-	// ID differs between different programs, but is shared by all executors
-	// within any given one. (i.e. Different Go processes have different IDs,
-	// but IDs are shared within any given process.) A process generates a new
-	// ULID (an ordered UUID) worker ID when it starts up.
+	// AttemptedBy is the set of client IDs that have worked this job.
 	AttemptedBy []string
 
 	// CreatedAt is when the job record was created.


### PR DESCRIPTION
Inspired by #203, I wanted to make the client IDs configurable by the user and also programmatically accessible (in the event a user decides to rely on auto-generated client IDs). This PR achieves both.