### PR TITLE
Periodic job enqueuer: Use original next run time when calculating next schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug in the (log-only for now) reindexer service in which it might repeat its work loop multiple times unexpectedly while stopping. [PR #280](https://github.com/riverqueue/river/pull/280).
+- Periodic job enqueuer now bases next run times on each periodic job's last target run time, instead of the time at which the enqueuer is currently running. This is a small difference that will be unnoticeable for most purposes, but makes scheduling of jobs with short cron frequencies a little more accurate. [PR #284](https://github.com/riverqueue/river/pull/284).
 - Fixed a bug in the elector in which it was possible for a resigning, but not completely stopped, elector to reelect despite having just resigned. [PR #286](https://github.com/riverqueue/river/pull/286).
 
 ## [0.1.0] - 2024-03-17

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -168,7 +168,11 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 						continue
 					}
 
-					periodicJob.nextRunAt = periodicJob.ScheduleFunc(now)
+					// Although we may have inserted a new job a little
+					// preemptively due to the margin applied above, try to stay
+					// as true as possible to the original schedule by using the
+					// original run time when calculating the next one.
+					periodicJob.nextRunAt = periodicJob.ScheduleFunc(periodicJob.nextRunAt)
 
 					if insertParams, uniqueOpts, ok := s.insertParamsFromConstructor(ctx, periodicJob.ConstructorFunc); ok {
 						if !uniqueOpts.IsEmpty() {


### PR DESCRIPTION
This one came up while I was looking into #283. Although I don't think
it'll fully resolve what's being reported there, this implementation
feels a little more correct compared to what we had originally.

Currently, when scheduling the next run of a job, we use the current
time. However, the current time may be somewhat staggered from when the
job was supposed to run at because we build in a 100 ms "ready margin"
when looking for jobs to run. Although a minor problem, this makes it
conceivably possible for a periodic job to drift 100 ms at a time until
it's deviated from its theoretically ideal run schedule by a non-trivial
margin (well, debatably, your definition of trivial depends a lot on
schedule tolerance).

Here, make a minor change that uses the job's original run target time
when calculating the next one. This will have been within 100 ms of the
current time anyway, but is a little more accurate for what was intended.

I started writing a test case for this, but anything I put in is so
intrusive that it feels like the noise added to code is bad enough that
it outweighs any additional marginal benefit from the test, so I just
opted not to have a test. The existing ones don't differentiate a
schedule based on current time versus original run time, but they do vet
that the change still works.