### PR TITLE
Add `rivertype` module to release instructions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -45,6 +45,7 @@ git tag cmd/river/$VERSION -m "release cmd/river/$VERSION"
 git tag riverdriver/$VERSION -m "release riverdriver/$VERSION"
 git tag riverdriver/riverpgxv5/$VERSION -m "release riverdriver/riverpgxv5/$VERSION"
 git tag riverdriver/riverdatabasesql/$VERSION -m "release riverdriver/riverdatabasesql/$VERSION"
+git tag rivertype/$VERSION -m "release rivertype/$VERSION"
 git tag $VERSION
 git push --tags
 ```

--- a/internal/cmd/update-submodule-versions/main.go
+++ b/internal/cmd/update-submodule-versions/main.go
@@ -24,6 +24,7 @@ var allProjectModules = []string{ //nolint:gochecknoglobals
 	"./riverdriver",
 	"./riverdriver/riverdatabasesql",
 	"./riverdriver/riverpgxv5",
+	"./rivertype",
 }
 
 func main() {


### PR DESCRIPTION
As of #212, `rivertype` became a separate Go module from the mainline
`river`. Here, add it to the release instructions so that it gets
properly tagged along with other all other modules.

Also add it to the `update-submodule-versions` program. This isn't
strictly necessary because `rivertype` doesn't have any submodule
versions to update, but it feels like it should be there for
completeness just in case, and also because it makes the list in the
program a complete list of all Go modules in the project.