### PR TITLE
Upgrade golangci-lint GitHub Action go `v5` and linter to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.55.2
+      GOLANGCI_LINT_VERSION: v1.56
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.
@@ -157,31 +157,31 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: .
 
       - name: Lint cmd/river
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./cmd/river
 
       - name: Lint riverdriver
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./riverdriver
 
       - name: Lint riverdriver/riverdatabasesql
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./riverdriver/riverdatabasesql
 
       - name: Lint riverdriver/riverpgxv5
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: ./riverdriver/riverpgxv5

--- a/internal/rivercommon/test_signal_test.go
+++ b/internal/rivercommon/test_signal_test.go
@@ -44,7 +44,7 @@ func TestTestSignal(t *testing.T) {
 }
 
 // Marked as non-parallel because `t.Setenv` is not compatible with `t.Parallel`.
-func TestWaitTimeout(t *testing.T) { //nolint:paralleltest
+func TestWaitTimeout(t *testing.T) {
 	t.Setenv("GITHUB_ACTIONS", "")
 	require.Equal(t, 3*time.Second, WaitTimeout())
 


### PR DESCRIPTION
A small one to upgrade:

* golangci-lint GitHub Action from `v4` to `v5`
* golangci-lint from 1.55 to 1.56

A small change, but I upgraded locally at some point, and it's causing a
build issue in #212. The `tparallel` lint previously had a bug where
it'd want you to put a `t.Parallel()` on test cases that use `t.Setenv()`,
even though use of `t.Parallel()` with `t.Setenv()` is disallowed by Go's
test framework, so you'd have to mark those test cases with `nolint`.

That bug's been fixed now, and now the linter detects that the `nolint`
is no longer necessary, and automatically strips it out with my upgraded
golangci-lint version, causing a failure when I push to CI.

The `v5` GitHub Action is also somewhat nice because it stops using a
deprecated NodeJS version, so produces fewer warnings in the log.