### PR TITLE
Make client a start/stop service

### DIFF
--- a/internal/riverinternaltest/startstoptest/startstoptest_test.go
+++ b/internal/riverinternaltest/startstoptest/startstoptest_test.go
@@ -2,8 +2,12 @@ package startstoptest
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"sync/atomic"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/internal/maintenance/startstop"
 	"github.com/riverqueue/river/internal/riverinternaltest"
@@ -11,13 +15,19 @@ import (
 
 type MyService struct {
 	startstop.BaseStartStop
-	logger *slog.Logger
+	logger   *slog.Logger
+	startErr error
 }
 
 func (s *MyService) Start(ctx context.Context) error {
 	ctx, shouldStart, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
+	}
+
+	if s.startErr != nil {
+		close(stopped)
+		return s.startErr
 	}
 
 	go func() {
@@ -39,3 +49,31 @@ func TestStress(t *testing.T) {
 
 	Stress(ctx, t, &MyService{logger: riverinternaltest.Logger(t)})
 }
+
+func TestStressErr(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	startErr := errors.New("error returned on start")
+
+	StressErr(ctx, t, &MyService{logger: riverinternaltest.Logger(t), startErr: startErr}, startErr)
+
+	mockT := newMockTestingT(t)
+	StressErr(ctx, mockT, &MyService{logger: riverinternaltest.Logger(t), startErr: errors.New("different error")}, startErr)
+	require.True(t, mockT.failed.Load())
+}
+
+type mockTestingT struct {
+	failed atomic.Bool
+	tb     testing.TB
+}
+
+func newMockTestingT(tb testing.TB) *mockTestingT {
+	tb.Helper()
+	return &mockTestingT{tb: tb}
+}
+
+func (t *mockTestingT) Errorf(format string, args ...interface{}) {}
+func (t *mockTestingT) FailNow()                                  { t.failed.Store(true) }
+func (t *mockTestingT) Helper()                                   { t.tb.Helper() }


### PR DESCRIPTION
Here, continue service refactoring to its ultimate conclusion, and make
the client itself a start/stop service, having a couple advantages:

* (IMO) considerably simplifies the start and stop code, putting it all
  in one place, and largely even one function. Fewer helpers to follow
  around to understand what's going on.

* Makes the client behave gracefully on double starts/stops.

* Allows the client to easily handle start/stop under duress. Any number
  of goroutines can be starting or stopping it simultaneously and it's
  guaranteed free from races.

Because the client's stop functions are different from the signature of
other start/stop services (taking a context and returning an error), I
had to modify the base start/stop service somewhat and allow for an
additional `StopInit` helper (like `StartInit`) that lets stop behavior
be customized while still providing race-free operations.