### PR TITLE
Minor logging improvements; hopefully to help route out intermittent test

### DIFF
--- a/client.go
+++ b/client.go
@@ -903,7 +903,8 @@ func (c *Client[TTx]) logStatsLoop(ctx context.Context) {
 }
 
 func (c *Client[TTx]) handleLeadershipChange(ctx context.Context, notification *leadership.Notification) {
-	c.baseService.Logger.InfoContext(ctx, "Election change received", slog.Bool("is_leader", notification.IsLeader))
+	c.baseService.Logger.InfoContext(ctx, c.baseService.Name+": Election change received",
+		slog.String("client_id", c.config.ID), slog.Bool("is_leader", notification.IsLeader))
 
 	leaderStatus := componentstatus.ElectorNonLeader
 	if notification.IsLeader {

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -96,6 +96,7 @@ func (n *Notifier) Run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			wg.Wait()
+			n.logger.Info(n.Name + ": Notifier stopped")
 			n.statusChangeFunc(componentstatus.Stopped)
 			return
 		default:
@@ -161,6 +162,7 @@ func (n *Notifier) getConnAndRun(ctx context.Context) {
 		}
 	}
 
+	n.logger.Info(n.Name + ": Notifier started")
 	n.statusChangeFunc(componentstatus.Healthy)
 	for {
 		// If context is already done, don't bother waiting for notifications:


### PR DESCRIPTION
Some very, very small logging improvements that log when the notifier
had started and stopped, like we already have for many other services.
This is an attempt to help diagnose a future CI failure of #213, since
I'm completely unable to reproduce this locally regardless of iteration
count.

Also, augment a log line in the client so it's prefixed with its service
name and contains a `client_id`, which is useful here because it helps
indicate which client ID was elected leader from logs alone.