### PR TITLE
Prepare `v0.0.22` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.21] - 2024-02-19
+## [0.0.22] - 2024-02-19
 
 ### Fixed
 
 - Brings in another leadership election fix similar to #217 in which a TTL equal to the elector's run interval plus a configured TTL padding is also used for the initial attempt to gain leadership (#217 brought it in for reelection only). [PR #219](https://github.com/riverqueue/river/pull/219).
+
+## [0.0.21] - 2024-02-19
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.21
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.21
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.21
+	github.com/riverqueue/river/riverdriver v0.0.22
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.22
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.22
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,7 +7,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.21
+	github.com/riverqueue/river/riverdriver v0.0.22
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -6,7 +6,7 @@ replace github.com/riverqueue/river/riverdriver => ../
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.21
+	github.com/riverqueue/river/riverdriver v0.0.22
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Prepares a new release for `v0.0.22`, which brings in one more
leadership election bug fix from #219.