### PR TITLE
Improve ListJob flexibility - Allow for querying based on a list of states and kinds

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1407,12 +1407,12 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateAvailable})
 		job3 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateRunning})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State(JobStateAvailable))
+		jobs, err := client.JobList(ctx, NewJobListParams().States(JobStateAvailable))
 		require.NoError(t, err)
 		// jobs ordered by ScheduledAt ASC by default
 		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(JobStateRunning))
+		jobs, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job3.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
@@ -1433,11 +1433,11 @@ func Test_Client_JobList(t *testing.T) {
 			job1 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbState, ScheduledAt: ptrutil.Ptr(now)})
 			job2 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbState, ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 
-			jobs, err := client.JobList(ctx, NewJobListParams().State(state))
+			jobs, err := client.JobList(ctx, NewJobListParams().States(state))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-			jobs, err = client.JobList(ctx, NewJobListParams().State(state).OrderBy(JobListOrderByTime, SortOrderDesc))
+			jobs, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 		}
@@ -1459,11 +1459,11 @@ func Test_Client_JobList(t *testing.T) {
 			job1 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbState, FinalizedAt: ptrutil.Ptr(now.Add(-10 * time.Second))})
 			job2 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbState, FinalizedAt: ptrutil.Ptr(now.Add(-15 * time.Second))})
 
-			jobs, err := client.JobList(ctx, NewJobListParams().State(state))
+			jobs, err := client.JobList(ctx, NewJobListParams().States(state))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-			jobs, err = client.JobList(ctx, NewJobListParams().State(state).OrderBy(JobListOrderByTime, SortOrderDesc))
+			jobs, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 		}
@@ -1478,11 +1478,11 @@ func Test_Client_JobList(t *testing.T) {
 		job1 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateRunning, AttemptedAt: ptrutil.Ptr(now)})
 		job2 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{State: dbsqlc.JobStateRunning, AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State(JobStateRunning))
+		jobs, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(JobStateRunning).OrderBy(JobListOrderByTime, SortOrderDesc))
+		jobs, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning).OrderBy(JobListOrderByTime, SortOrderDesc))
 		require.NoError(t, err)
 		// Sort order was explicitly reversed:
 		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
@@ -1524,11 +1524,11 @@ func Test_Client_JobList(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []int64{job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(rivertype.JobStateRunning).After(JobListCursorFromJob(jobRow3)))
+		jobs, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateRunning).After(JobListCursorFromJob(jobRow3)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job4.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(rivertype.JobStateCompleted).After(JobListCursorFromJob(jobRow5)))
+		jobs, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateCompleted).After(JobListCursorFromJob(jobRow5)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job6.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
@@ -1542,11 +1542,11 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{Metadata: []byte(`{"baz": "value"}`)})
 		job3 := insertJob(ctx, client.driver.GetDBPool(), insertJobParams{Metadata: []byte(`{"baz": "value"}`)})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State("").Metadata(`{"foo": "bar"}`))
+		jobs, err := client.JobList(ctx, NewJobListParams().States("").Metadata(`{"foo": "bar"}`))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State("").Metadata(`{"baz": "value"}`).OrderBy(JobListOrderByTime, SortOrderDesc))
+		jobs, err = client.JobList(ctx, NewJobListParams().States("").Metadata(`{"baz": "value"}`).OrderBy(JobListOrderByTime, SortOrderDesc))
 		require.NoError(t, err)
 		// Sort order was explicitly reversed:
 		require.Equal(t, []int64{job3.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
@@ -1560,7 +1560,7 @@ func Test_Client_JobList(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel() // cancel immediately
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State(JobStateRunning))
+		jobs, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.ErrorIs(t, context.Canceled, err)
 		require.Empty(t, jobs)
 	})

--- a/internal/dbadapter/db_adapter.go
+++ b/internal/dbadapter/db_adapter.go
@@ -21,7 +21,6 @@ import (
 	"github.com/riverqueue/river/internal/util/sliceutil"
 	"github.com/riverqueue/river/internal/util/valutil"
 	"github.com/riverqueue/river/riverdriver"
-	"github.com/riverqueue/river/rivertype"
 )
 
 // When a job has specified unique options, but has not set the ByState
@@ -95,7 +94,6 @@ type JobListParams struct {
 	OrderBy    []JobListOrderBy
 	Priorities []int16
 	Queues     []string
-	State      rivertype.JobState
 }
 
 // Adapter is an interface to the various database-level operations which River
@@ -510,7 +508,6 @@ func (a *StandardAdapter) JobListTx(ctx context.Context, tx pgx.Tx, params JobLi
 		NamedArgs:  namedArgs,
 		OrderBy:    orderBy,
 		Priorities: params.Priorities,
-		State:      dbsqlc.JobState(params.State),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/dbadapter/db_adapter_test.go
+++ b/internal/dbadapter/db_adapter_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/riverqueue/river/internal/util/ptrutil"
 	"github.com/riverqueue/river/internal/util/sliceutil"
 	"github.com/riverqueue/river/riverdriver"
-	"github.com/riverqueue/river/rivertype"
 )
 
 func Test_StandardAdapter_JobCancel(t *testing.T) {
@@ -881,7 +880,6 @@ func Test_StandardAdapter_JobList_and_JobListTx(t *testing.T) {
 		params := JobListParams{
 			LimitCount: 2,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderDesc}},
-			State:      rivertype.JobStateAvailable,
 		}
 
 		execTest(ctx, t, adapter, params, bundle.tx, func(jobs []*dbsqlc.RiverJob, err error) {
@@ -907,7 +905,6 @@ func Test_StandardAdapter_JobList_and_JobListTx(t *testing.T) {
 			LimitCount: 2,
 			NamedArgs:  map[string]any{"paths1": []string{"job_num"}, "value1": 2},
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderDesc}},
-			State:      rivertype.JobStateAvailable,
 		}
 
 		execTest(ctx, t, adapter, params, bundle.tx, func(jobs []*dbsqlc.RiverJob, err error) {
@@ -929,7 +926,6 @@ func Test_StandardAdapter_JobList_and_JobListTx(t *testing.T) {
 			LimitCount: 2,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderDesc}},
 			Queues:     []string{"priority"},
-			State:      rivertype.JobStateAvailable,
 		}
 
 		execTest(ctx, t, adapter, params, bundle.tx, func(jobs []*dbsqlc.RiverJob, err error) {

--- a/internal/dblist/job_list.go
+++ b/internal/dblist/job_list.go
@@ -72,7 +72,6 @@ func JobList(ctx context.Context, tx pgx.Tx, arg JobListParams) ([]*dbsqlc.River
 	}
 
 	var conditions []string
-
 	if arg.Conditions != "" {
 		conditions = append(conditions, arg.Conditions)
 	}

--- a/internal/dblist/job_list.go
+++ b/internal/dblist/job_list.go
@@ -36,7 +36,6 @@ type JobListOrderBy struct {
 }
 
 type JobListParams struct {
-	State      dbsqlc.JobState
 	Priorities []int16
 	Conditions string
 	OrderBy    []JobListOrderBy
@@ -73,10 +72,7 @@ func JobList(ctx context.Context, tx pgx.Tx, arg JobListParams) ([]*dbsqlc.River
 	}
 
 	var conditions []string
-	if arg.State != "" {
-		conditions = append(conditions, "state = @state::river_job_state")
-		namedArgs["state"] = arg.State
-	}
+
 	if arg.Conditions != "" {
 		conditions = append(conditions, arg.Conditions)
 	}

--- a/internal/dblist/job_list_test.go
+++ b/internal/dblist/job_list_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
-	"github.com/riverqueue/river/internal/dbsqlc"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 )
 
@@ -21,7 +20,6 @@ func TestJobList(t *testing.T) {
 		tx := riverinternaltest.TestTx(ctx, t)
 
 		_, err := JobList(ctx, tx, JobListParams{
-			State:      dbsqlc.JobStateCompleted,
 			LimitCount: 1,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderAsc}},
 		})
@@ -37,7 +35,6 @@ func TestJobList(t *testing.T) {
 		_, err := JobList(ctx, tx, JobListParams{
 			Conditions: "queue = 'test' AND priority = 1 AND args->>'foo' = @foo",
 			NamedArgs:  pgx.NamedArgs{"foo": "bar"},
-			State:      dbsqlc.JobStateCompleted,
 			LimitCount: 1,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderAsc}},
 		})

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -268,8 +268,8 @@ func (p *JobListParams) OrderBy(field JobListOrderByField, direction SortOrder) 
 // state.
 func (p *JobListParams) States(states ...rivertype.JobState) *JobListParams {
 	result := p.copy()
-	result.states = make([]rivertype.JobState, 0, len(p.states))
-	copy(result.states, p.states)
+	result.states = make([]rivertype.JobState, 0, len(states))
+	copy(result.states, states)
 	return result
 }
 

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -183,7 +183,7 @@ func (p *JobListParams) toDBParams() (*dbadapter.JobListParams, error) {
 		namedArgs["kinds"] = pq.Array(p.kinds)
 	}
 	if len(p.states) > 0 {
-		conditions = append(conditions, "state = ANY(@states)")
+		conditions = append(conditions, `state = ANY(@states)`)
 		namedArgs["states"] = pq.Array(p.states)
 	}
 

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -179,7 +179,7 @@ func (p *JobListParams) toDBParams() (*dbadapter.JobListParams, error) {
 	}
 
 	if len(p.kinds) > 0 {
-		conditions = append(conditions, `"kind = ANY(@kinds)`)
+		conditions = append(conditions, `kind = ANY(@kinds)`)
 		namedArgs["kinds"] = pq.Array(p.kinds)
 	}
 	if len(p.states) > 0 {

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -179,7 +179,7 @@ func (p *JobListParams) toDBParams() (*dbadapter.JobListParams, error) {
 	}
 
 	if len(p.kinds) > 0 {
-		conditions = append(conditions, `"kind" = ANY(@kinds)`)
+		conditions = append(conditions, `"kind = ANY(@kinds)`)
 		namedArgs["kinds"] = pq.Array(p.kinds)
 	}
 	if len(p.states) > 0 {

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -141,8 +141,8 @@ func (p *JobListParams) copy() *JobListParams {
 		queues:           append([]string(nil), p.queues...),
 		sortField:        p.sortField,
 		sortOrder:        p.sortOrder,
-		states:           p.states,
-		kinds:            p.kinds,
+		states:           append([]rivertype.JobState(nil), p.states...),
+		kinds:            append([]string(nil), p.kinds...),
 	}
 }
 

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -250,7 +250,7 @@ func (p *JobListParams) Metadata(json string) *JobListParams {
 // given queues.
 func (p *JobListParams) Queues(queues ...string) *JobListParams {
 	result := p.copy()
-	result.queues = make([]string, 0, len(queues))
+	result.queues = make([]string, len(queues))
 	copy(result.queues, queues)
 	return result
 }
@@ -268,7 +268,7 @@ func (p *JobListParams) OrderBy(field JobListOrderByField, direction SortOrder) 
 // state.
 func (p *JobListParams) States(states ...rivertype.JobState) *JobListParams {
 	result := p.copy()
-	result.states = make([]rivertype.JobState, 0, len(states))
+	result.states = make([]rivertype.JobState, len(states))
 	copy(result.states, states)
 	return result
 }
@@ -277,7 +277,7 @@ func (p *JobListParams) States(states ...rivertype.JobState) *JobListParams {
 // kinds.
 func (p *JobListParams) Kinds(kinds ...string) *JobListParams {
 	result := p.copy()
-	result.kinds = make([]string, 0, len(kinds))
+	result.kinds = make([]string, len(kinds))
 	copy(result.kinds, kinds)
 	return result
 }


### PR DESCRIPTION
This modifies the JobListParams such that the user can pass in any number of job states or job kinds to filter against. Before this, the JobList API only exposed a way to grab jobs with a single type of state at a time, and filtering based on job kind was not possible. 

This also allows the user to specify a specific timestamp field to sort by in case multiple job states are requested.

Happy to update / improve based on your feedback! Happy River user so far.