### PR TITLE
Tee up version `v0.1.0` including new CLI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2024-03-17
+
+Although it comes with a number of improvements, there's nothing particularly notable about version 0.1.0. Until now we've only been incrementing the patch version given the project's nascent nature, but from here on we'll try to adhere more closely to semantic versioning, using the patch version for bug fixes, and incrementing the minor version when new functionality is added.
+
 ### Added
 
 - The River CLI now supports `river bench` to benchmark River's job throughput against a database. [PR #254](https://github.com/riverqueue/river/pull/254).

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -2,13 +2,13 @@ module github.com/riverqueue/river/cmd/river
 
 go 1.21.4
 
-replace github.com/riverqueue/river => ../..
+// replace github.com/riverqueue/river => ../..
 
-replace github.com/riverqueue/river/riverdriver => ../../riverdriver
+// replace github.com/riverqueue/river/riverdriver => ../../riverdriver
 
-replace github.com/riverqueue/river/riverdriver/riverdatabasesql => ../../riverdriver/riverdatabasesql
+// replace github.com/riverqueue/river/riverdriver/riverdatabasesql => ../../riverdriver/riverdatabasesql
 
-replace github.com/riverqueue/river/riverdriver/riverpgxv5 => ../../riverdriver/riverpgxv5
+// replace github.com/riverqueue/river/riverdriver/riverpgxv5 => ../../riverdriver/riverpgxv5
 
 require (
 	github.com/jackc/pgx/v5 v5.5.5

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.0.25
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.25
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.25
-	github.com/riverqueue/river/rivertype v0.0.25
+	github.com/riverqueue/river/riverdriver v0.1.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.1.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.1.0
+	github.com/riverqueue/river/rivertype v0.1.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.0.25
+require github.com/riverqueue/river/rivertype v0.1.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.0.25
-	github.com/riverqueue/river/rivertype v0.0.25
+	github.com/riverqueue/river/riverdriver v0.1.0
+	github.com/riverqueue/river/rivertype v0.1.0
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -9,8 +9,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.0.25
-	github.com/riverqueue/river/rivertype v0.0.25
+	github.com/riverqueue/river/riverdriver v0.1.0
+	github.com/riverqueue/river/rivertype v0.1.0
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Tees up version `v0.1.0`, containing a number of changes like `river
bench`, `river migrate-get`, and a new, faster, completer.

We could pool a few more changes before release, but I kind of want to
get this out the door so I don't forget to the cut a CLI release and
remove the `replace` directives in its `go.mod`.