### PR TITLE
Use `EXECUTE FUNCTION` instead of `EXECUTE PROCEDURE` in trigger

### DIFF
--- a/rivermigrate/migration/002_initial_schema.up.sql
+++ b/rivermigrate/migration/002_initial_schema.up.sql
@@ -80,7 +80,7 @@ LANGUAGE plpgsql;
 CREATE TRIGGER river_notify
   AFTER INSERT ON river_job
   FOR EACH ROW
-  EXECUTE PROCEDURE river_job_notify();
+  EXECUTE FUNCTION river_job_notify();
 
 CREATE UNLOGGED TABLE river_leader(
   -- 8 bytes each (no alignment needed)


### PR DESCRIPTION
This one's very small and not neither here nor there, but I spent a lot
of time last week reading the docs for Postgres triggers [1] and
happened to notice this line in there:

> `function_name`
>
> A user-supplied function that is declared as taking no arguments and
> returning type `trigger`, which is executed when the trigger fires.
>
> In the syntax of `CREATE TRIGGER`, the keywords `FUNCTION` and
> `PROCEDURE` are equivalent, but the referenced function must in any case
> be a function, not a procedure. The use of the keyword `PROCEDURE` here
> is historical and deprecated.

Use of `FUNCTION` is now preferred over use of `PROCEDURE`, so here make
that little tweak in River's schema. Some River schemas will have
already been raised with `PROCEDURE`, but it doesn't matter since the
change doesn't produce any compatibility problems.

[1] https://www.postgresql.org/docs/current/sql-createtrigger.html