### PR TITLE
Have client insert functions return insert result instead of raw job row (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking change:** JobList/JobListTx now support querying Jobs by a list of Job Kinds and States. Also allows for filtering by specific timestamp values. Thank you Jos Kraaijeveld (@thatjos)! 🙏🏻 [PR #236](https://github.com/riverqueue/river/pull/236).
+- **Breaking change:** Client `Insert` and `InsertTx` functions now return a `JobInsertResult` struct instead of a `JobRow`. This allows the result to include metadata like the new `UniqueSkippedAsDuplicate` property, so callers can tell whether an inserted job was skipped due to unique constraint. [PR #292](https://github.com/riverqueue/river/pull/292).
 - **Breaking change:** Client `InsertMany` and `InsertManyTx` now return number of jobs inserted as `int` instead of `int64`. This change was made to make the type in use a little more idiomatic. [PR #293](https://github.com/riverqueue/river/pull/293).
 - **Breaking change:** `river.JobState*` type aliases have been removed. All job state constants should be accessed through `rivertype.JobState*` instead. [PR #300](https://github.com/riverqueue/river/pull/300).
 

--- a/example_job_cancel_from_client_test.go
+++ b/example_job_cancel_from_client_test.go
@@ -72,7 +72,7 @@ func Example_jobCancelFromClient() {
 	if err := riverClient.Start(ctx); err != nil {
 		panic(err)
 	}
-	job, err := riverClient.Insert(ctx, CancellingArgs{ShouldCancel: true}, nil)
+	insertRes, err := riverClient.Insert(ctx, CancellingArgs{ShouldCancel: true}, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -88,7 +88,7 @@ func Example_jobCancelFromClient() {
 	// cancellation signal.
 	time.Sleep(500 * time.Millisecond)
 
-	if _, err = riverClient.JobCancel(ctx, job.ID); err != nil {
+	if _, err = riverClient.JobCancel(ctx, insertRes.Job.ID); err != nil {
 		panic(err)
 	}
 	waitForNJobs(subscribeChan, 1)

--- a/internal/dbunique/db_unique.go
+++ b/internal/dbunique/db_unique.go
@@ -47,12 +47,7 @@ type UniqueInserter struct {
 	AdvisoryLockPrefix int32
 }
 
-type JobInsertResult struct {
-	Job                      *rivertype.JobRow
-	UniqueSkippedAsDuplicate bool
-}
-
-func (i *UniqueInserter) JobInsert(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobInsertFastParams, uniqueOpts *UniqueOpts) (*JobInsertResult, error) {
+func (i *UniqueInserter) JobInsert(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobInsertFastParams, uniqueOpts *UniqueOpts) (*rivertype.JobInsertResult, error) {
 	var execTx riverdriver.ExecutorTx
 
 	if uniqueOpts != nil && !uniqueOpts.IsEmpty() {
@@ -147,7 +142,7 @@ func (i *UniqueInserter) JobInsert(ctx context.Context, exec riverdriver.Executo
 
 			if existing != nil {
 				// Insert skipped; returns an existing row.
-				return &JobInsertResult{Job: existing, UniqueSkippedAsDuplicate: true}, nil
+				return &rivertype.JobInsertResult{Job: existing, UniqueSkippedAsDuplicate: true}, nil
 			}
 		}
 	}
@@ -163,5 +158,5 @@ func (i *UniqueInserter) JobInsert(ctx context.Context, exec riverdriver.Executo
 		}
 	}
 
-	return &JobInsertResult{Job: jobRow}, nil
+	return &rivertype.JobInsertResult{Job: jobRow}, nil
 }

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -13,6 +13,19 @@ import (
 // return this error.
 var ErrNotFound = errors.New("not found")
 
+// JobInsertResult is the result of a job insert, containing the inserted job
+// along with some other useful metadata.
+type JobInsertResult struct {
+	// Job is a struct containing the database persisted properties of the
+	// inserted job.
+	Job *JobRow
+
+	// UniqueSkippedAsDuplicate is true if for a unique job, the insertion was
+	// skipped due to an equivalent job matching unique property already being
+	// present.
+	UniqueSkippedAsDuplicate bool
+}
+
 // JobRow contains the properties of a job that are persisted to the database.
 // Use of `Job[T]` will generally be preferred in user-facing code like worker
 // interfaces.


### PR DESCRIPTION
This one's aimed at resolving the problem described in this discussion
[1]. In short, when an inserted job with unique properties in skipped
because it was a duplicate, there's no easy way to ascertain through
River's API that this is what happened.

The cleanest resolution is what's proposed here. Instead of returning a
raw `JobRow`, insert functions return a `JobInsertResult` that contains
a job row, along with a boolean indicating whether an insertion was
skipped due to a duplicate unique. The result struct is also better for
future compatibility in that it could contain other metadata pertaining
to job insertions.

The downside of this approach is that it's a breaking change. The hope
is that it's not _that_ bad of a breaking change because most of the
time callers don't care that much about properties on a return result
row given they just sent most of it as a parameter to `Insert`, so they
might not be accessing any return values and therefore not be broken.

You can get a rough idea for changes in callers by looking at what
changed in this diff. `client_test.go` needed quite a few tweaks because
it's doing some more comprehensive testing, but only one example test
(more representative of user code) had to change, which is a good sign.

[1] https://github.com/riverqueue/river/discussions/86