### PR TITLE
Emit pointers for struct parameters in sqlc as well as results

### DIFF
--- a/riverdriver/riverdatabasesql/internal/dbsqlc/pg_misc.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/pg_misc.sql.go
@@ -27,7 +27,7 @@ type PGNotifyParams struct {
 	Payload string
 }
 
-func (q *Queries) PGNotify(ctx context.Context, db DBTX, arg PGNotifyParams) error {
+func (q *Queries) PGNotify(ctx context.Context, db DBTX, arg *PGNotifyParams) error {
 	_, err := db.ExecContext(ctx, pGNotify, arg.Topic, arg.Payload)
 	return err
 }

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -60,7 +60,7 @@ type JobCancelParams struct {
 	CancelAttemptedAt json.RawMessage
 }
 
-func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg JobCancelParams) (*RiverJob, error) {
+func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg *JobCancelParams) (*RiverJob, error) {
 	row := db.QueryRowContext(ctx, jobCancel, arg.ID, arg.JobControlTopic, arg.CancelAttemptedAt)
 	var i RiverJob
 	err := row.Scan(
@@ -110,7 +110,7 @@ type JobDeleteBeforeParams struct {
 	Max                         int64
 }
 
-func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg JobDeleteBeforeParams) (int64, error) {
+func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg *JobDeleteBeforeParams) (int64, error) {
 	row := db.QueryRowContext(ctx, jobDeleteBefore,
 		arg.CancelledFinalizedAtHorizon,
 		arg.CompletedFinalizedAtHorizon,
@@ -161,7 +161,7 @@ type JobGetAvailableParams struct {
 	Max         int32
 }
 
-func (q *Queries) JobGetAvailable(ctx context.Context, db DBTX, arg JobGetAvailableParams) ([]*RiverJob, error) {
+func (q *Queries) JobGetAvailable(ctx context.Context, db DBTX, arg *JobGetAvailableParams) ([]*RiverJob, error) {
 	rows, err := db.QueryContext(ctx, jobGetAvailable, arg.AttemptedBy, arg.Queue, arg.Max)
 	if err != nil {
 		return nil, err
@@ -302,7 +302,7 @@ type JobGetByKindAndUniquePropertiesParams struct {
 	State          []string
 }
 
-func (q *Queries) JobGetByKindAndUniqueProperties(ctx context.Context, db DBTX, arg JobGetByKindAndUniquePropertiesParams) (*RiverJob, error) {
+func (q *Queries) JobGetByKindAndUniqueProperties(ctx context.Context, db DBTX, arg *JobGetByKindAndUniquePropertiesParams) (*RiverJob, error) {
 	row := db.QueryRowContext(ctx, jobGetByKindAndUniqueProperties,
 		arg.Kind,
 		arg.ByArgs,
@@ -398,7 +398,7 @@ type JobGetStuckParams struct {
 	Max          int32
 }
 
-func (q *Queries) JobGetStuck(ctx context.Context, db DBTX, arg JobGetStuckParams) ([]*RiverJob, error) {
+func (q *Queries) JobGetStuck(ctx context.Context, db DBTX, arg *JobGetStuckParams) ([]*RiverJob, error) {
 	rows, err := db.QueryContext(ctx, jobGetStuck, arg.StuckHorizon, arg.Max)
 	if err != nil {
 		return nil, err
@@ -477,7 +477,7 @@ type JobInsertFastParams struct {
 	Tags        []string
 }
 
-func (q *Queries) JobInsertFast(ctx context.Context, db DBTX, arg JobInsertFastParams) (*RiverJob, error) {
+func (q *Queries) JobInsertFast(ctx context.Context, db DBTX, arg *JobInsertFastParams) (*RiverJob, error) {
 	row := db.QueryRowContext(ctx, jobInsertFast,
 		arg.Args,
 		arg.FinalizedAt,
@@ -563,7 +563,7 @@ type JobInsertFullParams struct {
 	Tags        []string
 }
 
-func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg JobInsertFullParams) (*RiverJob, error) {
+func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFullParams) (*RiverJob, error) {
 	row := db.QueryRowContext(ctx, jobInsertFull,
 		arg.Args,
 		arg.Attempt,
@@ -629,7 +629,7 @@ type JobRescueManyParams struct {
 }
 
 // Run by the rescuer to queue for retry or discard depending on job state.
-func (q *Queries) JobRescueMany(ctx context.Context, db DBTX, arg JobRescueManyParams) error {
+func (q *Queries) JobRescueMany(ctx context.Context, db DBTX, arg *JobRescueManyParams) error {
 	_, err := db.ExecContext(ctx, jobRescueMany,
 		pq.Array(arg.ID),
 		pq.Array(arg.Error),
@@ -731,7 +731,7 @@ type JobScheduleParams struct {
 	Max         int64
 }
 
-func (q *Queries) JobSchedule(ctx context.Context, db DBTX, arg JobScheduleParams) (int64, error) {
+func (q *Queries) JobSchedule(ctx context.Context, db DBTX, arg *JobScheduleParams) (int64, error) {
 	row := db.QueryRowContext(ctx, jobSchedule, arg.InsertTopic, arg.Now, arg.Max)
 	var count int64
 	err := row.Scan(&count)
@@ -788,7 +788,7 @@ type JobSetStateIfRunningParams struct {
 	ScheduledAt         *time.Time
 }
 
-func (q *Queries) JobSetStateIfRunning(ctx context.Context, db DBTX, arg JobSetStateIfRunningParams) (*RiverJob, error) {
+func (q *Queries) JobSetStateIfRunning(ctx context.Context, db DBTX, arg *JobSetStateIfRunningParams) (*RiverJob, error) {
 	row := db.QueryRowContext(ctx, jobSetStateIfRunning,
 		arg.State,
 		arg.ID,
@@ -851,7 +851,7 @@ type JobUpdateParams struct {
 
 // A generalized update for any property on a job. This brings in a large number
 // of parameters and therefore may be more suitable for testing than production.
-func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg JobUpdateParams) (*RiverJob, error) {
+func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) (*RiverJob, error) {
 	row := db.QueryRowContext(ctx, jobUpdate,
 		arg.AttemptDoUpdate,
 		arg.Attempt,

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
@@ -23,7 +23,7 @@ type LeaderAttemptElectParams struct {
 	TTL      time.Duration
 }
 
-func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg LeaderAttemptElectParams) (int64, error) {
+func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAttemptElectParams) (int64, error) {
 	result, err := db.ExecContext(ctx, leaderAttemptElect, arg.Name, arg.LeaderID, arg.TTL)
 	if err != nil {
 		return 0, err
@@ -47,7 +47,7 @@ type LeaderAttemptReelectParams struct {
 	TTL      time.Duration
 }
 
-func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg LeaderAttemptReelectParams) (int64, error) {
+func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg *LeaderAttemptReelectParams) (int64, error) {
 	result, err := db.ExecContext(ctx, leaderAttemptReelect, arg.Name, arg.LeaderID, arg.TTL)
 	if err != nil {
 		return 0, err
@@ -109,7 +109,7 @@ type LeaderInsertParams struct {
 	Name      string
 }
 
-func (q *Queries) LeaderInsert(ctx context.Context, db DBTX, arg LeaderInsertParams) (*RiverLeader, error) {
+func (q *Queries) LeaderInsert(ctx context.Context, db DBTX, arg *LeaderInsertParams) (*RiverLeader, error) {
 	row := db.QueryRowContext(ctx, leaderInsert,
 		arg.ElectedAt,
 		arg.ExpiresAt,
@@ -152,7 +152,7 @@ type LeaderResignParams struct {
 	LeadershipTopic string
 }
 
-func (q *Queries) LeaderResign(ctx context.Context, db DBTX, arg LeaderResignParams) (int64, error) {
+func (q *Queries) LeaderResign(ctx context.Context, db DBTX, arg *LeaderResignParams) (int64, error) {
 	result, err := db.ExecContext(ctx, leaderResign, arg.Name, arg.LeaderID, arg.LeadershipTopic)
 	if err != nil {
 		return 0, err

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
@@ -18,6 +18,7 @@ sql:
         out: "."
         emit_exact_table_names: true
         emit_methods_with_db_argument: true
+        emit_params_struct_pointers: true
         emit_result_struct_pointers: true
 
         rename:

--- a/riverdriver/riverpgxv5/internal/dbsqlc/copyfrom.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/copyfrom.go
@@ -11,7 +11,7 @@ import (
 
 // iteratorForJobInsertMany implements pgx.CopyFromSource.
 type iteratorForJobInsertMany struct {
-	rows                 []JobInsertManyParams
+	rows                 []*JobInsertManyParams
 	skippedFirstNextCall bool
 }
 
@@ -46,6 +46,6 @@ func (r iteratorForJobInsertMany) Err() error {
 	return nil
 }
 
-func (q *Queries) JobInsertMany(ctx context.Context, db DBTX, arg []JobInsertManyParams) (int64, error) {
+func (q *Queries) JobInsertMany(ctx context.Context, db DBTX, arg []*JobInsertManyParams) (int64, error) {
 	return db.CopyFrom(ctx, []string{"river_job"}, []string{"args", "finalized_at", "kind", "max_attempts", "metadata", "priority", "queue", "scheduled_at", "state", "tags"}, &iteratorForJobInsertMany{rows: arg})
 }

--- a/riverdriver/riverpgxv5/internal/dbsqlc/pg_misc.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/pg_misc.sql.go
@@ -27,7 +27,7 @@ type PGNotifyParams struct {
 	Payload string
 }
 
-func (q *Queries) PGNotify(ctx context.Context, db DBTX, arg PGNotifyParams) error {
+func (q *Queries) PGNotify(ctx context.Context, db DBTX, arg *PGNotifyParams) error {
 	_, err := db.Exec(ctx, pGNotify, arg.Topic, arg.Payload)
 	return err
 }

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -57,7 +57,7 @@ type JobCancelParams struct {
 	CancelAttemptedAt []byte
 }
 
-func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg JobCancelParams) (*RiverJob, error) {
+func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg *JobCancelParams) (*RiverJob, error) {
 	row := db.QueryRow(ctx, jobCancel, arg.ID, arg.JobControlTopic, arg.CancelAttemptedAt)
 	var i RiverJob
 	err := row.Scan(
@@ -107,7 +107,7 @@ type JobDeleteBeforeParams struct {
 	Max                         int64
 }
 
-func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg JobDeleteBeforeParams) (int64, error) {
+func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg *JobDeleteBeforeParams) (int64, error) {
 	row := db.QueryRow(ctx, jobDeleteBefore,
 		arg.CancelledFinalizedAtHorizon,
 		arg.CompletedFinalizedAtHorizon,
@@ -158,7 +158,7 @@ type JobGetAvailableParams struct {
 	Max         int32
 }
 
-func (q *Queries) JobGetAvailable(ctx context.Context, db DBTX, arg JobGetAvailableParams) ([]*RiverJob, error) {
+func (q *Queries) JobGetAvailable(ctx context.Context, db DBTX, arg *JobGetAvailableParams) ([]*RiverJob, error) {
 	rows, err := db.Query(ctx, jobGetAvailable, arg.AttemptedBy, arg.Queue, arg.Max)
 	if err != nil {
 		return nil, err
@@ -293,7 +293,7 @@ type JobGetByKindAndUniquePropertiesParams struct {
 	State          []string
 }
 
-func (q *Queries) JobGetByKindAndUniqueProperties(ctx context.Context, db DBTX, arg JobGetByKindAndUniquePropertiesParams) (*RiverJob, error) {
+func (q *Queries) JobGetByKindAndUniqueProperties(ctx context.Context, db DBTX, arg *JobGetByKindAndUniquePropertiesParams) (*RiverJob, error) {
 	row := db.QueryRow(ctx, jobGetByKindAndUniqueProperties,
 		arg.Kind,
 		arg.ByArgs,
@@ -386,7 +386,7 @@ type JobGetStuckParams struct {
 	Max          int32
 }
 
-func (q *Queries) JobGetStuck(ctx context.Context, db DBTX, arg JobGetStuckParams) ([]*RiverJob, error) {
+func (q *Queries) JobGetStuck(ctx context.Context, db DBTX, arg *JobGetStuckParams) ([]*RiverJob, error) {
 	rows, err := db.Query(ctx, jobGetStuck, arg.StuckHorizon, arg.Max)
 	if err != nil {
 		return nil, err
@@ -462,7 +462,7 @@ type JobInsertFastParams struct {
 	Tags        []string
 }
 
-func (q *Queries) JobInsertFast(ctx context.Context, db DBTX, arg JobInsertFastParams) (*RiverJob, error) {
+func (q *Queries) JobInsertFast(ctx context.Context, db DBTX, arg *JobInsertFastParams) (*RiverJob, error) {
 	row := db.QueryRow(ctx, jobInsertFast,
 		arg.Args,
 		arg.FinalizedAt,
@@ -548,7 +548,7 @@ type JobInsertFullParams struct {
 	Tags        []string
 }
 
-func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg JobInsertFullParams) (*RiverJob, error) {
+func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFullParams) (*RiverJob, error) {
 	row := db.QueryRow(ctx, jobInsertFull,
 		arg.Args,
 		arg.Attempt,
@@ -614,7 +614,7 @@ type JobRescueManyParams struct {
 }
 
 // Run by the rescuer to queue for retry or discard depending on job state.
-func (q *Queries) JobRescueMany(ctx context.Context, db DBTX, arg JobRescueManyParams) error {
+func (q *Queries) JobRescueMany(ctx context.Context, db DBTX, arg *JobRescueManyParams) error {
 	_, err := db.Exec(ctx, jobRescueMany,
 		arg.ID,
 		arg.Error,
@@ -716,7 +716,7 @@ type JobScheduleParams struct {
 	Max         int64
 }
 
-func (q *Queries) JobSchedule(ctx context.Context, db DBTX, arg JobScheduleParams) (int64, error) {
+func (q *Queries) JobSchedule(ctx context.Context, db DBTX, arg *JobScheduleParams) (int64, error) {
 	row := db.QueryRow(ctx, jobSchedule, arg.InsertTopic, arg.Now, arg.Max)
 	var count int64
 	err := row.Scan(&count)
@@ -773,7 +773,7 @@ type JobSetStateIfRunningParams struct {
 	ScheduledAt         *time.Time
 }
 
-func (q *Queries) JobSetStateIfRunning(ctx context.Context, db DBTX, arg JobSetStateIfRunningParams) (*RiverJob, error) {
+func (q *Queries) JobSetStateIfRunning(ctx context.Context, db DBTX, arg *JobSetStateIfRunningParams) (*RiverJob, error) {
 	row := db.QueryRow(ctx, jobSetStateIfRunning,
 		arg.State,
 		arg.ID,
@@ -836,7 +836,7 @@ type JobUpdateParams struct {
 
 // A generalized update for any property on a job. This brings in a large number
 // of parameters and therefore may be more suitable for testing than production.
-func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg JobUpdateParams) (*RiverJob, error) {
+func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) (*RiverJob, error) {
 	row := db.QueryRow(ctx, jobUpdate,
 		arg.AttemptDoUpdate,
 		arg.Attempt,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
@@ -23,7 +23,7 @@ type LeaderAttemptElectParams struct {
 	TTL      time.Duration
 }
 
-func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg LeaderAttemptElectParams) (int64, error) {
+func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAttemptElectParams) (int64, error) {
 	result, err := db.Exec(ctx, leaderAttemptElect, arg.Name, arg.LeaderID, arg.TTL)
 	if err != nil {
 		return 0, err
@@ -47,7 +47,7 @@ type LeaderAttemptReelectParams struct {
 	TTL      time.Duration
 }
 
-func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg LeaderAttemptReelectParams) (int64, error) {
+func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg *LeaderAttemptReelectParams) (int64, error) {
 	result, err := db.Exec(ctx, leaderAttemptReelect, arg.Name, arg.LeaderID, arg.TTL)
 	if err != nil {
 		return 0, err
@@ -109,7 +109,7 @@ type LeaderInsertParams struct {
 	Name      string
 }
 
-func (q *Queries) LeaderInsert(ctx context.Context, db DBTX, arg LeaderInsertParams) (*RiverLeader, error) {
+func (q *Queries) LeaderInsert(ctx context.Context, db DBTX, arg *LeaderInsertParams) (*RiverLeader, error) {
 	row := db.QueryRow(ctx, leaderInsert,
 		arg.ElectedAt,
 		arg.ExpiresAt,
@@ -152,7 +152,7 @@ type LeaderResignParams struct {
 	LeadershipTopic string
 }
 
-func (q *Queries) LeaderResign(ctx context.Context, db DBTX, arg LeaderResignParams) (int64, error) {
+func (q *Queries) LeaderResign(ctx context.Context, db DBTX, arg *LeaderResignParams) (int64, error) {
 	result, err := db.Exec(ctx, leaderResign, arg.Name, arg.LeaderID, arg.LeadershipTopic)
 	if err != nil {
 		return 0, err

--- a/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
@@ -19,6 +19,7 @@ sql:
         out: "."
         emit_exact_table_names: true
         emit_methods_with_db_argument: true
+        emit_params_struct_pointers: true
         emit_result_struct_pointers: true
 
         rename:


### PR DESCRIPTION
By default, sqlc emits non-pointer structs for both parameters and
results. Since pretty much the beginning we've had this configuration to
emit pointers instead of structs for results:

    emit_result_struct_pointers: true

Here, I propose that we add a similar configuration that also makes
parameters pointers:

    emit_params_struct_pointers: true

It's not a big deal either way, but this fits a little better with the
`riverdriver` interface, which uses pointers for everything already, it
also makes it so we can do a direct pointer conversion in a couple
places, probably leading to a very, very nominal efficiency gain. e.g.:

    err := e.queries.JobRescueMany(ctx, e.dbtx, (*dbsqlc.JobRescueManyParams)(params))