### PR TITLE
`riverdrivertest`: Decrease tolerance required in inserted timestamps

### DIFF
--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -1382,8 +1382,8 @@ func ExerciseExecutorFull[TTx any](ctx context.Context, t *testing.T, driver riv
 			TTL:      leaderTTL,
 		})
 		require.NoError(t, err)
-		require.WithinDuration(t, time.Now(), leader.ElectedAt, 100*time.Millisecond)
-		require.WithinDuration(t, time.Now().Add(leaderTTL), leader.ExpiresAt, 100*time.Millisecond)
+		require.WithinDuration(t, time.Now(), leader.ElectedAt, 500*time.Millisecond)
+		require.WithinDuration(t, time.Now().Add(leaderTTL), leader.ExpiresAt, 500*time.Millisecond)
 		require.Equal(t, leaderInstanceName, leader.Name)
 		require.Equal(t, clientID, leader.LeaderID)
 	})
@@ -1400,8 +1400,8 @@ func ExerciseExecutorFull[TTx any](ctx context.Context, t *testing.T, driver riv
 
 		leader, err := exec.LeaderGetElectedLeader(ctx, leaderInstanceName)
 		require.NoError(t, err)
-		require.WithinDuration(t, time.Now(), leader.ElectedAt, 100*time.Millisecond)
-		require.WithinDuration(t, time.Now().Add(leaderTTL), leader.ExpiresAt, 100*time.Millisecond)
+		require.WithinDuration(t, time.Now(), leader.ElectedAt, 500*time.Millisecond)
+		require.WithinDuration(t, time.Now().Add(leaderTTL), leader.ExpiresAt, 500*time.Millisecond)
 		require.Equal(t, leaderInstanceName, leader.Name)
 		require.Equal(t, clientID, leader.LeaderID)
 	})


### PR DESCRIPTION
Noticed a failure in one of the driver tests where it can take longer
than 100 milliseconds for an inserted row to have its timestamp compared
against the current time (not much longer, 143 ms versus 100 ms):

    $ go test .
    --- FAIL: TestDriverRiverPgxV5_Executor (0.00s)
        --- FAIL: TestDriverRiverPgxV5_Executor/LeaderGetElectedLeader (0.15s)
            riverdrivertest.go:1403:
                    Error Trace:    /Users/brandur/Documents/projects/river/internal/riverinternaltest/riverdrivertest/riverdrivertest.go:1403
                    Error:          Max difference between 2024-03-01 07:05:55.905609 -0800 PST m=+2.603374667 and 2024-03-01 15:05:55.763974 +0000 UTC allowed is 100ms, but difference was 141.635ms
                    Test:           TestDriverRiverPgxV5_Executor/LeaderGetElectedLeader
    FAIL
    FAIL    github.com/riverqueue/river     9.516s
    FAIL

This actually occurred locally rather than in GitHub Actions.

I believe these sorts of slowdowns can occur when you have a lot of
parallel tests running and the scheduling of goroutines becomes somewhat
less predictable. Increase tolerance from 100ms to 500ms.