### PR TITLE
tweak JobRetry to reset ScheduledAt in most cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tweaked behavior of `JobRetry` so that it does actually update the `ScheduledAt` time of the job in all cases where the job is actually being rescheduled. As before, jobs which are already available with a past `ScheduledAt` will not be touched by this query so that they retain their place in line. [PR #211](https://github.com/riverqueue/river/pull/211).
+
 ## [0.0.20] - 2024-02-14
 
 ### Added

--- a/internal/dbsqlc/river_job.sql
+++ b/internal/dbsqlc/river_job.sql
@@ -260,7 +260,7 @@ updated_job AS (
   UPDATE river_job
   SET
     state = 'available'::river_job_state,
-    scheduled_at = CASE WHEN scheduled_at < now() THEN scheduled_at ELSE now() END,
+    scheduled_at = now(),
     max_attempts = CASE WHEN attempt = max_attempts THEN max_attempts + 1 ELSE max_attempts END,
     finalized_at = NULL
   FROM job_to_update

--- a/internal/dbsqlc/river_job.sql.go
+++ b/internal/dbsqlc/river_job.sql.go
@@ -656,7 +656,7 @@ updated_job AS (
   UPDATE river_job
   SET
     state = 'available'::river_job_state,
-    scheduled_at = CASE WHEN scheduled_at < now() THEN scheduled_at ELSE now() END,
+    scheduled_at = now(),
     max_attempts = CASE WHEN attempt = max_attempts THEN max_attempts + 1 ELSE max_attempts END,
     finalized_at = NULL
   FROM job_to_update


### PR DESCRIPTION
This is a small change in behavior on #190.

A job which has already completed will have a `ScheduledAt` that could be long in the past. Now that we're re-scheduling it, we should update that to the current time to slot it in alongside other recently-scheduled jobs and not skip the line. Also, its wait duration can't be calculated accurately if we don't reset the `ScheduledAt` (it could show days of wait time even if it was picked up immediately after being retried).

The only time we will continue to avoid touching `ScheduledAt` here is for an already-available job with a `ScheduledAt` in the past.