### PR TITLE
Drop sqlc overrides for `JobState`

### DIFF
--- a/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
@@ -14,13 +14,13 @@ import (
 type JobState string
 
 const (
-	JobStateAvailable JobState = "available"
-	JobStateCancelled JobState = "cancelled"
-	JobStateCompleted JobState = "completed"
-	JobStateDiscarded JobState = "discarded"
-	JobStateRetryable JobState = "retryable"
-	JobStateRunning   JobState = "running"
-	JobStateScheduled JobState = "scheduled"
+	RiverJobStateAvailable JobState = "available"
+	RiverJobStateCancelled JobState = "cancelled"
+	RiverJobStateCompleted JobState = "completed"
+	RiverJobStateDiscarded JobState = "discarded"
+	RiverJobStateRetryable JobState = "retryable"
+	RiverJobStateRunning   JobState = "running"
+	RiverJobStateScheduled JobState = "scheduled"
 )
 
 func (e *JobState) Scan(src interface{}) error {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
@@ -22,13 +22,6 @@ sql:
 
         rename:
           river_job_state: "JobState"
-          river_job_state_available: "JobStateAvailable"
-          river_job_state_cancelled: "JobStateCancelled"
-          river_job_state_completed: "JobStateCompleted"
-          river_job_state_discarded: "JobStateDiscarded"
-          river_job_state_retryable: "JobStateRetryable"
-          river_job_state_running: "JobStateRunning"
-          river_job_state_scheduled: "JobStateScheduled"
           ttl: "TTL"
 
         overrides:

--- a/riverdriver/riverpgxv5/internal/dbsqlc/models.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/models.go
@@ -10,51 +10,51 @@ import (
 	"time"
 )
 
-type JobState string
+type RiverJobState string
 
 const (
-	JobStateAvailable JobState = "available"
-	JobStateCancelled JobState = "cancelled"
-	JobStateCompleted JobState = "completed"
-	JobStateDiscarded JobState = "discarded"
-	JobStateRetryable JobState = "retryable"
-	JobStateRunning   JobState = "running"
-	JobStateScheduled JobState = "scheduled"
+	RiverJobStateAvailable RiverJobState = "available"
+	RiverJobStateCancelled RiverJobState = "cancelled"
+	RiverJobStateCompleted RiverJobState = "completed"
+	RiverJobStateDiscarded RiverJobState = "discarded"
+	RiverJobStateRetryable RiverJobState = "retryable"
+	RiverJobStateRunning   RiverJobState = "running"
+	RiverJobStateScheduled RiverJobState = "scheduled"
 )
 
-func (e *JobState) Scan(src interface{}) error {
+func (e *RiverJobState) Scan(src interface{}) error {
 	switch s := src.(type) {
 	case []byte:
-		*e = JobState(s)
+		*e = RiverJobState(s)
 	case string:
-		*e = JobState(s)
+		*e = RiverJobState(s)
 	default:
-		return fmt.Errorf("unsupported scan type for JobState: %T", src)
+		return fmt.Errorf("unsupported scan type for RiverJobState: %T", src)
 	}
 	return nil
 }
 
-type NullJobState struct {
-	JobState JobState
-	Valid    bool // Valid is true if JobState is not NULL
+type NullRiverJobState struct {
+	RiverJobState RiverJobState
+	Valid         bool // Valid is true if RiverJobState is not NULL
 }
 
 // Scan implements the Scanner interface.
-func (ns *NullJobState) Scan(value interface{}) error {
+func (ns *NullRiverJobState) Scan(value interface{}) error {
 	if value == nil {
-		ns.JobState, ns.Valid = "", false
+		ns.RiverJobState, ns.Valid = "", false
 		return nil
 	}
 	ns.Valid = true
-	return ns.JobState.Scan(value)
+	return ns.RiverJobState.Scan(value)
 }
 
 // Value implements the driver Valuer interface.
-func (ns NullJobState) Value() (driver.Value, error) {
+func (ns NullRiverJobState) Value() (driver.Value, error) {
 	if !ns.Valid {
 		return nil, nil
 	}
-	return string(ns.JobState), nil
+	return string(ns.RiverJobState), nil
 }
 
 type RiverJob struct {
@@ -71,7 +71,7 @@ type RiverJob struct {
 	Metadata    []byte
 	Priority    int16
 	Queue       string
-	State       JobState
+	State       RiverJobState
 	ScheduledAt time.Time
 	Tags        []string
 }

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -458,7 +458,7 @@ type JobInsertFastParams struct {
 	Priority    int16
 	Queue       string
 	ScheduledAt *time.Time
-	State       JobState
+	State       RiverJobState
 	Tags        []string
 }
 
@@ -544,7 +544,7 @@ type JobInsertFullParams struct {
 	Priority    int16
 	Queue       string
 	ScheduledAt *time.Time
-	State       JobState
+	State       RiverJobState
 	Tags        []string
 }
 
@@ -761,7 +761,7 @@ FROM updated_job
 `
 
 type JobSetStateIfRunningParams struct {
-	State               JobState
+	State               RiverJobState
 	ID                  int64
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
@@ -830,7 +830,7 @@ type JobUpdateParams struct {
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
 	StateDoUpdate       bool
-	State               JobState
+	State               RiverJobState
 	ID                  int64
 }
 

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql.go
@@ -18,6 +18,6 @@ type JobInsertManyParams struct {
 	Priority    int16
 	Queue       string
 	ScheduledAt time.Time
-	State       JobState
+	State       RiverJobState
 	Tags        []string
 }

--- a/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
@@ -22,14 +22,6 @@ sql:
         emit_result_struct_pointers: true
 
         rename:
-          river_job_state: "JobState"
-          river_job_state_available: "JobStateAvailable"
-          river_job_state_cancelled: "JobStateCancelled"
-          river_job_state_completed: "JobStateCompleted"
-          river_job_state_discarded: "JobStateDiscarded"
-          river_job_state_retryable: "JobStateRetryable"
-          river_job_state_running: "JobStateRunning"
-          river_job_state_scheduled: "JobStateScheduled"
           ttl: "TTL"
 
         overrides:

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -154,7 +154,7 @@ func (e *Executor) JobInsertFast(ctx context.Context, params *riverdriver.JobIns
 		Priority:    int16(min(params.Priority, math.MaxInt16)),
 		Queue:       params.Queue,
 		ScheduledAt: params.ScheduledAt,
-		State:       dbsqlc.JobState(params.State),
+		State:       dbsqlc.RiverJobState(params.State),
 		Tags:        params.Tags,
 	})
 	if err != nil {
@@ -193,7 +193,7 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 			Priority:    int16(min(params.Priority, math.MaxInt16)),
 			Queue:       params.Queue,
 			ScheduledAt: scheduledAt,
-			State:       dbsqlc.JobState(params.State),
+			State:       dbsqlc.RiverJobState(params.State),
 			Tags:        tags,
 		}
 	}
@@ -220,7 +220,7 @@ func (e *Executor) JobInsertFull(ctx context.Context, params *riverdriver.JobIns
 		Priority:    int16(min(params.Priority, math.MaxInt16)),
 		Queue:       params.Queue,
 		ScheduledAt: params.ScheduledAt,
-		State:       dbsqlc.JobState(params.State),
+		State:       dbsqlc.RiverJobState(params.State),
 		Tags:        params.Tags,
 	})
 	if err != nil {
@@ -310,7 +310,7 @@ func (e *Executor) JobSetStateIfRunning(ctx context.Context, params *riverdriver
 		MaxAttempts:         maxAttempts,
 		ScheduledAtDoUpdate: params.ScheduledAt != nil,
 		ScheduledAt:         params.ScheduledAt,
-		State:               dbsqlc.JobState(params.State),
+		State:               dbsqlc.RiverJobState(params.State),
 	})
 	if err != nil {
 		return nil, interpretError(err)
@@ -330,7 +330,7 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		FinalizedAtDoUpdate: params.FinalizedAtDoUpdate,
 		FinalizedAt:         params.FinalizedAt,
 		StateDoUpdate:       params.StateDoUpdate,
-		State:               dbsqlc.JobState(params.State),
+		State:               dbsqlc.RiverJobState(params.State),
 	})
 	if err != nil {
 		return nil, interpretError(err)


### PR DESCRIPTION
This is another small one, but I noticed while doing driver work that
since we put a layer of abstraction between sqlc and any public-facing
APIs, the `JobState*` state constants in sqlc are not really used
anymore. Even the `JobState` type is used to infrequently that golfing
"River" off the front also does very little.

Here, I propose that we just get rid of the sqlc overrides. They're not
a big deal, but not having them means less sqlc configuration that needs
to be shared around between YAML files, and less opportunity for error
there.