### PR TITLE
Prepare release `v0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2024-03-28
+
 ### Added
 
 - New periodic jobs can now be added after a client's already started using `Client.PeriodicJobs().Add()` and removed with `Remove()`. [PR #288](https://github.com/riverqueue/river/pull/288).

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,7 @@ queries. After changing an sqlc `.sql` file, generate Go with:
 
     ```shell
     git checkout master && git pull --rebase
-    export VERSION=v0.0.x
+    export VERSION=v0.x.y
     go run ./internal/cmd/update-submodule-versions/main.go
     ```
 

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.1.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.1.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.1.0
-	github.com/riverqueue/river/rivertype v0.1.0
+	github.com/riverqueue/river/riverdriver v0.2.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.2.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.2.0
+	github.com/riverqueue/river/rivertype v0.2.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.1.0
+require github.com/riverqueue/river/rivertype v0.2.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.1.0
-	github.com/riverqueue/river/rivertype v0.1.0
+	github.com/riverqueue/river/riverdriver v0.2.0
+	github.com/riverqueue/river/rivertype v0.2.0
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -9,8 +9,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.1.0
-	github.com/riverqueue/river/rivertype v0.1.0
+	github.com/riverqueue/river/riverdriver v0.2.0
+	github.com/riverqueue/river/rivertype v0.2.0
 	github.com/stretchr/testify v1.8.1
 )
 


### PR DESCRIPTION
Tees up the project for version `v0.2.0`. Contains a few small changes
and bug fixes, and with a new periodic job feature from #288.