### PR TITLE
Prepare `v0.0.21` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.21] - 2024-02-19
+
 ### Changed
 
 - Tweaked behavior of `JobRetry` so that it does actually update the `ScheduledAt` time of the job in all cases where the job is actually being rescheduled. As before, jobs which are already available with a past `ScheduledAt` will not be touched by this query so that they retain their place in line. [PR #211](https://github.com/riverqueue/river/pull/211).

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.20
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.20
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.20
+	github.com/riverqueue/river/riverdriver v0.0.21
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.21
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.21
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,7 +7,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.20
+	github.com/riverqueue/river/riverdriver v0.0.21
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -6,7 +6,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.20
+	github.com/riverqueue/river/riverdriver v0.0.21
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Prepare a new release for `v0.0.21`, with the most important change
contained being #217, which fixes a bug in the leadership election code.

I know I said I'd switch to minor version releases after `v0.0.20`, but
since this version is largely a hotfix with a small change, I did
another patch.