### PR TITLE
Fix intermittent test failure on periodic job enqueuer by raising "ready margin"

### DIFF
--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -163,7 +163,7 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 				// Add a small margin to the current time so we're not only
 				// running jobs that are already ready, but also ones ready at
 				// this exact moment or ready in the very near future.
-				nowWithMargin := now.Add(10 * time.Millisecond)
+				nowWithMargin := now.Add(100 * time.Millisecond)
 
 				for _, periodicJob := range s.periodicJobs {
 					if !periodicJob.nextRunAt.Before(nowWithMargin) {

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -90,6 +90,15 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		startstoptest.Stress(ctx, t, svc)
 	})
 
+	// This test run is somewhat susceptible to the "ready margin" applied on
+	// enqueuer loops to find jobs that aren't quite ready yet, but close
+	// enough. The 500 ms/1500 ms job types can have their ready times diverge
+	// slightly as they're enqueued separately. Usually they're ~identical, but
+	// a large enough divergence which can occur with `-race` and a hundred test
+	// iterations can cause the test to fail as an expected job wasn't enqueued
+	// on the expected loop. The ready margin is currently high enough (100 ms)
+	// that this problem won't occur, but in case it's ever substantially
+	// lowered, this test will need to be rewritten.
 	t.Run("EnqueuesPeriodicJobs", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
This one's aimed at fixing the intermittent test described in #215. By
reading some additional logging probes in #271, I've been able to see
that the failures occur when the two jobs in the test case, 500ms and
1500ms, have their ready times diverge ever so slightly across run
iterations, which given enough test runs, can diverge enough so that
both jobs aren't ready on the last check where they're supposed to sync
up.

There's a few different potential ways to solve this one, most involving
rewriting the test, but here I'm proposing that we solve it by
increasing the "now margin" in the enqueuer from 10ms to 100ms. This is
a small margin applied on each run loop that look for jobs that are not
quite ready, but so close to ready that we enqueue them anyway. The
choice of 10ms originally was somewhat arbitrary, and 100ms isn't a
substantially larger number and still makes sense, so I think this is a
reasonable resolution.

I verified the fix works by pushing it up in the repro bootstrap in #271
that runs with `-race` and high iteration count in the slower GitHub CI
environment. It moves the CI matrix from failing on every job on every
run to succeeding on every job on every run.

Fixes #215.