### PR TITLE
Don't disable sleep by default from `riverinternaltest.BaseServiceArchetype`

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -125,7 +125,6 @@ func newTestConfig(t *testing.T, callback callbackFunc) *Config {
 		Logger:            riverinternaltest.Logger(t),
 		Queues:            map[string]QueueConfig{QueueDefault: {MaxWorkers: 50}},
 		Workers:           workers,
-		disableSleep:      true,
 		schedulerInterval: riverinternaltest.SchedulerShortInterval,
 	}
 }
@@ -1772,6 +1771,7 @@ func Test_Client_Maintenance(t *testing.T) {
 		config.CancelledJobRetentionPeriod = 1 * time.Hour
 		config.CompletedJobRetentionPeriod = 1 * time.Hour
 		config.DiscardedJobRetentionPeriod = 1 * time.Hour
+		config.disableSleep = true
 
 		client := newTestClient(t, dbPool, config)
 		exec := client.driver.GetExecutor()
@@ -1830,6 +1830,7 @@ func Test_Client_Maintenance(t *testing.T) {
 
 		config := newTestConfig(t, nil)
 		config.RescueStuckJobsAfter = 5 * time.Minute
+		config.disableSleep = true
 
 		client := newTestClient(t, dbPool, config)
 		exec := client.driver.GetExecutor()
@@ -1897,6 +1898,7 @@ func Test_Client_Maintenance(t *testing.T) {
 
 		config := newTestConfig(t, nil)
 		config.Queues = map[string]QueueConfig{"another_queue": {MaxWorkers: 1}} // don't work jobs on the default queue we're using in this test
+		config.disableSleep = true
 
 		client := newTestClient(t, dbPool, config)
 		exec := client.driver.GetExecutor()
@@ -1952,6 +1954,8 @@ func Test_Client_Maintenance(t *testing.T) {
 		t.Parallel()
 
 		config := newTestConfig(t, nil)
+		config.disableSleep = true
+
 		worker := &periodicJobWorker{}
 		AddWorker(config.Workers, worker)
 		config.PeriodicJobs = []*PeriodicJob{
@@ -1976,6 +1980,8 @@ func Test_Client_Maintenance(t *testing.T) {
 		t.Parallel()
 
 		config := newTestConfig(t, nil)
+		config.disableSleep = true
+
 		worker := &periodicJobWorker{}
 		AddWorker(config.Workers, worker)
 		config.PeriodicJobs = []*PeriodicJob{
@@ -2003,6 +2009,7 @@ func Test_Client_Maintenance(t *testing.T) {
 
 		config := newTestConfig(t, nil)
 		config.ReindexerSchedule = cron.Every(time.Second)
+		config.disableSleep = true
 
 		client := runNewTestClient(ctx, t, config)
 

--- a/internal/baseservice/base_service.go
+++ b/internal/baseservice/base_service.go
@@ -24,8 +24,7 @@ type Archetype struct {
 	// `BaseService`'s `CancellableSleep` functions. This is meant to provide a
 	// convenient way to disable sleep in one place and which will automatically
 	// propagate from a parent into its subcomponents as they initialize
-	// themselves from its archetype. `riverinternaltest.BaseServiceArchetype`
-	// returns an archetype with sleep disabled.
+	// themselves from its archetype.
 	DisableSleep bool
 
 	// Logger is a structured logger.
@@ -36,6 +35,14 @@ type Archetype struct {
 	// injection. Services should try to use this function instead of the
 	// vanilla ones from the `time` package for testing purposes.
 	TimeNowUTC func() time.Time
+}
+
+// WithSleepDisabled disables sleep in services that are using `BaseService`'s
+// `CancellableSleep` functions and returns the archetype for convenience. Use
+// of this is only appropriate in tests.
+func (a *Archetype) WithSleepDisabled() *Archetype {
+	a.DisableSleep = true
+	return a
 }
 
 // BaseService is a struct that's meant to be embedded on "service-like" objects

--- a/internal/baseservice/base_service_test.go
+++ b/internal/baseservice/base_service_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestArchetype_WithSleepDisabled(t *testing.T) {
+	t.Parallel()
+
+	archetype := (&Archetype{}).WithSleepDisabled()
+	require.True(t, archetype.DisableSleep)
+}
+
 func TestInit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/jobcompleter/job_completer_test.go
+++ b/internal/jobcompleter/job_completer_test.go
@@ -42,7 +42,7 @@ func TestInlineJobCompleter_Complete(t *testing.T) {
 		},
 	}
 
-	completer := NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t), adapter)
+	completer := NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), adapter)
 	t.Cleanup(completer.Wait)
 
 	err := completer.JobSetStateIfRunning(&jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(1, time.Now()))
@@ -58,7 +58,7 @@ func TestInlineJobCompleter_Subscribe(t *testing.T) {
 	t.Parallel()
 
 	testCompleterSubscribe(t, func(exec PartialExecutor) JobCompleter {
-		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t), exec)
+		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec)
 	})
 }
 
@@ -66,7 +66,7 @@ func TestInlineJobCompleter_Wait(t *testing.T) {
 	t.Parallel()
 
 	testCompleterWait(t, func(exec PartialExecutor) JobCompleter {
-		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t), exec)
+		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec)
 	})
 }
 
@@ -96,7 +96,7 @@ func TestAsyncJobCompleter_Complete(t *testing.T) {
 			return nil, err
 		},
 	}
-	completer := NewAsyncCompleter(riverinternaltest.BaseServiceArchetype(t), adapter, 2)
+	completer := NewAsyncCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), adapter, 2)
 	t.Cleanup(completer.Wait)
 
 	// launch 4 completions, only 2 can be inline due to the concurrency limit:
@@ -159,7 +159,7 @@ func TestAsyncJobCompleter_Subscribe(t *testing.T) {
 	t.Parallel()
 
 	testCompleterSubscribe(t, func(exec PartialExecutor) JobCompleter {
-		return NewAsyncCompleter(riverinternaltest.BaseServiceArchetype(t), exec, 4)
+		return NewAsyncCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec, 4)
 	})
 }
 
@@ -167,7 +167,7 @@ func TestAsyncJobCompleter_Wait(t *testing.T) {
 	t.Parallel()
 
 	testCompleterWait(t, func(exec PartialExecutor) JobCompleter {
-		return NewAsyncCompleter(riverinternaltest.BaseServiceArchetype(t), exec, 4)
+		return NewAsyncCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec, 4)
 	})
 }
 

--- a/internal/maintenance/job_cleaner_test.go
+++ b/internal/maintenance/job_cleaner_test.go
@@ -39,7 +39,7 @@ func TestJobCleaner(t *testing.T) {
 		}
 
 		cleaner := NewJobCleaner(
-			riverinternaltest.BaseServiceArchetype(t),
+			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
 			&JobCleanerConfig{
 				CancelledJobRetentionPeriod: CancelledJobRetentionPeriodDefault,
 				CompletedJobRetentionPeriod: CompletedJobRetentionPeriodDefault,
@@ -56,7 +56,7 @@ func TestJobCleaner(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
 		t.Parallel()
 
-		cleaner := NewJobCleaner(riverinternaltest.BaseServiceArchetype(t), &JobCleanerConfig{}, nil)
+		cleaner := NewJobCleaner(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), &JobCleanerConfig{}, nil)
 
 		require.Equal(t, CancelledJobRetentionPeriodDefault, cleaner.Config.CancelledJobRetentionPeriod)
 		require.Equal(t, CompletedJobRetentionPeriodDefault, cleaner.Config.CompletedJobRetentionPeriod)

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -69,7 +69,7 @@ func TestJobRescuer(t *testing.T) {
 		}
 
 		rescuer := NewRescuer(
-			riverinternaltest.BaseServiceArchetype(t),
+			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
 			&JobRescuerConfig{
 				ClientRetryPolicy: &SimpleClientRetryPolicy{},
 				Interval:          JobRescuerIntervalDefault,
@@ -92,7 +92,7 @@ func TestJobRescuer(t *testing.T) {
 		t.Parallel()
 
 		cleaner := NewRescuer(
-			riverinternaltest.BaseServiceArchetype(t),
+			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
 			&JobRescuerConfig{
 				ClientRetryPolicy:   &SimpleClientRetryPolicy{},
 				WorkUnitFactoryFunc: func(kind string) workunit.WorkUnitFactory { return nil },

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -36,7 +36,7 @@ func TestJobScheduler(t *testing.T) {
 		}
 
 		scheduler := NewScheduler(
-			riverinternaltest.BaseServiceArchetype(t),
+			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
 			&JobSchedulerConfig{
 				Interval: JobSchedulerIntervalDefault,
 				Limit:    10,
@@ -72,7 +72,7 @@ func TestJobScheduler(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
 		t.Parallel()
 
-		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t), &JobSchedulerConfig{}, nil)
+		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), &JobSchedulerConfig{}, nil)
 
 		require.Equal(t, JobSchedulerIntervalDefault, scheduler.config.Interval)
 		require.Equal(t, JobSchedulerLimitDefault, scheduler.config.Limit)

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -55,7 +55,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 			waitChan: make(chan struct{}),
 		}
 
-		archetype := riverinternaltest.BaseServiceArchetype(t)
+		archetype := riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled()
 
 		svc := NewPeriodicJobEnqueuer(
 			archetype,

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -29,7 +29,7 @@ type testService struct {
 func newTestService(tb testing.TB) *testService {
 	tb.Helper()
 
-	testSvc := baseservice.Init(riverinternaltest.BaseServiceArchetype(tb), &testService{})
+	testSvc := baseservice.Init(riverinternaltest.BaseServiceArchetype(tb).WithSleepDisabled(), &testService{})
 	testSvc.testSignals.Init()
 
 	return testSvc
@@ -70,7 +70,7 @@ func TestQueueMaintainer(t *testing.T) {
 	setup := func(t *testing.T, services []Service) *QueueMaintainer {
 		t.Helper()
 
-		maintainer := NewQueueMaintainer(riverinternaltest.BaseServiceArchetype(t), services)
+		maintainer := NewQueueMaintainer(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), services)
 
 		return maintainer
 	}
@@ -93,7 +93,7 @@ func TestQueueMaintainer(t *testing.T) {
 		tx := riverinternaltest.TestTx(ctx, t)
 		sharedTx := sharedtx.NewSharedTx(tx)
 
-		archetype := riverinternaltest.BaseServiceArchetype(t)
+		archetype := riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled()
 		archetype.Logger = riverinternaltest.LoggerWarn(t) // loop started/stop log is very noisy; suppress
 
 		driver := riverpgxv5.New(nil).UnwrapExecutor(sharedTx)

--- a/internal/maintenance/reindexer_test.go
+++ b/internal/maintenance/reindexer_test.go
@@ -31,7 +31,7 @@ func TestReindexer(t *testing.T) {
 			now:  time.Now(),
 		}
 
-		archetype := riverinternaltest.BaseServiceArchetype(t)
+		archetype := riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled()
 		archetype.TimeNowUTC = func() time.Time { return bundle.now }
 
 		fromNow := func(d time.Duration) func(time.Time) time.Time {

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -56,9 +56,8 @@ func BaseServiceArchetype(tb testing.TB) *baseservice.Archetype {
 	tb.Helper()
 
 	return &baseservice.Archetype{
-		DisableSleep: true,
-		Logger:       Logger(tb),
-		TimeNowUTC:   func() time.Time { return time.Now().UTC() },
+		Logger:     Logger(tb),
+		TimeNowUTC: func() time.Time { return time.Now().UTC() },
 	}
 }
 


### PR DESCRIPTION
The `riverinternaltest.BaseServiceArchetype` test helper has up until
now return an archetype with sleep disabled, with the idea that
deactivating it by default derisked the possibility that tests would
accidentally introduce sleep invocations that'd make them slow.

(Note this only works for invocations of `BaseService.CancellableSleep`
which a lot of River doesn't use.)

This made more sense when the main use of the archetype was in in the
queue maintenance services, which all start up with a short jittered
sleep so that they don't all go for the database at the same time.

But since then, the use of archetype has become more widespread, and
disabling sleep probably doesn't make sense in most situations,
especially when testing at the client level. It'd have the effect of
making all the queue maintenance services run more aggressively than
they would by default, which isn't desirable, and may even lead to
contention problems.

Here, add a `WithSleepDisabled()` helper to archetype that lets sleep be
disabled easily in tests that want to do that (and add invocations of it
to each of the queue maintainer tests), but keep sleep on everywhere
else.