### PR TITLE
fix memory leak of job cancellation contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a memory leak caused by not always cancelling the context used to enable jobs to be cancelled remotely. [PR #243](https://github.com/riverqueue/river/pull/243).
+
 ## [0.0.23] - 2024-02-29
 
 ### Added

--- a/job_executor.go
+++ b/job_executor.go
@@ -17,6 +17,10 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
+// Error used in CancelFunc in cases where the job was not cancelled for
+// purposes of resource cleanup. Should never be user visible.
+var errExecutorDefaultCancel = errors.New("context cancelled as executor finished")
+
 // UnknownJobKindError is returned when a Client fetches and attempts to
 // work a job that has not been registered on the Client's Workers bundle (using
 // AddWorker).
@@ -139,7 +143,7 @@ func (e *jobExecutor) Cancel() {
 
 func (e *jobExecutor) Execute(ctx context.Context) {
 	// Ensure that the context is cancelled no matter what, or it will leak:
-	defer e.CancelFunc(nil)
+	defer e.CancelFunc(errExecutorDefaultCancel)
 
 	e.start = e.TimeNowUTC()
 	e.stats = &jobstats.JobStatistics{

--- a/job_executor.go
+++ b/job_executor.go
@@ -138,6 +138,9 @@ func (e *jobExecutor) Cancel() {
 }
 
 func (e *jobExecutor) Execute(ctx context.Context) {
+	// Ensure that the context is cancelled no matter what, or it will leak:
+	defer e.CancelFunc(nil)
+
 	e.start = e.TimeNowUTC()
 	e.stats = &jobstats.JobStatistics{
 		QueueWaitDuration: e.start.Sub(e.JobRow.ScheduledAt),

--- a/producer.go
+++ b/producer.go
@@ -358,6 +358,7 @@ func (p *producer) startNewExecutors(workCtx context.Context, jobs []*rivertype.
 			workUnit = workInfo.workUnitFactory.MakeUnit(job)
 		}
 
+		// jobCancel will always be called by the executor to prevent leaks.
 		jobCtx, jobCancel := context.WithCancelCause(workCtx)
 
 		executor := baseservice.Init(&p.Archetype, &jobExecutor{


### PR DESCRIPTION
When remote job cancellation was added, a new cancellable context was allocated within the producer before the executor is spawned. The cancel func here was only called if the job was actually cancelled remotely or via a parent context cancellation, meaning we would slowly leak memory for every job worked that wasn't cancelled.

In my recent testing, the memory usage of my sample program is now stable. After churning through >100k jobs with pprof running, it's still cruising at ~17MB usage.

Thank you @brandur for pinpointing the issue, and @shawnstephens for getting us to look into it :pray:

Fixes #239.