### PR TITLE
Tee up version `v0.0.25`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.25] - 2024-03-01
+
 ### Fixed
 
 - Fixed a problem in `riverpgxv5`'s `Listener` where it wouldn't unset an internal connection if `Close` returned an error, making the listener not reusable. Thanks @mfrister for pointing this one out! [PR #246](https://github.com/riverqueue/river/pull/246).

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/jackc/pgx/v5 v5.5.3
 	github.com/jackc/puddle/v2 v2.2.1
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/riverqueue/river/riverdriver v0.0.24
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.24
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.24
-	github.com/riverqueue/river/rivertype v0.0.24
+	github.com/riverqueue/river/riverdriver v0.0.25
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.25
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.25
+	github.com/riverqueue/river/rivertype v0.0.25
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.0.24
+require github.com/riverqueue/river/rivertype v0.0.25

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.24
-	github.com/riverqueue/river/rivertype v0.0.24
+	github.com/riverqueue/river/riverdriver v0.0.25
+	github.com/riverqueue/river/rivertype v0.0.25
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0
-	github.com/riverqueue/river/riverdriver v0.0.24
-	github.com/riverqueue/river/rivertype v0.0.24
+	github.com/riverqueue/river/riverdriver v0.0.25
+	github.com/riverqueue/river/rivertype v0.0.25
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Contains an important fix from #246 which resolves a problem wherein a
listener from the `riverpgxv5` driver couldn't be reused in cases where
`Close` returned an error.