### PR TITLE
Make more River logging debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The level of some of River's common log statements has changed, most often demoting `info` statements to `debug` so that `info`-level logging is overall less verbose. [PR #275](https://github.com/riverqueue/river/pull/275).
+
 ## [0.1.0] - 2024-03-17
 
 Although it comes with a number of improvements, there's nothing particularly notable about version 0.1.0. Until now we've only been incrementing the patch version given the project's nascent nature, but from here on we'll try to adhere more closely to semantic versioning, using the patch version for bug fixes, and incrementing the minor version when new functionality is added.

--- a/cmd/river/riverbench/river_bench.go
+++ b/cmd/river/riverbench/river_bench.go
@@ -49,7 +49,7 @@ func (b *Benchmarker[TTx]) Run(ctx context.Context) error {
 	// Prevents double-close on shutdown channel.
 	closeShutdown := func() {
 		if !shutdownClosed {
-			b.logger.InfoContext(ctx, "Closing shutdown channel")
+			b.logger.DebugContext(ctx, "Closing shutdown channel")
 			close(shutdown)
 		}
 		shutdownClosed = true
@@ -236,17 +236,14 @@ func (b *Benchmarker[TTx]) Run(ctx context.Context) error {
 
 	b.logger.InfoContext(ctx, b.name+": Minimum jobs inserted; starting iteration")
 
-	b.logger.InfoContext(ctx, b.name+": Client starting")
 	if err := client.Start(ctx); err != nil {
 		return err
 	}
 
 	defer func() {
-		b.logger.InfoContext(ctx, b.name+": Client stopping")
 		if err := client.Stop(ctx); err != nil {
 			b.logger.ErrorContext(ctx, b.name+": Error stopping client", "err", err)
 		}
-		b.logger.InfoContext(ctx, b.name+": Client stopped")
 	}()
 
 	// Prints one last log line before exit summarizing all operations.

--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -205,8 +205,8 @@ func (c *BatchCompleter) Start(ctx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		c.Logger.InfoContext(ctx, c.Name+": Run loop started")
-		defer c.Logger.InfoContext(ctx, c.Name+": Run loop stopped")
+		c.Logger.DebugContext(ctx, c.Name+": Run loop started")
+		defer c.Logger.DebugContext(ctx, c.Name+": Run loop stopped")
 
 		ticker := time.NewTicker(50 * time.Millisecond)
 		defer ticker.Stop()

--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -167,8 +167,8 @@ func (e *Elector) Start(ctx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		e.Logger.InfoContext(ctx, e.Name+": Run loop started")
-		defer e.Logger.InfoContext(ctx, e.Name+": Run loop stopped")
+		e.Logger.DebugContext(ctx, e.Name+": Run loop started")
+		defer e.Logger.DebugContext(ctx, e.Name+": Run loop stopped")
 
 		if sub != nil {
 			defer sub.Unlisten(ctx)

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -108,8 +108,8 @@ func (s *JobCleaner) Start(ctx context.Context) error { //nolint:dupl
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
-		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
+		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		ticker := timeutil.NewTickerWithInitialTick(ctx, s.Config.Interval)
 		for {

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -113,8 +113,8 @@ func (s *JobRescuer) Start(ctx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
-		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
+		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		ticker := timeutil.NewTickerWithInitialTick(ctx, s.Config.Interval)
 		for {

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -90,8 +90,8 @@ func (s *JobScheduler) Start(ctx context.Context) error { //nolint:dupl
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
-		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
+		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		ticker := timeutil.NewTickerWithInitialTick(ctx, s.config.Interval)
 		for {

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -112,8 +112,8 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
-		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
+		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		// An initial loop to assign next runs for every configured job and
 		// queues any jobs that should run immediately.

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -104,8 +104,8 @@ func (s *Reindexer) Start(ctx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStarted)
-		defer s.Logger.InfoContext(ctx, s.Name+logPrefixRunLoopStopped)
+		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)
 
 		// On each run, we calculate the new schedule based on the previous run's
 		// start time. This ensures that we don't accidentally skip a run as time

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -106,8 +106,8 @@ func (n *Notifier) Start(ctx context.Context) error {
 	go func() {
 		defer close(stopped)
 
-		n.Logger.InfoContext(ctx, n.Name+": Run loop started")
-		defer n.Logger.InfoContext(ctx, n.Name+": Run loop stopped")
+		n.Logger.DebugContext(ctx, n.Name+": Run loop started")
+		defer n.Logger.DebugContext(ctx, n.Name+": Run loop stopped")
 
 		n.withLock(func() { n.isStarted = true })
 		defer n.withLock(func() { n.isStarted = false })
@@ -186,7 +186,7 @@ func (n *Notifier) listenAndWait(ctx context.Context) error {
 		}
 	}
 
-	n.Logger.InfoContext(ctx, n.Name+": Notifier healthy")
+	n.Logger.DebugContext(ctx, n.Name+": Notifier healthy")
 	n.statusChangeFunc(componentstatus.Healthy)
 
 	n.testSignals.ListeningBegin.Signal(struct{}{})

--- a/producer.go
+++ b/producer.go
@@ -256,9 +256,9 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 		// races.
 		defer close(stopped)
 
-		p.Logger.InfoContext(fetchCtx, p.Name+": Run loop started", slog.String("queue", p.config.Queue))
+		p.Logger.DebugContext(fetchCtx, p.Name+": Run loop started", slog.String("queue", p.config.Queue))
 		defer func() {
-			p.Logger.InfoContext(fetchCtx, p.Name+": Run loop stopped", slog.String("queue", p.config.Queue), slog.Uint64("num_completed_jobs", p.numJobsRan.Load()))
+			p.Logger.DebugContext(fetchCtx, p.Name+": Run loop stopped", slog.String("queue", p.config.Queue), slog.Uint64("num_completed_jobs", p.numJobsRan.Load()))
 		}()
 
 		if insertSub != nil {


### PR DESCRIPTION
Here, in an attempt to reduce the level of noise of River logging
somewhat, move more logging that's not as useful from into to debug
level. Most of the changed log statements are the start/stop message of
each subservice (so the River client will still emit start/stop at info
level, but each subservice moves theirs to debug).

Also remove a few log statements that are quite duplicative of an almost
identical one happening elsehwere (e.g. "client started" in benchmark,
which is almost the same as "client started" in the client), and a few
that I'm pretty sure I'd left in by accident while debugging.

The CLI now takes a `--debug` parameter, and `riverinternaltest` now
provides `BaseServiceArchetypeDebug` to easily swap into a failing test,
so access to the additional logging is fairly easy to get at in case
it's needed.