### PR TITLE
Fix hot loop in reindexer service + no more disabling sleep in base services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The level of some of River's common log statements has changed, most often demoting `info` statements to `debug` so that `info`-level logging is overall less verbose. [PR #275](https://github.com/riverqueue/river/pull/275).
 
+### Fixed
+
+- Fixed a  bug in the (log-only for now) reindexer service in which it might repeat its work loop multiple times unexpectedly while stopping. [PR #280](https://github.com/riverqueue/river/pull/280).
+
 ## [0.1.0] - 2024-03-17
 
 Although it comes with a number of improvements, there's nothing particularly notable about version 0.1.0. Until now we've only been incrementing the patch version given the project's nascent nature, but from here on we'll try to adhere more closely to semantic versioning, using the patch version for bug fixes, and incrementing the minor version when new functionality is added.

--- a/internal/baseservice/base_service_test.go
+++ b/internal/baseservice/base_service_test.go
@@ -12,20 +12,12 @@ import (
 	"github.com/riverqueue/river/internal/util/randutil"
 )
 
-func TestArchetype_WithSleepDisabled(t *testing.T) {
-	t.Parallel()
-
-	archetype := (&Archetype{}).WithSleepDisabled()
-	require.True(t, archetype.DisableSleep)
-}
-
 func TestInit(t *testing.T) {
 	t.Parallel()
 
 	archetype := archetype()
 
 	myService := Init(archetype, &MyService{})
-	require.False(t, myService.DisableSleep)
 	require.NotNil(t, myService.Logger)
 	require.Equal(t, "MyService", myService.Name)
 	require.WithinDuration(t, time.Now().UTC(), myService.TimeNowUTC(), 2*time.Second)
@@ -61,17 +53,6 @@ func TestBaseService_CancellableSleep(t *testing.T) {
 		case <-sleepDone:
 		case <-time.After(50 * time.Millisecond):
 			require.FailNow(t, "Timed out waiting for sleep to finish after cancel")
-		}
-
-		archetype.DisableSleep = true
-
-		// Start again with sleep disabled and expect an immediate return.
-		sleepDone = startSleepFunc(ctx, myService)
-
-		select {
-		case <-sleepDone:
-		case <-time.After(50 * time.Millisecond):
-			require.FailNow(t, "Timed out waiting for sleep to finish with sleep disabled")
 		}
 	}
 

--- a/internal/jobcompleter/job_completer_test.go
+++ b/internal/jobcompleter/job_completer_test.go
@@ -71,8 +71,9 @@ func TestInlineJobCompleter_Complete(t *testing.T) {
 		},
 	}
 
-	completer := NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), execMock)
+	completer := NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t), execMock)
 	t.Cleanup(completer.Stop)
+	completer.disableSleep = true
 
 	err := completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(1, time.Now()))
 	if !errors.Is(err, expectedErr) {
@@ -87,7 +88,7 @@ func TestInlineJobCompleter_Subscribe(t *testing.T) {
 	t.Parallel()
 
 	testCompleterSubscribe(t, func(exec PartialExecutor) JobCompleter {
-		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec)
+		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t), exec)
 	})
 }
 
@@ -95,7 +96,7 @@ func TestInlineJobCompleter_Wait(t *testing.T) {
 	t.Parallel()
 
 	testCompleterWait(t, func(exec PartialExecutor) JobCompleter {
-		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec)
+		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t), exec)
 	})
 }
 
@@ -127,8 +128,9 @@ func TestAsyncJobCompleter_Complete(t *testing.T) {
 			return nil, err
 		},
 	}
-	completer := newAsyncCompleterWithConcurrency(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), adapter, 2)
+	completer := newAsyncCompleterWithConcurrency(riverinternaltest.BaseServiceArchetype(t), adapter, 2)
 	t.Cleanup(completer.Stop)
+	completer.disableSleep = true
 
 	// launch 4 completions, only 2 can be inline due to the concurrency limit:
 	for i := int64(0); i < 2; i++ {
@@ -190,7 +192,7 @@ func TestAsyncJobCompleter_Subscribe(t *testing.T) {
 	t.Parallel()
 
 	testCompleterSubscribe(t, func(exec PartialExecutor) JobCompleter {
-		return newAsyncCompleterWithConcurrency(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec, 4)
+		return newAsyncCompleterWithConcurrency(riverinternaltest.BaseServiceArchetype(t), exec, 4)
 	})
 }
 
@@ -198,7 +200,7 @@ func TestAsyncJobCompleter_Wait(t *testing.T) {
 	t.Parallel()
 
 	testCompleterWait(t, func(exec PartialExecutor) JobCompleter {
-		return newAsyncCompleterWithConcurrency(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), exec, 4)
+		return newAsyncCompleterWithConcurrency(riverinternaltest.BaseServiceArchetype(t), exec, 4)
 	})
 }
 
@@ -302,7 +304,7 @@ func TestAsyncCompleter(t *testing.T) {
 		t.Helper()
 		return NewAsyncCompleter(riverinternaltest.BaseServiceArchetype(t), exec)
 	},
-		func(completer *AsyncCompleter) { completer.DisableSleep = true },
+		func(completer *AsyncCompleter) { completer.disableSleep = true },
 		func(completer *AsyncCompleter, exec PartialExecutor) { completer.exec = exec })
 }
 
@@ -313,7 +315,7 @@ func TestBatchCompleter(t *testing.T) {
 		t.Helper()
 		return NewBatchCompleter(riverinternaltest.BaseServiceArchetype(t), exec)
 	},
-		func(completer *BatchCompleter) { completer.DisableSleep = true },
+		func(completer *BatchCompleter) { completer.disableSleep = true },
 		func(completer *BatchCompleter, exec PartialExecutor) { completer.exec = exec })
 
 	ctx := context.Background()
@@ -397,7 +399,7 @@ func TestInlineCompleter(t *testing.T) {
 		t.Helper()
 		return NewInlineCompleter(riverinternaltest.BaseServiceArchetype(t), exec)
 	},
-		func(completer *InlineCompleter) { completer.DisableSleep = true },
+		func(completer *InlineCompleter) { completer.disableSleep = true },
 		func(completer *InlineCompleter, exec PartialExecutor) { completer.exec = exec })
 }
 

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -68,7 +68,7 @@ func (c *JobCleanerConfig) mustValidate() *JobCleanerConfig {
 // JobCleaner periodically removes finalized jobs that are cancelled, completed,
 // or discarded. Each state's retention time can be configured individually.
 type JobCleaner struct {
-	baseservice.BaseService
+	queueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	// exported for test purposes
@@ -99,9 +99,7 @@ func (s *JobCleaner) Start(ctx context.Context) error { //nolint:dupl
 		return nil
 	}
 
-	// Jitter start up slightly so services don't all perform their first run at
-	// exactly the same time.
-	s.CancellableSleepRandomBetween(ctx, JitterMin, JitterMax)
+	s.StaggerStart(ctx)
 
 	go func() {
 		// This defer should come first so that it's last out, thereby avoiding

--- a/internal/maintenance/job_cleaner_test.go
+++ b/internal/maintenance/job_cleaner_test.go
@@ -40,7 +40,7 @@ func TestJobCleaner(t *testing.T) {
 		}
 
 		cleaner := NewJobCleaner(
-			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
+			riverinternaltest.BaseServiceArchetype(t),
 			&JobCleanerConfig{
 				CancelledJobRetentionPeriod: CancelledJobRetentionPeriodDefault,
 				CompletedJobRetentionPeriod: CompletedJobRetentionPeriodDefault,
@@ -48,6 +48,7 @@ func TestJobCleaner(t *testing.T) {
 				Interval:                    JobCleanerIntervalDefault,
 			},
 			bundle.exec)
+		cleaner.StaggerStartupDisable(true)
 		cleaner.TestSignals.Init()
 		t.Cleanup(cleaner.Stop)
 
@@ -57,7 +58,7 @@ func TestJobCleaner(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
 		t.Parallel()
 
-		cleaner := NewJobCleaner(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), &JobCleanerConfig{}, nil)
+		cleaner := NewJobCleaner(riverinternaltest.BaseServiceArchetype(t), &JobCleanerConfig{}, nil)
 
 		require.Equal(t, CancelledJobRetentionPeriodDefault, cleaner.Config.CancelledJobRetentionPeriod)
 		require.Equal(t, CompletedJobRetentionPeriodDefault, cleaner.Config.CompletedJobRetentionPeriod)

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -73,7 +73,7 @@ func (c *JobRescuerConfig) mustValidate() *JobRescuerConfig {
 // JobRescuer periodically rescues jobs that have been executing for too long
 // and are considered to be "stuck".
 type JobRescuer struct {
-	baseservice.BaseService
+	queueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	// exported for test purposes
@@ -104,9 +104,7 @@ func (s *JobRescuer) Start(ctx context.Context) error {
 		return nil
 	}
 
-	// Jitter start up slightly so services don't all perform their first run at
-	// exactly the same time.
-	s.CancellableSleepRandomBetween(ctx, JitterMin, JitterMax)
+	s.StaggerStart(ctx)
 
 	go func() {
 		// This defer should come first so that it's last out, thereby avoiding

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -70,7 +70,7 @@ func TestJobRescuer(t *testing.T) {
 		}
 
 		rescuer := NewRescuer(
-			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
+			riverinternaltest.BaseServiceArchetype(t),
 			&JobRescuerConfig{
 				ClientRetryPolicy: &SimpleClientRetryPolicy{},
 				Interval:          JobRescuerIntervalDefault,
@@ -83,6 +83,7 @@ func TestJobRescuer(t *testing.T) {
 				},
 			},
 			bundle.exec)
+		rescuer.StaggerStartupDisable(true)
 		rescuer.TestSignals.Init()
 		t.Cleanup(rescuer.Stop)
 
@@ -93,7 +94,7 @@ func TestJobRescuer(t *testing.T) {
 		t.Parallel()
 
 		cleaner := NewRescuer(
-			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
+			riverinternaltest.BaseServiceArchetype(t),
 			&JobRescuerConfig{
 				ClientRetryPolicy:   &SimpleClientRetryPolicy{},
 				WorkUnitFactoryFunc: func(kind string) workunit.WorkUnitFactory { return nil },

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -55,7 +55,7 @@ func (c *JobSchedulerConfig) mustValidate() *JobSchedulerConfig {
 // which are ready to run over to `available` so that they're eligible to be
 // worked.
 type JobScheduler struct {
-	baseservice.BaseService
+	queueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	// exported for test purposes
@@ -81,9 +81,7 @@ func (s *JobScheduler) Start(ctx context.Context) error { //nolint:dupl
 		return nil
 	}
 
-	// Jitter start up slightly so services don't all perform their first run at
-	// exactly the same time.
-	s.CancellableSleepRandomBetween(ctx, JitterMin, JitterMax)
+	s.StaggerStart(ctx)
 
 	go func() {
 		// This defer should come first so that it's last out, thereby avoiding

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -37,7 +37,7 @@ func TestJobScheduler(t *testing.T) {
 		}
 
 		scheduler := NewScheduler(
-			riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(),
+			riverinternaltest.BaseServiceArchetype(t),
 			&JobSchedulerConfig{
 				Interval: JobSchedulerIntervalDefault,
 				Limit:    10,
@@ -73,7 +73,7 @@ func TestJobScheduler(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
 		t.Parallel()
 
-		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), &JobSchedulerConfig{}, nil)
+		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t), &JobSchedulerConfig{}, nil)
 
 		require.Equal(t, JobSchedulerIntervalDefault, scheduler.config.Interval)
 		require.Equal(t, JobSchedulerLimitDefault, scheduler.config.Limit)

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -65,7 +65,7 @@ func (c *PeriodicJobEnqueuerConfig) mustValidate() *PeriodicJobEnqueuerConfig {
 // PeriodicJobEnqueuer inserts jobs configured to run periodically as unique
 // jobs to make sure they'll run as frequently as their period dictates.
 type PeriodicJobEnqueuer struct {
-	baseservice.BaseService
+	queueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	// exported for test purposes
@@ -103,9 +103,7 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 		return nil
 	}
 
-	// Jitter start up slightly so services don't all perform their first run at
-	// exactly the same time.
-	s.CancellableSleepRandomBetween(ctx, JitterMin, JitterMax)
+	s.StaggerStart(ctx)
 
 	go func() {
 		// This defer should come first so that it's last out, thereby avoiding

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -56,7 +56,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 			waitChan: make(chan struct{}),
 		}
 
-		archetype := riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled()
+		archetype := riverinternaltest.BaseServiceArchetype(t)
 
 		svc := NewPeriodicJobEnqueuer(
 			archetype,
@@ -66,6 +66,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 					{ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false)},
 				},
 			}, bundle.exec)
+		svc.StaggerStartupDisable(true)
 		svc.TestSignals.Init()
 		t.Cleanup(svc.Stop)
 

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 type testService struct {
-	baseservice.BaseService
+	queueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	testSignals testServiceTestSignals
@@ -29,7 +29,7 @@ type testService struct {
 func newTestService(tb testing.TB) *testService {
 	tb.Helper()
 
-	testSvc := baseservice.Init(riverinternaltest.BaseServiceArchetype(tb).WithSleepDisabled(), &testService{})
+	testSvc := baseservice.Init(riverinternaltest.BaseServiceArchetype(tb), &testService{})
 	testSvc.testSignals.Init()
 
 	return testSvc
@@ -70,7 +70,8 @@ func TestQueueMaintainer(t *testing.T) {
 	setup := func(t *testing.T, services []startstop.Service) *QueueMaintainer {
 		t.Helper()
 
-		maintainer := NewQueueMaintainer(riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled(), services)
+		maintainer := NewQueueMaintainer(riverinternaltest.BaseServiceArchetype(t), services)
+		maintainer.StaggerStartupDisable(true)
 
 		return maintainer
 	}
@@ -93,7 +94,7 @@ func TestQueueMaintainer(t *testing.T) {
 		tx := riverinternaltest.TestTx(ctx, t)
 		sharedTx := sharedtx.NewSharedTx(tx)
 
-		archetype := riverinternaltest.BaseServiceArchetype(t).WithSleepDisabled()
+		archetype := riverinternaltest.BaseServiceArchetype(t)
 		archetype.Logger = riverinternaltest.LoggerWarn(t) // loop started/stop log is very noisy; suppress
 
 		driver := riverpgxv5.New(nil).UnwrapExecutor(sharedTx)

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -61,6 +61,7 @@ type Notifier struct {
 	baseservice.BaseService
 	startstop.BaseStartStop
 
+	disableSleep      bool // for tests only; disable sleep on exponential backoff
 	listener          riverdriver.Listener
 	notificationBuf   chan *riverdriver.Notification
 	statusChangeFunc  func(componentstatus.Status)
@@ -133,7 +134,9 @@ func (n *Notifier) Start(ctx context.Context) error {
 				n.Logger.ErrorContext(ctx, n.Name+": Error running listener (will attempt reconnect after backoff)",
 					"attempt", attempt, "err", err, "sleep_duration", sleepDuration)
 				n.testSignals.BackoffError.Signal(err)
-				n.CancellableSleep(ctx, sleepDuration)
+				if !n.disableSleep {
+					n.CancellableSleep(ctx, sleepDuration)
+				}
 			}
 		}
 

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -474,7 +474,7 @@ func TestNotifier(t *testing.T) {
 
 		notifier, _ := setup(t)
 
-		notifier.DisableSleep = true
+		notifier.disableSleep = true
 
 		var errorNum int
 
@@ -521,7 +521,7 @@ func TestNotifier(t *testing.T) {
 		notifier, bundle := setup(t)
 
 		// Disable the backoff sleep that would occur after the first retry.
-		notifier.DisableSleep = true
+		notifier.disableSleep = true
 
 		var errorNum int
 

--- a/internal/rivercommon/test_signal.go
+++ b/internal/rivercommon/test_signal.go
@@ -51,6 +51,16 @@ func (s *TestSignal[T]) Signal(val T) {
 	}
 }
 
+// WaitC returns a channel on which a value from the test signal can be waited
+// upon.
+func (s TestSignal[T]) WaitC() <-chan T {
+	if s.internalChan == nil {
+		panic("test only signal is not initialized; called outside of tests?")
+	}
+
+	return s.internalChan
+}
+
 // WaitOrTimeout waits on the next value injected by Signal. This should only be
 // used in tests, and can only be used if Init has been invoked on the test
 // signal.

--- a/internal/rivercommon/test_signal_test.go
+++ b/internal/rivercommon/test_signal_test.go
@@ -41,6 +41,38 @@ func TestTestSignal(t *testing.T) {
 			signal.WaitOrTimeout()
 		}
 	})
+
+	t.Run("WaitC", func(t *testing.T) {
+		t.Parallel()
+
+		signal := TestSignal[struct{}]{}
+		signal.Init()
+
+		select {
+		case <-signal.WaitC():
+			require.FailNow(t, "Test signal should not have fired")
+		default:
+		}
+
+		signal.Signal(struct{}{})
+
+		select {
+		case <-signal.WaitC():
+		default:
+			require.FailNow(t, "Test signal should have fired")
+		}
+	})
+
+	t.Run("WaitOrTimeout", func(t *testing.T) {
+		t.Parallel()
+
+		signal := TestSignal[struct{}]{}
+		signal.Init()
+
+		signal.Signal(struct{}{})
+
+		signal.WaitOrTimeout()
+	})
 }
 
 // Marked as non-parallel because `t.Setenv` is not compatible with `t.Parallel`.


### PR DESCRIPTION
Fix a bug in the reindexer which was causing it to enter a hot loop on
shutdown. It wasn't doing any work since reindexing is currently
disabled, but it was emitting an inordinate amount of logging output.

The problem stemmed from trying to use a `context.Deadline` as a timer:

    for {
        timerCancel := context.WithDeadline(ctx, nextRunAt)

        select {
        case <-ctx.Done():
            timerCancel()
            return
        case <-timerCtx.Done():
        }

        ...
    }

The bug is easy to miss on the first read, but involves context
inheritance. A service's context is cancelled when its being stopped,
and in this case `timerCtx` inherits from `ctx`, so on stop, _both_
`ctx` and `timerCtx` are cancelled, making the `select` statement's
precedence indeterminate, and causing the loop to fall through and
continue an arbitrary number of times. (I would've expected the branch
taken to be a 50/50, but there's some other implementation detail at
work here because I was seeing `timerCtx` preferred in a statistically
improbable way on most runs, and it'd often fire 4-5 times before
`ctx.Done()` was found a test case would end.)

I replaced the use of a context with a `CancellableSleep` with a context
check following it.

This then let to a bit of a yakshake because the cancellable sleep was
being respect _either_, which turned out to be because all base service
sleep is disabled in the queue maintainers in order to avoid their
staggered sleep that occurs on start up.

I changed my mind a while ago that being able to broadly disable sleep
like this is actually not a very good idea, but hadn't gotten around to
refactoring it out yet, so I finally did so here. The staggered sleep is
moved to a new base function with a disable flag specifically for this
use rather than all sleeps everywhere:

    func (s *queueMaintainerServiceBase) StaggerStart(ctx context.Context) {
        if s.staggerStartupDisabled {
            return
        }

        const (
            jitterMin = 0 * time.Second
            jitterMax = 1 * time.Second
        )

        s.CancellableSleepRandomBetween(ctx, jitterMin, jitterMax)
    }

The client then may disable start on all the queue maintainer services
as it initializes them based on a non-exported flag from its `Config`.
Unlike disabling sleep, disabling start up stagger is _always_
appropriate in client tests, and won't lead to unintended side effects
like accidentally disabling sleep on exponential backoffs.

Over all, despite a little more work for services that want to disable
their sleep for tests, I think this produces a far more obvious model
that's going to lead to fewer test bugs.