### PR TITLE
Poll only mode for environments without listen/notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The River client now supports "poll only" mode with `Config.PollOnly` which makes it avoid issuing `LISTEN` statements to wait for new events like a leadership resignation or new job available. The program instead polls periodically to look for changes. A leader resigning or a new job being available will be noticed less quickly, but `PollOnly` potentially makes River operable on systems without listen/notify support, like PgBouncer operating in transaction pooling mode. [PR #281](https://github.com/riverqueue/river/pull/281).
+
 ## [0.2.0] - 2024-03-28
 
 ### Added

--- a/producer.go
+++ b/producer.go
@@ -209,8 +209,7 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 			p.Logger.DebugContext(workCtx, p.Name+": Received insert notification", slog.String("queue", decoded.Queue))
 			fetchLimiter.Call()
 		}
-		// TODO(brandur): Get rid of this retry loop after refactor.
-		insertSub, err = notifier.ListenRetryLoop(fetchCtx, &p.BaseService, p.config.Notifier, notifier.NotificationTopicInsert, handleInsertNotification)
+		insertSub, err = p.config.Notifier.Listen(fetchCtx, notifier.NotificationTopicInsert, handleInsertNotification)
 		if err != nil {
 			close(stopped)
 			if strings.HasSuffix(err.Error(), "conn closed") || errors.Is(err, context.Canceled) {
@@ -240,8 +239,7 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 				slog.String("queue", decoded.Queue),
 			)
 		}
-		// TODO(brandur): Get rid of this retry loop after refactor.
-		jobControlSub, err = notifier.ListenRetryLoop(fetchCtx, &p.BaseService, p.config.Notifier, notifier.NotificationTopicJobControl, handleJobControlNotification)
+		jobControlSub, err = p.config.Notifier.Listen(fetchCtx, notifier.NotificationTopicJobControl, handleJobControlNotification)
 		if err != nil {
 			close(stopped)
 			if strings.HasSuffix(err.Error(), "conn closed") || errors.Is(err, context.Canceled) {


### PR DESCRIPTION
Here, add a new River client option in `Config.PollOnly` which causes it
to start in "poll only" mode where a notifier isn't initialized, and no
`LISTEN` statements are issued. This has the downside of events like a
leadership resignation or a new job being available not noticed as
quickly, but the advantage of making River operable on systems where
listen/notify aren't supported, like PgBouncer in transaction mode, or
maybe even eventually MySQL or SQLite.

A slightly unrelated change that I also made here was to give the
elector a more traditional `Config` struct (like other services take)
that encompasses more of its configuration instead of raw constructor
parameters. I thought I needed to do this originally to better expose a
custom elect interval for the client's `PollOnly` test, but it turned
out that my slow test was actually due to a different problem and the
extra configuration wasn't actually necessary. It seemed to me to clean
things up somewhat though, so I left the refactor in.

I also remove the listen retry loop on client start up found in the
elector and producer. These are probably a bad idea because they may
hide a real database problem as they enter their retry loops, and cause
the client to require a very lengthy amount of time for its `Start` to
fail because of the built-in sleep backoffs. But we'd added them over
concerns that the notifier's previous implementation (prior to #253) of
discarding all listen/notify problems may have papered over errors that
would've otherwise been returned for people trying to use a River client
against say a PgBouncer operating in transaction pooling mode.

So instead, we now fail fast if there's a problem with listen/notify in
their database, and for those wanting to use PgBouncer in transaction
pooling mode, we can now recommend using the much cleaner approach of
activating `PollOnly` instead. Users can implement their own retry loop
on client `Start` if they'd like to protect against intermittent
problems on listen/notify start up, but personally I wouldn't expect
this to ever be desirable. (The alternative is to allow the program to
fail fast and have its supervisor resurrect it, like most programs would
do for any other start up hiccup.) The program will already fail fast
under most circumstances due to the `SELECT` it performs on start.