### PR TITLE
Implement `rivertest.RequireNotInserted` test helper (inverse of `RequireInserted`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RequireNotInserted` test helper (in addition to the existing `RequireInserted`) that verifies that a job with matching conditions was _not_ inserted. [PR #237](https://github.com/riverqueue/river/pull/237).
+
 ## [0.5.0] - 2024-05-03
 
 ⚠️ Version 0.5.0 contains a new database migration, version 4. This migration is backward compatible with any River installation running the v3 migration. Be sure to run the v4 migration prior to deploying the code from this release.

--- a/rivertest/rivertest_test.go
+++ b/rivertest/rivertest_test.go
@@ -148,42 +148,6 @@ func TestRequireInsertedTx(t *testing.T) {
 		require.True(t, bundle.mockT.Failed)
 	})
 
-	t.Run("VerifiesInsertOpts", func(t *testing.T) {
-		t.Parallel()
-
-		riverClient, bundle := setup(t)
-
-		// Verify default insertion options.
-		_, err := riverClient.InsertTx(ctx, bundle.tx, Job1Args{String: "foo"}, nil)
-		require.NoError(t, err)
-
-		_ = requireInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job1Args{}, &RequireInsertedOpts{
-			MaxAttempts: river.MaxAttemptsDefault,
-			Priority:    1,
-			Queue:       river.QueueDefault,
-		})
-		require.False(t, bundle.mockT.Failed)
-
-		// Verify custom insertion options.
-		_, err = riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, &river.InsertOpts{
-			MaxAttempts: 78,
-			Priority:    2,
-			Queue:       "another_queue",
-			ScheduledAt: testTime,
-			Tags:        []string{"tag1"},
-		})
-		require.NoError(t, err)
-
-		_ = requireInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
-			MaxAttempts: 78,
-			Priority:    2,
-			Queue:       "another_queue",
-			ScheduledAt: testTime,
-			Tags:        []string{"tag1"},
-		})
-		require.False(t, bundle.mockT.Failed)
-	})
-
 	t.Run("FailsWithoutInsert", func(t *testing.T) {
 		t.Parallel()
 
@@ -220,7 +184,10 @@ func TestRequireInsertedTx(t *testing.T) {
 	t.Run("FailsOnWrongJobInsert", func(t *testing.T) {
 		t.Parallel()
 
-		_, bundle := setup(t)
+		riverClient, bundle := setup(t)
+
+		_, err := riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, nil)
+		require.NoError(t, err)
 
 		_ = requireInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job1Args{}, nil)
 		require.True(t, bundle.mockT.Failed)
@@ -229,13 +196,13 @@ func TestRequireInsertedTx(t *testing.T) {
 			bundle.mockT.LogOutput())
 	})
 
-	t.Run("FailsOnInsertOpts", func(t *testing.T) {
+	t.Run("InsertOpts", func(t *testing.T) {
 		t.Parallel()
 
 		riverClient, bundle := setup(t)
 
 		// Verify custom insertion options.
-		_, err := riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, &river.InsertOpts{
+		insertRes, err := riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, &river.InsertOpts{
 			MaxAttempts: 78,
 			Priority:    2,
 			Queue:       "another_queue",
@@ -243,108 +210,402 @@ func TestRequireInsertedTx(t *testing.T) {
 			Tags:        []string{"tag1"},
 		})
 		require.NoError(t, err)
+		job := insertRes.Job
 
-		// Max attempts
-		{
-			mockT := NewMockT(t)
-			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
-				MaxAttempts: 77,
+		emptyOpts := func() *RequireInsertedOpts { return &RequireInsertedOpts{} }
+
+		sameOpts := func() *RequireInsertedOpts {
+			return &RequireInsertedOpts{
+				MaxAttempts: 78,
 				Priority:    2,
 				Queue:       "another_queue",
 				ScheduledAt: testTime,
 				State:       rivertype.JobStateScheduled,
 				Tags:        []string{"tag1"},
-			})
+			}
+		}
+
+		t.Run("MaxAttempts", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := sameOpts()
+			opts.MaxAttempts = 77
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
 			require.True(t, mockT.Failed)
 			require.Equal(t,
 				failureString("Job with kind 'job2' max attempts 78 not equal to expected 77")+"\n",
 				mockT.LogOutput())
-		}
+		})
 
-		// Priority
-		{
+		t.Run("Priority", func(t *testing.T) {
 			mockT := NewMockT(t)
-			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
-				MaxAttempts: 78,
-				Priority:    3,
-				Queue:       "another_queue",
-				ScheduledAt: testTime,
-				State:       rivertype.JobStateScheduled,
-				Tags:        []string{"tag1"},
-			})
+			opts := sameOpts()
+			opts.Priority = 3
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
 			require.True(t, mockT.Failed)
 			require.Equal(t,
 				failureString("Job with kind 'job2' priority 2 not equal to expected 3")+"\n",
 				mockT.LogOutput())
-		}
+		})
 
-		// Queue
-		{
+		t.Run("Queue", func(t *testing.T) {
 			mockT := NewMockT(t)
-			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
-				MaxAttempts: 78,
-				Priority:    2,
-				Queue:       "wrong-queue",
-				ScheduledAt: testTime,
-				State:       rivertype.JobStateScheduled,
-				Tags:        []string{"tag1"},
-			})
+			opts := sameOpts()
+			opts.Queue = "wrong_queue"
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
 			require.True(t, mockT.Failed)
 			require.Equal(t,
-				failureString("Job with kind 'job2' queue 'another_queue' not equal to expected 'wrong-queue'")+"\n",
+				failureString("Job with kind 'job2' queue 'another_queue' not equal to expected 'wrong_queue'")+"\n",
 				mockT.LogOutput())
-		}
+		})
 
-		// Scheduled at
-		{
+		t.Run("ScheduledAt", func(t *testing.T) {
 			mockT := NewMockT(t)
-			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
-				MaxAttempts: 78,
-				Priority:    2,
-				Queue:       "another_queue",
-				ScheduledAt: testTime.Add(3*time.Minute + 23*time.Second + 123*time.Microsecond),
-				State:       rivertype.JobStateScheduled,
-				Tags:        []string{"tag1"},
-			})
+			opts := sameOpts()
+			opts.ScheduledAt = testTime.Add(3*time.Minute + 23*time.Second + 123*time.Microsecond)
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
 			require.True(t, mockT.Failed)
 			require.Equal(t,
 				failureString("Job with kind 'job2' scheduled at 2023-10-30T10:45:23.000123Z not equal to expected 2023-10-30T10:48:46.000246Z")+"\n",
 				mockT.LogOutput())
-		}
+		})
 
-		// State
-		{
+		t.Run("State", func(t *testing.T) {
 			mockT := NewMockT(t)
-			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
-				MaxAttempts: 78,
-				Priority:    2,
-				Queue:       "another_queue",
-				ScheduledAt: testTime,
-				State:       rivertype.JobStateCancelled,
-				Tags:        []string{"tag1"},
-			})
+			opts := sameOpts()
+			opts.State = rivertype.JobStateCancelled
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
 			require.True(t, mockT.Failed)
 			require.Equal(t,
 				failureString("Job with kind 'job2' state 'scheduled' not equal to expected 'cancelled'")+"\n",
 				mockT.LogOutput())
-		}
+		})
 
-		// Tags
-		{
+		t.Run("Tags", func(t *testing.T) {
 			mockT := NewMockT(t)
-			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, &RequireInsertedOpts{
+			opts := sameOpts()
+			opts.Tags = []string{"tag2"}
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' tags [tag1] not equal to expected [tag2]")+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("MultiplePropertiesSucceed", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.MaxAttempts = job.MaxAttempts
+			opts.Priority = job.Priority
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.False(t, mockT.Failed, "Should have succeeded, but failed with: "+mockT.LogOutput())
+		})
+
+		t.Run("MultiplePropertiesFails", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := sameOpts()
+			opts.MaxAttempts = 77
+			opts.Priority = 3
+			_ = requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' max attempts 78 not equal to expected 77, priority 2 not equal to expected 3")+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("AllSameSucceeds", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := sameOpts()
+			requireInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.False(t, mockT.Failed)
+		})
+	})
+}
+
+// The tests for this function are quite minimal because it uses the same
+// implementation as the `*Tx` variant, so most of the test happens below.
+func TestRequireNotInserted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		dbPool *pgxpool.Pool
+		mockT  *MockT
+	}
+
+	setup := func(t *testing.T) (*river.Client[pgx.Tx], *testBundle) {
+		t.Helper()
+
+		dbPool := riverinternaltest.TestDB(ctx, t)
+
+		riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{})
+		require.NoError(t, err)
+
+		return riverClient, &testBundle{
+			dbPool: dbPool,
+			mockT:  NewMockT(t),
+		}
+	}
+
+	t.Run("VerifiesNotInsert", func(t *testing.T) {
+		t.Parallel()
+
+		riverClient, bundle := setup(t)
+
+		_, err := riverClient.Insert(ctx, Job2Args{Int: 123}, nil)
+		require.NoError(t, err)
+
+		requireNotInserted(ctx, t, riverpgxv5.New(bundle.dbPool), &Job1Args{}, nil)
+		require.False(t, bundle.mockT.Failed)
+	})
+}
+
+func TestRequireNotInsertedTx(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		mockT *MockT
+		tx    pgx.Tx
+	}
+
+	setup := func(t *testing.T) (*river.Client[pgx.Tx], *testBundle) {
+		t.Helper()
+
+		riverClient, err := river.NewClient(riverpgxv5.New(nil), &river.Config{})
+		require.NoError(t, err)
+
+		return riverClient, &testBundle{
+			mockT: NewMockT(t),
+			tx:    riverinternaltest.TestTx(ctx, t),
+		}
+	}
+
+	t.Run("VerifiesInsert", func(t *testing.T) {
+		t.Parallel()
+
+		riverClient, bundle := setup(t)
+
+		_, err := riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, nil)
+		require.NoError(t, err)
+
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, t, bundle.tx, &Job1Args{}, nil)
+		require.False(t, bundle.mockT.Failed)
+	})
+
+	t.Run("VerifiesMultiple", func(t *testing.T) {
+		t.Parallel()
+
+		_, bundle := setup(t)
+
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, t, bundle.tx, &Job1Args{}, nil)
+		require.False(t, bundle.mockT.Failed)
+
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, t, bundle.tx, &Job2Args{}, nil)
+		require.False(t, bundle.mockT.Failed)
+	})
+
+	t.Run("TransactionVisibility", func(t *testing.T) {
+		t.Parallel()
+
+		riverClient, bundle := setup(t)
+
+		// Start a second transaction with different visibility.
+		otherTx := riverinternaltest.TestTx(ctx, t)
+
+		_, err := riverClient.InsertTx(ctx, bundle.tx, Job1Args{String: "foo"}, nil)
+		require.NoError(t, err)
+
+		// Not visible in the second transaction.
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, otherTx, &Job1Args{}, nil)
+		require.False(t, bundle.mockT.Failed)
+
+		// Visible in the original transaction.
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job1Args{}, nil)
+		require.True(t, bundle.mockT.Failed)
+	})
+
+	t.Run("SucceedsWithoutInsert", func(t *testing.T) {
+		t.Parallel()
+
+		_, bundle := setup(t)
+
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job2Args{}, nil)
+		require.False(t, bundle.mockT.Failed)
+	})
+
+	t.Run("FailsWithTooManyInserts", func(t *testing.T) {
+		t.Parallel()
+
+		riverClient, bundle := setup(t)
+
+		_, err := riverClient.InsertManyTx(ctx, bundle.tx, []river.InsertManyParams{
+			{Args: Job1Args{String: "foo"}},
+			{Args: Job1Args{String: "bar"}},
+		})
+		require.NoError(t, err)
+
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job1Args{}, nil)
+		require.True(t, bundle.mockT.Failed)
+		require.Equal(t,
+			failureString("2 jobs found with kind, but expected to find none: job1")+"\n",
+			bundle.mockT.LogOutput())
+	})
+
+	t.Run("SucceedsOnWrongJobInsert", func(t *testing.T) {
+		t.Parallel()
+
+		riverClient, bundle := setup(t)
+
+		_, err := riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, nil)
+		require.NoError(t, err)
+
+		requireNotInsertedTx[*riverpgxv5.Driver](ctx, bundle.mockT, bundle.tx, &Job1Args{}, nil)
+		require.False(t, bundle.mockT.Failed)
+	})
+
+	t.Run("InsertOpts", func(t *testing.T) {
+		t.Parallel()
+
+		riverClient, bundle := setup(t)
+
+		// Verify custom insertion options.
+		insertRes, err := riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, &river.InsertOpts{
+			MaxAttempts: 78,
+			Priority:    2,
+			Queue:       "another_queue",
+			ScheduledAt: testTime,
+			Tags:        []string{"tag1"},
+		})
+		require.NoError(t, err)
+		job := insertRes.Job
+
+		emptyOpts := func() *RequireInsertedOpts { return &RequireInsertedOpts{} }
+
+		sameOpts := func() *RequireInsertedOpts {
+			return &RequireInsertedOpts{
 				MaxAttempts: 78,
 				Priority:    2,
 				Queue:       "another_queue",
 				ScheduledAt: testTime,
 				State:       rivertype.JobStateScheduled,
-				Tags:        []string{"tag2"},
-			})
+				Tags:        []string{"tag1"},
+			}
+		}
+
+		t.Run("MaxAttempts", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.MaxAttempts = job.MaxAttempts
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
 			require.True(t, mockT.Failed)
 			require.Equal(t,
-				failureString("Job with kind 'job2' tags attempts [tag1] not equal to expected [tag2]")+"\n",
+				failureString("Job with kind 'job2' max attempts equal to excluded %d", job.MaxAttempts)+"\n",
 				mockT.LogOutput())
-		}
+		})
+
+		t.Run("Priority", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.Priority = job.Priority
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' priority equal to excluded %d", job.Priority)+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("Queue", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.Queue = job.Queue
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' queue equal to excluded '%s'", job.Queue)+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("ScheduledAt", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.ScheduledAt = job.ScheduledAt
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' scheduled at equal to excluded %s", opts.ScheduledAt.Format(rfc3339Micro))+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("State", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.State = job.State
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' state equal to excluded '%s'", job.State)+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("Tags", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.Tags = job.Tags
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' tags equal to excluded %+v", job.Tags)+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("MultiplePropertiesSucceed", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.MaxAttempts = job.MaxAttempts // one property matches job, but the other does not
+			opts.Priority = 3
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.False(t, mockT.Failed, "Should have succeeded, but failed with: "+mockT.LogOutput())
+		})
+
+		t.Run("MultiplePropertiesFail", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.MaxAttempts = job.MaxAttempts
+			opts.Priority = job.Priority
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' max attempts equal to excluded %d, priority equal to excluded %d", job.MaxAttempts, job.Priority)+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("AllSameFails", func(t *testing.T) {
+			mockT := NewMockT(t)
+			opts := sameOpts()
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' max attempts equal to excluded %d, priority equal to excluded %d, queue equal to excluded '%s', scheduled at equal to excluded %s, state equal to excluded '%s', tags equal to excluded %+v", job.MaxAttempts, job.Priority, job.Queue, job.ScheduledAt.Format(rfc3339Micro), job.State, job.Tags)+"\n",
+				mockT.LogOutput())
+		})
+
+		t.Run("FailsWithTooManyInserts", func(t *testing.T) {
+			_, err := riverClient.InsertTx(ctx, bundle.tx, Job2Args{Int: 123}, &river.InsertOpts{
+				Priority: 3,
+			})
+			require.NoError(t, err)
+
+			mockT := NewMockT(t)
+			opts := emptyOpts()
+			opts.Priority = 3
+			requireNotInsertedTx[*riverpgxv5.Driver](ctx, mockT, bundle.tx, &Job2Args{}, opts)
+			require.True(t, mockT.Failed)
+			require.Equal(t,
+				failureString("Job with kind 'job2' priority equal to excluded %d", 3)+"\n",
+				mockT.LogOutput())
+		})
 	})
 }
 
@@ -792,7 +1053,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 			})
 			require.True(t, mockT.Failed)
 			require.Equal(t,
-				failureString("Job with kind 'job2' (expected job slice index 0) tags attempts [tag1] not equal to expected [tag2]")+"\n",
+				failureString("Job with kind 'job2' (expected job slice index 0) tags [tag1] not equal to expected [tag2]")+"\n",
 				mockT.LogOutput())
 		}
 	})


### PR DESCRIPTION
Here, introduce a new test helper for `rivertest.RequireNotInserted`,
which fails in cases where a job matching in the input kind and
(optional) properties _was_ inserted rather than was not. Its purpose is
to invert the checks made by the existing `RequireInserted`.

Unlike `RequireInserted`, I _didn't_ implement a batch version of the
helper like `RequireNotInsertedMany`. I was going to do it, but after
thinking about it for a while, I don't think it really makes sense.
`RequireInsertedMany` is useful because it allows you to verify a
sequence of job inserts that occurred in a particular order with
particular options. There's no sequence for jobs that weren't inserted,
so the only thing a `RequireNotInsertedMany` would do is verify that
many different job kinds were all not inserted as part of one operation,
which doesn't really seem that useful. I figure if there's demand we can
think about adding a batch helper, but it may be better to not do so
prospectively to keep the API smaller, and avoiding adding a function
that doesn't end up getting any use.