### PR TITLE
better client logs for flaky insert and work test, shorter test connect timeout

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -82,7 +83,7 @@ type callbackFunc func(context.Context, *Job[callbackArgs]) error
 func makeAwaitCallback(startedCh chan<- int64, doneCh chan struct{}) callbackFunc {
 	return func(ctx context.Context, job *Job[callbackArgs]) error {
 		client := ClientFromContext[pgx.Tx](ctx)
-		client.config.Logger.InfoContext(ctx, "callback job started with id="+fmt.Sprint(job.ID))
+		client.config.Logger.InfoContext(ctx, "callback job started with id="+strconv.FormatInt(job.ID, 10))
 
 		select {
 		case <-ctx.Done():

--- a/client_test.go
+++ b/client_test.go
@@ -81,6 +81,9 @@ type callbackFunc func(context.Context, *Job[callbackArgs]) error
 
 func makeAwaitCallback(startedCh chan<- int64, doneCh chan struct{}) callbackFunc {
 	return func(ctx context.Context, job *Job[callbackArgs]) error {
+		client := ClientFromContext[pgx.Tx](ctx)
+		client.config.Logger.InfoContext(ctx, "callback job started with id="+fmt.Sprint(job.ID))
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/client_test.go
+++ b/client_test.go
@@ -40,6 +40,7 @@ func waitForClientHealthy(ctx context.Context, t *testing.T, statusUpdateCh <-ch
 	for {
 		select {
 		case status := <-statusUpdateCh:
+			t.Logf("Client status: elector=%d notifier=%d producers=%+v", status.Elector, status.Notifier, status.Producers)
 			if status.Healthy() {
 				return
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -2412,10 +2412,11 @@ func Test_Client_InsertTriggersImmediateWork(t *testing.T) {
 	client := newTestClient(t, dbPool, config)
 	statusUpdateCh := client.monitor.RegisterUpdates()
 
+	startClient(ctx, t, client)
+	waitForClientHealthy(ctx, t, statusUpdateCh)
+
 	insertedJob, err := client.Insert(ctx, callbackArgs{}, nil)
 	require.NoError(err)
-
-	startClient(ctx, t, client)
 
 	// Wait for the client to be ready by waiting for a job to be executed:
 	select {
@@ -2424,7 +2425,6 @@ func Test_Client_InsertTriggersImmediateWork(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for warmup job to start")
 	}
-	waitForClientHealthy(ctx, t, statusUpdateCh)
 
 	// Now that we've run one job, we shouldn't take longer than the cooldown to
 	// fetch another after insertion. LISTEN/NOTIFY should ensure we find out

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -69,7 +69,9 @@ func DatabaseConfig(databaseName string) *pgxpool.Config {
 		panic(fmt.Sprintf("error parsing database URL: %v", err))
 	}
 	config.MaxConns = dbPoolMaxConns
-	config.ConnConfig.ConnectTimeout = 10 * time.Second
+	// Use a short conn timeout here to attempt to quickly cancel attempts that
+	// are unlikely to succeed even with more time:
+	config.ConnConfig.ConnectTimeout = 2 * time.Second
 	config.ConnConfig.RuntimeParams["timezone"] = "UTC"
 	return config
 }


### PR DESCRIPTION
This contains a few small fixes and logging improvements encountered while debugging flaky tests from #213. The main one that actually fixes one of the flaky scenarios is included in the final commit: shortening `ConnectTimeout` from 10s to 2s in tests. By failing faster than our typical test timeout, the occasional flaky conn attempt that hangs will no longer make the test immediately fail. In my testing this completely eliminated this one flaky test cause (of several).