### PR TITLE
Make more client services into `startstop.Service`

### DIFF
--- a/internal/maintenance/queue_maintainer.go
+++ b/internal/maintenance/queue_maintainer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/riverqueue/river/internal/baseservice"
 	"github.com/riverqueue/river/internal/maintenance/startstop"
+	"github.com/riverqueue/river/internal/util/maputil"
 )
 
 const (
@@ -75,9 +76,7 @@ func (m *QueueMaintainer) Start(ctx context.Context) error {
 
 		<-ctx.Done()
 
-		for _, service := range m.servicesByName {
-			service.Stop()
-		}
+		startstop.StopAllParallel(maputil.Values(m.servicesByName))
 	}()
 
 	return nil

--- a/internal/maintenance/startstop/start_stop_test.go
+++ b/internal/maintenance/startstop/start_stop_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/riverqueue/river/internal/riverinternaltest"
 )
 
-type testService struct {
+type sampleService struct {
 	baseservice.BaseService
 	BaseStartStop
 
@@ -21,7 +21,7 @@ type testService struct {
 	state bool
 }
 
-func (s *testService) Start(ctx context.Context) error {
+func (s *sampleService) Start(ctx context.Context) error {
 	ctx, shouldStart, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
@@ -36,63 +36,160 @@ func (s *testService) Start(ctx context.Context) error {
 	return nil
 }
 
-func TestBaseStartStop_doubleStop(t *testing.T) {
-	t.Parallel()
+func testService(t *testing.T, newService func(t *testing.T) serviceWithStopped) {
+	t.Helper()
 
-	var (
-		ctx     = context.Background()
-		testSvc = &testService{}
-	)
+	ctx := context.Background()
 
-	require.NoError(t, testSvc.Start(ctx))
-	testSvc.Stop()
-	testSvc.Stop()
-}
+	type testBundle struct{}
 
-func TestBaseStartStop_stopWithoutStart(t *testing.T) {
-	t.Parallel()
+	setup := func(t *testing.T) (serviceWithStopped, *testBundle) {
+		t.Helper()
 
-	testSvc := &testService{}
-	testSvc.Stop()
-}
-
-func TestBaseStartStop_stopped(t *testing.T) {
-	t.Parallel()
-
-	var (
-		ctx     = context.Background()
-		testSvc = &testService{}
-	)
-
-	require.NoError(t, testSvc.Start(ctx))
-
-	// A reference to stopped must be procured _before_ stopping the service
-	// because the stopped channel is deinitialized as part of the stop
-	// procedure.
-	stopped := testSvc.Stopped()
-	testSvc.Stop()
-	riverinternaltest.WaitOrTimeout(t, stopped)
-}
-
-func TestBaseStartStop_stress(t *testing.T) {
-	t.Parallel()
-
-	var (
-		ctx     = context.Background()
-		testSvc = &testService{}
-		wg      sync.WaitGroup
-	)
-
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			for j := 0; j < 50; j++ {
-				require.NoError(t, testSvc.Start(ctx))
-				testSvc.Stop()
-			}
-			wg.Done()
-		}()
+		return newService(t), &testBundle{}
 	}
 
-	wg.Wait()
+	t.Run("DoubleStop", func(t *testing.T) {
+		t.Parallel()
+
+		service, _ := setup(t)
+
+		require.NoError(t, service.Start(ctx))
+		service.Stop()
+		service.Stop()
+	})
+
+	t.Run("StopWithoutStart", func(t *testing.T) {
+		t.Parallel()
+
+		service, _ := setup(t)
+
+		service.Stop()
+	})
+
+	t.Run("StoppedChannel", func(t *testing.T) {
+		t.Parallel()
+
+		service, _ := setup(t)
+
+		require.NoError(t, service.Start(ctx))
+
+		// A reference to stopped must be procured _before_ stopping the service
+		// because the stopped channel is deinitialized as part of the stop
+		// procedure.
+		stopped := service.Stopped()
+		service.Stop()
+		riverinternaltest.WaitOrTimeout(t, stopped)
+	})
+
+	t.Run("StartStopStress", func(t *testing.T) {
+		t.Parallel()
+
+		service, _ := setup(t)
+
+		var wg sync.WaitGroup
+
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				for j := 0; j < 50; j++ {
+					require.NoError(t, service.Start(ctx))
+					service.Stop()
+				}
+				wg.Done()
+			}()
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestBaseStartStop(t *testing.T) {
+	t.Parallel()
+
+	testService(t, func(t *testing.T) serviceWithStopped { t.Helper(); return &sampleService{} })
+}
+
+func TestBaseStartStopFunc(t *testing.T) {
+	t.Parallel()
+
+	makeFunc := func(t *testing.T) serviceWithStopped {
+		t.Helper()
+
+		// Some simple state in the service which a started service taints. The
+		// purpose of this variable is to allow us to detect a data race allowed by
+		// BaseStartStop.
+		var state bool
+
+		return StartStopFunc(func(ctx context.Context, shouldStart bool, stopped chan struct{}) error {
+			if !shouldStart {
+				return nil
+			}
+
+			go func() {
+				defer close(stopped)
+				state = true
+				t.Logf("State: %t", state) // here so variable doesn't register as unused
+				<-ctx.Done()
+			}()
+
+			return nil
+		})
+	}
+
+	testService(t, makeFunc)
+}
+
+func TestStopAllParallel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("Started", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			service1 = &sampleService{}
+			service2 = &sampleService{}
+			service3 = &sampleService{}
+		)
+
+		require.NoError(t, service1.Start(ctx))
+		require.NoError(t, service2.Start(ctx))
+		require.NoError(t, service3.Start(ctx))
+
+		var (
+			stopped1 = service1.Stopped()
+			stopped2 = service2.Stopped()
+			stopped3 = service3.Stopped()
+		)
+
+		StopAllParallel([]Service{
+			service1,
+			service2,
+			service3,
+		})
+
+		riverinternaltest.WaitOrTimeout(t, stopped1)
+		riverinternaltest.WaitOrTimeout(t, stopped2)
+		riverinternaltest.WaitOrTimeout(t, stopped3)
+	})
+
+	// We can't use the stopped channels in this case because they're only
+	// initiated when a service is started.
+	t.Run("NotStarted", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			service1 = &sampleService{}
+			service2 = &sampleService{}
+			service3 = &sampleService{}
+		)
+
+		StopAllParallel([]Service{
+			service1,
+			service2,
+			service3,
+		})
+	})
 }


### PR DESCRIPTION
Here, we aim to move in a direction where the client can treat most of
its subservices generically by starting/stopping the notifier as a
generic service, along with converting three other smaller services over
to use the `startstop.Service` interface:

* Client monitor. (This ends up cleaning up its internal code
  significantly, and has a major improvement on its test coverage and
  robustness.)

* The client's statistics logging loop.

* The client's leadership change handling loop.

Both the latter two are very small functions, so I implement the new
function `startstop.StartStopFunc` which similar to `river.WorkFunc`,
provides an easy way to get a small service using only a function, which
keeps the code quite clean.

It's going to take a few more changes to get our full simplification
change, but you can already see the beginnings of it as many services
can be started and stopped in ~one line:

    func (c *Client[TTx]) signalStopComplete(ctx context.Context) {
        // Wait for producers and elector to exit:
        c.wg.Wait()

        // Stop all mainline services where stop order isn't important.
        startstop.StopAllParallel(c.services)

By the end of it, both the elector and producers will also become
services, and we'll be able to fully eliminate the wait group, along
with the stop channels and the roundabout stop functions like
`signalStopComplete`. The idea is that the client itself will also
become a start/stop service, and itself become protected against being
started multiple times, or potential races where `Start`/`Stop` may be
called by multiple goroutines.