### PR TITLE
Tee up release `v0.0.24`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.24] - 2024-02-29
+
 ### Fixed
 
 - Fixed a memory leak caused by not always cancelling the context used to enable jobs to be cancelled remotely. [PR #243](https://github.com/riverqueue/river/pull/243).

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.23
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.23
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.23
-	github.com/riverqueue/river/rivertype v0.0.23
+	github.com/riverqueue/river/riverdriver v0.0.24
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.24
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.24
+	github.com/riverqueue/river/rivertype v0.0.24
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.0.23
+require github.com/riverqueue/river/rivertype v0.0.24

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.23
-	github.com/riverqueue/river/rivertype v0.0.23
+	github.com/riverqueue/river/riverdriver v0.0.24
+	github.com/riverqueue/river/rivertype v0.0.24
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.23
-	github.com/riverqueue/river/rivertype v0.0.23
+	github.com/riverqueue/river/riverdriver v0.0.24
+	github.com/riverqueue/river/rivertype v0.0.24
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Prepares `v0.0.24`, a small release, but one which contains an important
fix from #243 which resolves a context memory leak that'd cause River's
memory usage to bloat over time.