### PR TITLE
Elector: Add TTL padding on initial election as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.21] - 2024-02-19
 
+### Fixed
+
+- Brings in another leadership election fix similar to #217 in which a TTL equal to the elector's run interval plus a configured TTL padding is also used for the initial attempt to gain leadership (#217 brought it in for reelection only). [PR #219](https://github.com/riverqueue/river/pull/219).
+
 ### Changed
 
 - Tweaked behavior of `JobRetry` so that it does actually update the `ScheduledAt` time of the job in all cases where the job is actually being rescheduled. As before, jobs which are already available with a past `ScheduledAt` will not be touched by this query so that they retain their place in line. [PR #211](https://github.com/riverqueue/river/pull/211).


### PR DESCRIPTION
Follows up #217 to add TTL padding on the elector's initial election
attempt in addition to adding it to reelection attempts as was done
previously. We move the TTL calculation to a struct variable for easier
and more foolproof access, and to be able put a comment on it.