### PR TITLE
Prepare for release `v0.0.23`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.23] - 2024-02-29
+
 ### Added
 
 - `JobListParams.Kinds()` has been added so that jobs can now be listed by kind. [PR #212](https://github.com/riverqueue/river/pull/212).

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.22
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.22
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.22
-	github.com/riverqueue/river/rivertype v0.0.22
+	github.com/riverqueue/river/riverdriver v0.0.23
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.23
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.23
+	github.com/riverqueue/river/rivertype v0.0.23
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.0.20
+require github.com/riverqueue/river/rivertype v0.0.23

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.22
-	github.com/riverqueue/river/rivertype v0.0.22
+	github.com/riverqueue/river/riverdriver v0.0.23
+	github.com/riverqueue/river/rivertype v0.0.23
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.22
-	github.com/riverqueue/river/rivertype v0.0.22
+	github.com/riverqueue/river/riverdriver v0.0.23
+	github.com/riverqueue/river/rivertype v0.0.23
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Tee up the `v0.0.23` release. This contains a large refactor in #212
that changes substantial code, and an important memory leak fix from #240.