### PR TITLE
Fix build status badge in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# River [![Build Status](https://github.com/riverqueue/river/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/riverqueue/river/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/riverqueue/river.svg)](https://pkg.go.dev/github.com/riverqueue/river)
+# River [![Build Status](https://github.com/riverqueue/river/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/riverqueue/river/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/riverqueue/river.svg)](https://pkg.go.dev/github.com/riverqueue/river)
 
 River is a robust high-performance job processing system for Go and Postgres.
 


### PR DESCRIPTION
Rendering of the build status badge in the README on GitHub is currently
broken because of the change I made in #228 that changed the extension
of the CI file from `.yml` to `.yaml`. I didn't realize the filename was
in the badge's source path, but it is, and trying to locate `ci.yml` no
longer finds anything. Here, a very small change to fix the problem.