### PR TITLE
Add two minute timeouts to each `go test` invocation in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,23 +73,23 @@ jobs:
 
       - name: Test cmd/river
         working-directory: ./cmd/river
-        run: go test -race ./...
+        run: go test -race ./... -timeout 2m
 
       - name: Test riverdriver
         working-directory: ./riverdriver
-        run: go test -race ./...
+        run: go test -race ./... -timeout 2m
 
       - name: Test riverdriver/riverdatabasesql
         working-directory: ./riverdriver/riverdatabasesql
-        run: go test -race ./...
+        run: go test -race ./... -timeout 2m
 
       - name: Test riverdriver/riverpgxv5
         working-directory: ./riverdriver/riverpgxv5
-        run: go test -race ./...
+        run: go test -race ./... -timeout 2m
 
       - name: Test rivertype
         working-directory: ./rivertype
-        run: go test -race ./...
+        run: go test -race ./... -timeout 2m
 
   cli:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I accidentally snuck a `-timeout 2m` on the main `go test` invocation
last night as a I was debugging another problem and forgot to remove it.

Instead of removing it, here, double down and put `-timeout 2m` on every
`go test` invocation. The overall job still has a five minute timeout,
but it's really bad when you hit it because although the job is killed,
you get no information about what was happening. `go test . -timeout 2m`
is nice because if the timeout is hit, Go dumps the stack of every
goroutine that was still alive which can be extremely helpful for
debugging.

Two minutes is a little arbitrary, but I'm seeing test runs sticking
pretty close to one minute, so this is about ~2x overhead (for the main
River package anyway, all other packages are >10x overhead). We can
always bump it up further in case it's necessary to do so.