### PR TITLE
`Rescuer` -> `JobRescuer` + `Scheduler` -> `JobScheduler`

### DIFF
--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -17,20 +17,20 @@ import (
 )
 
 const (
-	SchedulerIntervalDefault = 5 * time.Second
-	SchedulerLimitDefault    = 10_000
+	JobSchedulerIntervalDefault = 5 * time.Second
+	JobSchedulerLimitDefault    = 10_000
 )
 
 // Test-only properties.
-type SchedulerTestSignals struct {
+type JobSchedulerTestSignals struct {
 	ScheduledBatch rivercommon.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
-func (ts *SchedulerTestSignals) Init() {
+func (ts *JobSchedulerTestSignals) Init() {
 	ts.ScheduledBatch.Init()
 }
 
-type SchedulerConfig struct {
+type JobSchedulerConfig struct {
 	// Interval is the amount of time between periodic checks for jobs to
 	// be moved from "scheduled" to "available".
 	Interval time.Duration
@@ -40,7 +40,7 @@ type SchedulerConfig struct {
 	Limit int
 }
 
-func (c *SchedulerConfig) mustValidate() *SchedulerConfig {
+func (c *JobSchedulerConfig) mustValidate() *JobSchedulerConfig {
 	if c.Interval <= 0 {
 		panic("SchedulerConfig.Interval must be above zero")
 	}
@@ -51,31 +51,31 @@ func (c *SchedulerConfig) mustValidate() *SchedulerConfig {
 	return c
 }
 
-// Scheduler periodically moves jobs in `scheduled` or `retryable` state and
+// JobScheduler periodically moves jobs in `scheduled` or `retryable` state and
 // which are ready to run over to `available` so that they're eligible to be
 // worked.
-type Scheduler struct {
+type JobScheduler struct {
 	baseservice.BaseService
 	startstop.BaseStartStop
 
 	// exported for test purposes
-	TestSignals SchedulerTestSignals
+	TestSignals JobSchedulerTestSignals
 
-	config *SchedulerConfig
+	config *JobSchedulerConfig
 	exec   riverdriver.Executor
 }
 
-func NewScheduler(archetype *baseservice.Archetype, config *SchedulerConfig, exec riverdriver.Executor) *Scheduler {
-	return baseservice.Init(archetype, &Scheduler{
-		config: (&SchedulerConfig{
-			Interval: valutil.ValOrDefault(config.Interval, SchedulerIntervalDefault),
-			Limit:    valutil.ValOrDefault(config.Limit, SchedulerLimitDefault),
+func NewScheduler(archetype *baseservice.Archetype, config *JobSchedulerConfig, exec riverdriver.Executor) *JobScheduler {
+	return baseservice.Init(archetype, &JobScheduler{
+		config: (&JobSchedulerConfig{
+			Interval: valutil.ValOrDefault(config.Interval, JobSchedulerIntervalDefault),
+			Limit:    valutil.ValOrDefault(config.Limit, JobSchedulerLimitDefault),
 		}).mustValidate(),
 		exec: exec,
 	})
 }
 
-func (s *Scheduler) Start(ctx context.Context) error { //nolint:dupl
+func (s *JobScheduler) Start(ctx context.Context) error { //nolint:dupl
 	ctx, shouldStart, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
@@ -121,7 +121,7 @@ type schedulerRunOnceResult struct {
 	NumCompletedJobsScheduled int
 }
 
-func (s *Scheduler) runOnce(ctx context.Context) (*schedulerRunOnceResult, error) {
+func (s *JobScheduler) runOnce(ctx context.Context) (*schedulerRunOnceResult, error) {
 	res := &schedulerRunOnceResult{}
 
 	for {

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-func TestScheduler(t *testing.T) {
+func TestJobScheduler(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -28,7 +28,7 @@ func TestScheduler(t *testing.T) {
 		exec riverdriver.Executor
 	}
 
-	setup := func(t *testing.T, ex riverdriver.Executor) (*Scheduler, *testBundle) {
+	setup := func(t *testing.T, ex riverdriver.Executor) (*JobScheduler, *testBundle) {
 		t.Helper()
 
 		bundle := &testBundle{
@@ -37,8 +37,8 @@ func TestScheduler(t *testing.T) {
 
 		scheduler := NewScheduler(
 			riverinternaltest.BaseServiceArchetype(t),
-			&SchedulerConfig{
-				Interval: SchedulerIntervalDefault,
+			&JobSchedulerConfig{
+				Interval: JobSchedulerIntervalDefault,
 				Limit:    10,
 			},
 			bundle.exec)
@@ -48,7 +48,7 @@ func TestScheduler(t *testing.T) {
 		return scheduler, bundle
 	}
 
-	setupTx := func(t *testing.T) (*Scheduler, *testBundle) {
+	setupTx := func(t *testing.T) (*JobScheduler, *testBundle) {
 		t.Helper()
 		tx := riverinternaltest.TestTx(ctx, t)
 		return setup(t, riverpgxv5.New(nil).UnwrapExecutor(tx))
@@ -72,10 +72,10 @@ func TestScheduler(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
 		t.Parallel()
 
-		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t), &SchedulerConfig{}, nil)
+		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t), &JobSchedulerConfig{}, nil)
 
-		require.Equal(t, SchedulerIntervalDefault, scheduler.config.Interval)
-		require.Equal(t, SchedulerLimitDefault, scheduler.config.Limit)
+		require.Equal(t, JobSchedulerIntervalDefault, scheduler.config.Interval)
+		require.Equal(t, JobSchedulerLimitDefault, scheduler.config.Limit)
 	})
 
 	t.Run("StartStopStress", func(t *testing.T) {
@@ -83,7 +83,7 @@ func TestScheduler(t *testing.T) {
 
 		scheduler, _ := setupTx(t)
 		scheduler.Logger = riverinternaltest.LoggerWarn(t) // loop started/stop log is very noisy; suppress
-		scheduler.TestSignals = SchedulerTestSignals{}     // deinit so channels don't fill
+		scheduler.TestSignals = JobSchedulerTestSignals{}  // deinit so channels don't fill
 
 		runStartStopStress(ctx, t, scheduler)
 	})

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -112,7 +112,7 @@ func TestQueueMaintainer(t *testing.T) {
 					},
 				},
 			}, driver),
-			NewScheduler(archetype, &SchedulerConfig{}, driver),
+			NewScheduler(archetype, &JobSchedulerConfig{}, driver),
 		})
 		maintainer.Logger = riverinternaltest.LoggerWarn(t) // loop started/stop log is very noisy; suppress
 		runStartStopStress(ctx, t, maintainer)

--- a/producer_test.go
+++ b/producer_test.go
@@ -83,7 +83,7 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 		Notifier:          notifier,
 		Queue:             rivercommon.QueueDefault,
 		RetryPolicy:       &DefaultClientRetryPolicy{},
-		SchedulerInterval: maintenance.SchedulerIntervalDefault,
+		SchedulerInterval: maintenance.JobSchedulerIntervalDefault,
 		ClientID:          "fakeWorkerNameTODO",
 		Workers:           workers,
 	}


### PR DESCRIPTION
Another small one, but it's triggering my OCD in that for services
inside the queue maintainer, the job cleaner is called `JobCleaner`, the
periodic enqueuer is called `PeriodicJobEnqueuer`, but the rescuer is
only `Rescuer` (without a "job" prefix) and scheduler is `Scheduler`.

Here, rename the rescuer and scheduler so they pick up a prefix and
become `JobRescuer` and `JobScheduler`. I think this is nominally
beneficial anyway because it helps telegraph that these are services
that are specific to jobs (unlike say `Reindexer` for example, which is
not related to jobs specifically, and therefore unprefixed).