### PR TITLE
fix leadership election TTL issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tweaked behavior of `JobRetry` so that it does actually update the `ScheduledAt` time of the job in all cases where the job is actually being rescheduled. As before, jobs which are already available with a past `ScheduledAt` will not be touched by this query so that they retain their place in line. [PR #211](https://github.com/riverqueue/river/pull/211).
 
+### Fixed
+
+- Fixed a leadership re-election issue that was exposed by the fix in #199. Because we were internally using the same TTL for both an internal timer/ticker and the database update to set the new leader expiration time, a leader wasn't guaranteed to successfully re-elect itself even under normal operation. [PR #217](https://github.com/riverqueue/river/pull/217).
+
 ## [0.0.20] - 2024-02-14
 
 ### Added

--- a/client.go
+++ b/client.go
@@ -476,7 +476,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 
 		client.notifier = notifier.New(archetype, driver.GetDBPool().Config().ConnConfig, client.monitor.SetNotifierStatus, logger)
 		var err error
-		client.elector, err = leadership.NewElector(client.adapter, client.notifier, instanceName, client.ID(), 5*time.Second, logger)
+		client.elector, err = leadership.NewElector(client.adapter, client.notifier, instanceName, client.ID(), 5*time.Second, 10*time.Second, logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Due to a glaring oversight in the leader elector code, it actually uses the same interval for both the internal ticker (for re-electing itself) and for extending the TTL in the database. These timers and queries are of course not instantaneous, which means a perfectly functional leader can fail to re-elect itself cleanly.

Extensive test coverage on the elector to come in subsequent PRs.

Fixes #216.