### PR TITLE
Reuse timer on `DebouncedChan` + put in some comments + continous test

### DIFF
--- a/internal/util/chanutil/debounced_chan.go
+++ b/internal/util/chanutil/debounced_chan.go
@@ -11,45 +11,68 @@ import (
 // subsequent calls are delayed until the cooldown period has elapsed and are
 // also coalesced into a single call.
 type DebouncedChan struct {
-	done     <-chan struct{}
 	c        chan struct{}
 	cooldown time.Duration
+	ctxDone  <-chan struct{}
 
-	mu                   sync.Mutex
-	timer                *time.Timer
-	sendWhenTimerExpired bool
+	// mu protects variables in group below
+	mu                 sync.Mutex
+	sendOnTimerExpired bool
+	timer              *time.Timer
+	timerDone          bool
 }
 
 // NewDebouncedChan returns a new DebouncedChan which sends on the channel no
 // more often than the cooldown period.
 func NewDebouncedChan(ctx context.Context, cooldown time.Duration) *DebouncedChan {
 	return &DebouncedChan{
-		done:     ctx.Done(),
+		ctxDone:  ctx.Done(),
 		c:        make(chan struct{}, 1),
 		cooldown: cooldown,
 	}
 }
 
+// C is the debounced channel. Multiple invocations to Call during the cooldown
+// period will deduplicate to a single emission on this channel on the period's
+// leading edge, and one more on the trailing edge.
 func (d *DebouncedChan) C() <-chan struct{} {
 	return d.c
 }
 
+// Call invokes the debounced channel, and is the call which will be debounced.
+// If multiple invocations of this function are made during the cooldown period,
+// they'll be debounced to a single emission on C on the period's leading edge,
+// and one more on the trailing edge.
 func (d *DebouncedChan) Call() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.timer != nil {
-		d.sendWhenTimerExpired = true
+
+	// A timer has already been initialized and hasn't already expired. (If it
+	// has expired, we'll reset it below.) Set to signal when it does expire.
+	if d.timer != nil && !d.timerDone {
+		d.sendOnTimerExpired = true
 		return
 	}
 
-	// TODO: The design of this can probably be simplified to not rely on creating
-	// a new timer every time.
-	d.timer = time.NewTimer(d.cooldown)
+	// No timer had been started yet, or the last one running was expired and
+	// will be reset. Send immediately. (i.e. On the leading edge of the
+	// debounce period.)
+	d.nonBlockingSendOnC()
+
+	// Next, start the timer, during which we'll monitor for additional calls,
+	// and send at the end of the period if any came in. Create a new timer if
+	// this is the first run. Otherwise, reset an existing one.
+	if d.timer == nil {
+		d.timer = time.NewTimer(d.cooldown)
+	} else {
+		d.timer.Reset(d.cooldown)
+	}
+	d.timerDone = false
+
 	go d.waitForTimer()
-	d.sendOnChan()
 }
 
-func (d *DebouncedChan) sendOnChan() {
+func (d *DebouncedChan) nonBlockingSendOnC() {
 	select {
 	case d.c <- struct{}{}:
 	default:
@@ -58,21 +81,23 @@ func (d *DebouncedChan) sendOnChan() {
 
 func (d *DebouncedChan) waitForTimer() {
 	select {
-	case <-d.done:
+	case <-d.ctxDone:
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		if d.timer != nil {
 			if !d.timer.Stop() {
 				<-d.timer.C
 			}
+			d.timerDone = true
 		}
+
 	case <-d.timer.C:
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		if d.sendWhenTimerExpired {
-			d.sendOnChan()
+		if d.sendOnTimerExpired {
+			d.nonBlockingSendOnC()
 		}
-		d.timer = nil
-		d.sendWhenTimerExpired = false
+		d.timerDone = true
+		d.sendOnTimerExpired = false
 	}
 }

--- a/internal/util/chanutil/debounced_chan_test.go
+++ b/internal/util/chanutil/debounced_chan_test.go
@@ -2,9 +2,12 @@ package chanutil
 
 import (
 	"context"
+	"math"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDebouncedChan_TriggersImmediately(t *testing.T) {
@@ -76,4 +79,64 @@ func TestDebouncedChan_OnlyBuffersOneEvent(t *testing.T) {
 		t.Fatal("received from debounced chan unexpectedly")
 	case <-time.After(20 * time.Millisecond):
 	}
+}
+
+func TestDebouncedChan_ContinuousOperation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	const (
+		cooldown  = 17 * time.Millisecond
+		increment = 1 * time.Millisecond
+		testTime  = 150 * time.Millisecond
+	)
+
+	var (
+		debouncedChan = NewDebouncedChan(ctx, cooldown)
+		goroutineDone = make(chan struct{})
+		numSignals    int
+	)
+
+	go func() {
+		defer close(goroutineDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-debouncedChan.C():
+				numSignals++
+			}
+		}
+	}()
+
+	for tm := increment; tm <= testTime; tm += increment {
+		time.Sleep(increment)
+		debouncedChan.Call()
+	}
+
+	cancel()
+
+	select {
+	case <-goroutineDone:
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "Timed out waiting for goroutine to finish")
+	}
+
+	// Expect number of signals equal to number of cooldown periods that fit
+	// into our total test time, multiplied by two, because the debounced chan
+	// fires at the beginning and end of a bounce period. +1 for the last period
+	// that fires on the leading edge, but which we don't give time for the
+	// timer to fully expire. (We've chosen numbers so that test time doesn't
+	// divide by cooldown perfectly.)
+	//
+	// This usually lands right on the expected number, but allow a delta of
+	// +/-4 to allow the channel to be off by two cycles (again, one cycle
+	// signals once at leading edge of the period and once at trailing, so 2
+	// cycles * 2 signals = 4) in either direction. By running at `-count 1000`
+	// or so I can usually reproduce an off-by-one-or-two cycle.
+	expectedNumSignal := int(math.Round(float64(testTime)/float64(cooldown)))*2 + 1
+	t.Logf("Expected: %d, actual: %d", expectedNumSignal, numSignals)
+	require.InDelta(t, expectedNumSignal, numSignals, 4)
 }

--- a/internal/util/chanutil/main_test.go
+++ b/internal/util/chanutil/main_test.go
@@ -1,0 +1,11 @@
+package chanutil
+
+import (
+	"testing"
+
+	"github.com/riverqueue/river/internal/riverinternaltest"
+)
+
+func TestMain(m *testing.M) {
+	riverinternaltest.WrapTestMain(m)
+}


### PR DESCRIPTION
I wanted to understand a little more clearly how `DebouncedChan` works,
so I went in to look for a few refactoring opportunities. There was a
TODO in the file to potentially reuse the internal timer so it doesn't
need to be reallocated every debounce cycle, so here we implement that.

To make sure that the reused timer is really working we also add a new
"continuous" test that checks that the channel will in fact fire many
times in a row. We also go through and add a few comments and rename a
couple things for clarity, and bring in a `TestMain` wrapper so that the
package tests are checked for goroutine leaks.