### PR TITLE
Fix release instructions for River CLI + make accidental copy/paste harder

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -27,30 +27,39 @@ queries. After changing an sqlc `.sql` file, generate Go with:
 
 1. Fetch changes to the repo and any new tags. Export `VERSION` by incrementing the last tag. Execute `update-submodule-versions` to add it the project's `go.mod` files:
 
-```shell
-git checkout master && git pull --rebase
-export VERSION=v0.0.x
-go run ./internal/cmd/update-submodule-versions/main.go
-```
+    ```shell
+    git checkout master && git pull --rebase
+    export VERSION=v0.0.x
+    go run ./internal/cmd/update-submodule-versions/main.go
+    ```
 
 2. Prepare a PR with the changes, updating `CHANGELOG.md` with any necessary additions at the same time. Have it reviewed and merged.
 
-    Unfortunately, the build will fail because the version in the updated `go.mod` files isn't yet available.
-
 3. Upon merge, pull down the changes, tag each module with the new version, and push the new tags:
 
-```shell
-git pull origin master
-git tag cmd/river/$VERSION -m "release cmd/river/$VERSION"
-git tag riverdriver/$VERSION -m "release riverdriver/$VERSION"
-git tag riverdriver/riverpgxv5/$VERSION -m "release riverdriver/riverpgxv5/$VERSION"
-git tag riverdriver/riverdatabasesql/$VERSION -m "release riverdriver/riverdatabasesql/$VERSION"
-git tag rivertype/$VERSION -m "release rivertype/$VERSION"
-git tag $VERSION
-git push --tags
-```
 
-4. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/river/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.
+    ```shell
+    git pull origin master
+    git tag riverdriver/$VERSION -m "release riverdriver/$VERSION"
+    git tag riverdriver/riverpgxv5/$VERSION -m "release riverdriver/riverpgxv5/$VERSION"
+    git tag riverdriver/riverdatabasesql/$VERSION -m "release riverdriver/riverdatabasesql/$VERSION"
+    git tag rivertype/$VERSION -m "release rivertype/$VERSION"
+    git tag $VERSION
+    ```
+
+    If you _don't_ need a new River CLI release that requires API changes in the main River package from `$VERSION`, tag that immediately as well (if you do, skip this command, and see "Releasing River CLI" below):
+
+    ```shell
+    git tag cmd/river/$VERSION -m "release cmd/river/$VERSION"
+    ```
+
+4. Push new tags to GitHub:
+
+    ```shell
+    git push --tags
+    ```
+
+5. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/river/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.
 
 ### Releasing River CLI
 
@@ -58,9 +67,36 @@ The CLI (`./cmd/river`) is different than other River submodules in that it does
 
 If changes to it don't require updates to its other River dependencies (i.e. they're internal to the CLI only), it can be released normally as shown above.
 
-If updates to River dependencies _are_ required, then a two-phase update is necessary:
+If updates to River dependencies _are_ required, then a second phase of the release is necessary:
 
-1. Release River dependencies with an initial version (e.g. `v0.0.14`).
-2. From `./cmd/river`, `go get` to upgrade to the version from (1), run `go mod tidy`, then tag it with the same version (e.g. `v0.0.14`).
+1. Release River dependencies with an initial version (i.e. all the steps above).
 
-    The main `v0.0.14` tag and `cmd/river/v0.0.14` will point to different commits, but this is tolerable.
+2. Comment out `replace` directives to River's top level packages in `./cmd/river/go.mod`. These were probably needed for developing the new feature, but need to be removed because they prevent the module from being `go install`-able.
+
+3. From `./cmd/river`, `go get` to upgrade to the main package versions were just released (make sure you're getting `$VERSION` and not thwarted by shenanigans in Go's module proxy):
+
+    ```shell
+    cmd ./cmd/river/
+    go get -u github.com/riverqueue/river@$VERSION
+    go get -u github.com/riverqueue/river/riverdriver@$VERSION
+    go get -u github.com/riverqueue/river/riverdriver/riverdatabasesql@$VERSION
+    go get -u github.com/riverqueue/river/riverdriver/riverpgxv5@$VERSION
+    ```
+
+4. Run `go mod tidy`:
+
+    ```shell
+    go mod tidy
+    ```
+
+5. Prepare a PR with the changes. Have it reviewed and merged.
+
+6. Pull the changes back down, add a tag for `cmd/river/$VERSION`, and push it to GitHub:
+
+    ```shell
+    git pull origin master
+    git tag cmd/river/$VERSION -m "release cmd/river/$VERSION"
+    git push --tags
+    ```
+
+    The main `$VERSION` tag and `cmd/river/$VERSION` will point to different commits, and although a little odd, is tolerable.


### PR DESCRIPTION
I noticed yesterday while releasing `v0.1.0` that the CLI's release
instructions are still not quite right. In particular, the main block of
`git tag` includes `cmd/river/$VERSION`, so it's a really easy to
mistakenly tag the CLI with the wrong commit when you're really trying
to release it separately.

In this change:

* Move the CLI tag to a separate command block with clear instructions
  to skip it if the CLI needs a special release.

* Expand the section on releasing the CLI to have specific `go get`
  commands for each required mainline package containing `$VERSION`.

* Indicate that a second pull request will be required for the CLI
  release, and add a step explicitly indicating that `replace`
  directives in the CLI's `go.mod` should be removed (it's better for
  the build's health if they're removed in the second phase rather than
  the first).