### PR TITLE
Proof of concept: River operating with pgx simple protocol

### DIFF
--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -73,6 +73,7 @@ func DatabaseConfig(databaseName string) *pgxpool.Config {
 	// are unlikely to succeed even with more time:
 	config.ConnConfig.ConnectTimeout = 2 * time.Second
 	config.ConnConfig.RuntimeParams["timezone"] = "UTC"
+	config.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 	return config
 }
 

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
@@ -6,7 +6,6 @@ package dbsqlc
 
 import (
 	"database/sql/driver"
-	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -60,7 +59,7 @@ func (ns NullJobState) Value() (driver.Value, error) {
 
 type RiverJob struct {
 	ID          int64
-	Args        []byte
+	Args        *string
 	Attempt     int16
 	AttemptedAt *time.Time
 	AttemptedBy []string
@@ -69,7 +68,7 @@ type RiverJob struct {
 	FinalizedAt *time.Time
 	Kind        string
 	MaxAttempts int16
-	Metadata    json.RawMessage
+	Metadata    string
 	Priority    int16
 	Queue       string
 	State       JobState

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -7,7 +7,6 @@ package dbsqlc
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"github.com/lib/pq"
@@ -57,7 +56,7 @@ FROM updated_job
 type JobCancelParams struct {
 	ID                int64
 	JobControlTopic   string
-	CancelAttemptedAt json.RawMessage
+	CancelAttemptedAt string
 }
 
 func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg *JobCancelParams) (*RiverJob, error) {
@@ -292,7 +291,7 @@ WHERE kind = $1
 type JobGetByKindAndUniquePropertiesParams struct {
 	Kind           string
 	ByArgs         bool
-	Args           []byte
+	Args           *string
 	ByCreatedAt    bool
 	CreatedAtBegin time.Time
 	CreatedAtEnd   time.Time
@@ -465,11 +464,11 @@ INSERT INTO river_job(
 `
 
 type JobInsertFastParams struct {
-	Args        json.RawMessage
+	Args        string
 	FinalizedAt *time.Time
 	Kind        string
 	MaxAttempts int16
-	Metadata    json.RawMessage
+	Metadata    *string
 	Priority    int16
 	Queue       string
 	ScheduledAt *time.Time
@@ -529,7 +528,7 @@ INSERT INTO river_job(
     state,
     tags
 ) VALUES (
-    $1::jsonb,
+    $1,
     coalesce($2::smallint, 0),
     $3,
     coalesce($4::timestamptz, now()),
@@ -547,15 +546,15 @@ INSERT INTO river_job(
 `
 
 type JobInsertFullParams struct {
-	Args        json.RawMessage
+	Args        *string
 	Attempt     int16
 	AttemptedAt *time.Time
 	CreatedAt   *time.Time
-	Errors      []json.RawMessage
+	Errors      []string
 	FinalizedAt *time.Time
 	Kind        string
 	MaxAttempts int16
-	Metadata    json.RawMessage
+	Metadata    string
 	Priority    int16
 	Queue       string
 	ScheduledAt *time.Time
@@ -622,7 +621,7 @@ WHERE river_job.id = updated_job.id
 
 type JobRescueManyParams struct {
 	ID          []int64
-	Error       []json.RawMessage
+	Error       []string
 	FinalizedAt []time.Time
 	ScheduledAt []time.Time
 	State       []string
@@ -781,7 +780,7 @@ type JobSetStateIfRunningParams struct {
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
 	ErrorDoUpdate       bool
-	Error               json.RawMessage
+	Error               string
 	MaxAttemptsUpdate   bool
 	MaxAttempts         int16
 	ScheduledAtDoUpdate bool
@@ -841,7 +840,7 @@ type JobUpdateParams struct {
 	AttemptedAtDoUpdate bool
 	AttemptedAt         *time.Time
 	ErrorsDoUpdate      bool
-	Errors              []json.RawMessage
+	Errors              []string
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
 	StateDoUpdate       bool

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
@@ -26,6 +26,15 @@ sql:
           ttl: "TTL"
 
         overrides:
+          - db_type: "jsonb"
+            go_type: "string"
+
+          - db_type: "jsonb"
+            go_type:
+              type: "string"
+              pointer: true
+            nullable: true
+
           - db_type: "pg_catalog.interval"
             go_type: "time.Duration"
 
@@ -39,14 +48,6 @@ sql:
             nullable: true
 
           # specific columns
-
-          # This one is necessary because `args` is nullable (this seems to have
-          # been an oversight, but one we're determined isn't worth correcting
-          # for now), and the `database/sql` variant of sqlc will give it a
-          # crazy type by default, so here we give it something more reasonable.
-          - column: "river_job.args"
-            go_type:
-              type: "[]byte"
 
           - column: "river_job.errors"
             go_type:

--- a/riverdriver/riverpgxv5/internal/dbsqlc/models.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/models.go
@@ -59,7 +59,7 @@ func (ns NullRiverJobState) Value() (driver.Value, error) {
 
 type RiverJob struct {
 	ID          int64
-	Args        []byte
+	Args        *string
 	Attempt     int16
 	AttemptedAt *time.Time
 	AttemptedBy []string
@@ -68,7 +68,7 @@ type RiverJob struct {
 	FinalizedAt *time.Time
 	Kind        string
 	MaxAttempts int16
-	Metadata    []byte
+	Metadata    string
 	Priority    int16
 	Queue       string
 	State       RiverJobState

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -174,7 +174,7 @@ INSERT INTO river_job(
     @finalized_at,
     @kind::text,
     @max_attempts::smallint,
-    coalesce(@metadata::jsonb, '{}'),
+    coalesce(sqlc.narg('metadata')::jsonb, '{}'),
     @priority::smallint,
     @queue::text,
     coalesce(sqlc.narg('scheduled_at')::timestamptz, now()),
@@ -199,7 +199,7 @@ INSERT INTO river_job(
     state,
     tags
 ) VALUES (
-    @args::jsonb,
+    @args,
     coalesce(@attempt::smallint, 0),
     @attempted_at,
     coalesce(sqlc.narg('created_at')::timestamptz, now()),

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -54,7 +54,7 @@ FROM updated_job
 type JobCancelParams struct {
 	ID                int64
 	JobControlTopic   string
-	CancelAttemptedAt []byte
+	CancelAttemptedAt string
 }
 
 func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg *JobCancelParams) (*RiverJob, error) {
@@ -283,7 +283,7 @@ WHERE kind = $1
 type JobGetByKindAndUniquePropertiesParams struct {
 	Kind           string
 	ByArgs         bool
-	Args           []byte
+	Args           *string
 	ByCreatedAt    bool
 	CreatedAtBegin time.Time
 	CreatedAtEnd   time.Time
@@ -450,11 +450,11 @@ INSERT INTO river_job(
 `
 
 type JobInsertFastParams struct {
-	Args        []byte
+	Args        string
 	FinalizedAt *time.Time
 	Kind        string
 	MaxAttempts int16
-	Metadata    []byte
+	Metadata    *string
 	Priority    int16
 	Queue       string
 	ScheduledAt *time.Time
@@ -514,7 +514,7 @@ INSERT INTO river_job(
     state,
     tags
 ) VALUES (
-    $1::jsonb,
+    $1,
     coalesce($2::smallint, 0),
     $3,
     coalesce($4::timestamptz, now()),
@@ -532,15 +532,15 @@ INSERT INTO river_job(
 `
 
 type JobInsertFullParams struct {
-	Args        []byte
+	Args        *string
 	Attempt     int16
 	AttemptedAt *time.Time
 	CreatedAt   *time.Time
-	Errors      [][]byte
+	Errors      []string
 	FinalizedAt *time.Time
 	Kind        string
 	MaxAttempts int16
-	Metadata    []byte
+	Metadata    string
 	Priority    int16
 	Queue       string
 	ScheduledAt *time.Time
@@ -607,7 +607,7 @@ WHERE river_job.id = updated_job.id
 
 type JobRescueManyParams struct {
 	ID          []int64
-	Error       [][]byte
+	Error       []string
 	FinalizedAt []time.Time
 	ScheduledAt []time.Time
 	State       []string
@@ -766,7 +766,7 @@ type JobSetStateIfRunningParams struct {
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
 	ErrorDoUpdate       bool
-	Error               []byte
+	Error               string
 	MaxAttemptsUpdate   bool
 	MaxAttempts         int16
 	ScheduledAtDoUpdate bool
@@ -826,7 +826,7 @@ type JobUpdateParams struct {
 	AttemptedAtDoUpdate bool
 	AttemptedAt         *time.Time
 	ErrorsDoUpdate      bool
-	Errors              [][]byte
+	Errors              []string
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
 	StateDoUpdate       bool

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql.go
@@ -10,11 +10,11 @@ import (
 )
 
 type JobInsertManyParams struct {
-	Args        []byte
+	Args        *string
 	FinalizedAt *time.Time
 	Kind        string
 	MaxAttempts int16
-	Metadata    []byte
+	Metadata    string
 	Priority    int16
 	Queue       string
 	ScheduledAt time.Time

--- a/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
@@ -29,6 +29,15 @@ sql:
           - db_type: "pg_catalog.interval"
             go_type: "time.Duration"
 
+          - db_type: "jsonb"
+            go_type: "string"
+
+          - db_type: "jsonb"
+            go_type:
+              type: "string"
+              pointer: true
+            nullable: true
+
           - db_type: "timestamptz"
             go_type: "time.Time"
 

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver_test.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver_test.go
@@ -57,7 +57,7 @@ func TestListener_Close(t *testing.T) {
 
 		var connStub *connStub
 
-		config := testPoolConfig()
+		var config *pgxpool.Config = testPoolConfig()
 		config.ConnConfig.DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			// Dialer settings come from pgx's default internal one (not exported unfortunately).
 			conn, err := (&net.Dialer{KeepAlive: 5 * time.Minute}).Dial(network, addr)


### PR DESCRIPTION
We had an issue opened a little while back (#171) wherein it turned out
that River couldn't operate with pgx's simple protocol turned on, which
appeared to be because the simple protocol doesn't know anything about a
target Postgres tuple's makeup and therefore had to guess how to encode
parameters based on input types, which was leading `[]byte` intended for
`jsonb`s to be binary encoded, which isn't allowed.

We closed that issue after I pointed out that PgBouncer now supports
prepared statement pooling, and therefore simple protocol is no longer
necessary.

We recently got another comment [1] where someone had tried to use River
with Supavisor on Supabase, which also does not supported prepared
statements, leading to lots of errors. Normally, pgx's simple protocol
could be used to address this, but as we saw in #171, River doesn't
support that.

Here, a proof of concept demonstrating how River could support simple
protocol by modeling `jsonb` fields in sqlc as strings, which prevents
pgx from encoding to binary with simple procotol, and we get to a point
where all driver tests are passing.

I'm not sure if we should action on this one or not. Having to fall back
to `string` fields a bit gross, although I don't *think* carries
significant performance penalty because it's basically the same
underlying structure as far as Go is concerned.

[1] https://github.com/riverqueue/river/issues/205#issuecomment-1963001669