### PR TITLE
Change return value of `InsertMany` from `int64` to more conventional `int` (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking change:** JobList/JobListTx now support querying Jobs by a list of Job Kinds and States. Also allows for filtering by specific timestamp values. Thank you Jos Kraaijeveld (@thatjos)! 🙏🏻 [PR #236](https://github.com/riverqueue/river/pull/236).
+- **Breaking change:** Client `InsertMany` and `InsertManyTx` now return number of jobs inserted as `int` instead of `int64`. This change was made to make the type in use a little more idiomatic. [PR #293](https://github.com/riverqueue/river/pull/293).
 - **Breaking change:** `river.JobState*` type aliases have been removed. All job state constants should be accessed through `rivertype.JobState*` instead. [PR #300](https://github.com/riverqueue/river/pull/300).
 
 ## [0.3.0] - 2024-04-15

--- a/client.go
+++ b/client.go
@@ -1342,7 +1342,7 @@ type InsertManyParams struct {
 //	if err != nil {
 //		// handle error
 //	}
-func (c *Client[TTx]) InsertMany(ctx context.Context, params []InsertManyParams) (int64, error) {
+func (c *Client[TTx]) InsertMany(ctx context.Context, params []InsertManyParams) (int, error) {
 	if !c.driver.HasPool() {
 		return 0, errNoDriverDBPool
 	}
@@ -1374,7 +1374,7 @@ func (c *Client[TTx]) InsertMany(ctx context.Context, params []InsertManyParams)
 // This variant lets a caller insert jobs atomically alongside other database
 // changes. An inserted job isn't visible to be worked until the transaction
 // commits, and if the transaction rolls back, so too is the inserted job.
-func (c *Client[TTx]) InsertManyTx(ctx context.Context, tx TTx, params []InsertManyParams) (int64, error) {
+func (c *Client[TTx]) InsertManyTx(ctx context.Context, tx TTx, params []InsertManyParams) (int, error) {
 	insertParams, err := c.insertManyParams(params)
 	if err != nil {
 		return 0, err

--- a/client_test.go
+++ b/client_test.go
@@ -1134,7 +1134,7 @@ func Test_Client_InsertMany(t *testing.T) {
 			{Args: noOpArgs{}},
 		})
 		require.NoError(t, err)
-		require.Equal(t, int64(2), count)
+		require.Equal(t, 2, count)
 
 		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
 		require.NoError(t, err)
@@ -1150,7 +1150,7 @@ func Test_Client_InsertMany(t *testing.T) {
 			{Args: &noOpArgs{}, InsertOpts: &InsertOpts{ScheduledAt: time.Time{}}},
 		})
 		require.NoError(t, err)
-		require.Equal(t, int64(1), count)
+		require.Equal(t, 1, count)
 
 		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
 		require.NoError(t, err)
@@ -1168,7 +1168,7 @@ func Test_Client_InsertMany(t *testing.T) {
 			{Args: &noOpArgs{}, InsertOpts: &InsertOpts{Queue: "invalid*queue"}},
 		})
 		require.ErrorContains(t, err, "queue name is invalid")
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 
 	t.Run("ErrorsOnDriverWithoutPool", func(t *testing.T) {
@@ -1185,7 +1185,7 @@ func Test_Client_InsertMany(t *testing.T) {
 			{Args: noOpArgs{}},
 		})
 		require.ErrorIs(t, err, errNoDriverDBPool)
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 
 	t.Run("ErrorsWithZeroJobs", func(t *testing.T) {
@@ -1195,7 +1195,7 @@ func Test_Client_InsertMany(t *testing.T) {
 
 		count, err := client.InsertMany(ctx, []InsertManyParams{})
 		require.EqualError(t, err, "no jobs to insert")
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 
 	t.Run("ErrorsOnUnknownJobKindWithWorkers", func(t *testing.T) {
@@ -1209,7 +1209,7 @@ func Test_Client_InsertMany(t *testing.T) {
 		var unknownJobKindErr *UnknownJobKindError
 		require.ErrorAs(t, err, &unknownJobKindErr)
 		require.Equal(t, (&unregisteredJobArgs{}).Kind(), unknownJobKindErr.Kind)
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 
 	t.Run("AllowsUnknownJobKindWithoutWorkers", func(t *testing.T) {
@@ -1234,7 +1234,7 @@ func Test_Client_InsertMany(t *testing.T) {
 			{Args: noOpArgs{}, InsertOpts: &InsertOpts{UniqueOpts: UniqueOpts{ByArgs: true}}},
 		})
 		require.EqualError(t, err, "UniqueOpts are not supported for batch inserts")
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 }
 
@@ -1273,7 +1273,7 @@ func Test_Client_InsertManyTx(t *testing.T) {
 			{Args: noOpArgs{}},
 		})
 		require.NoError(t, err)
-		require.Equal(t, int64(2), count)
+		require.Equal(t, 2, count)
 
 		jobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
 		require.NoError(t, err)
@@ -1296,7 +1296,7 @@ func Test_Client_InsertManyTx(t *testing.T) {
 
 		count, err := client.InsertManyTx(ctx, bundle.tx, []InsertManyParams{{noOpArgs{}, &InsertOpts{ScheduledAt: time.Now().Add(time.Minute)}}})
 		require.NoError(t, err)
-		require.Equal(t, int64(1), count)
+		require.Equal(t, 1, count)
 
 		insertedJobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
 		require.NoError(t, err)
@@ -1321,7 +1321,7 @@ func Test_Client_InsertManyTx(t *testing.T) {
 			{Args: noOpArgs{}},
 		})
 		require.NoError(t, err)
-		require.Equal(t, int64(1), count)
+		require.Equal(t, 1, count)
 	})
 
 	t.Run("ErrorsWithZeroJobs", func(t *testing.T) {
@@ -1331,7 +1331,7 @@ func Test_Client_InsertManyTx(t *testing.T) {
 
 		count, err := client.InsertManyTx(ctx, bundle.tx, []InsertManyParams{})
 		require.EqualError(t, err, "no jobs to insert")
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 
 	t.Run("ErrorsOnUnknownJobKindWithWorkers", func(t *testing.T) {
@@ -1345,7 +1345,7 @@ func Test_Client_InsertManyTx(t *testing.T) {
 		var unknownJobKindErr *UnknownJobKindError
 		require.ErrorAs(t, err, &unknownJobKindErr)
 		require.Equal(t, (&unregisteredJobArgs{}).Kind(), unknownJobKindErr.Kind)
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 
 	t.Run("AllowsUnknownJobKindWithoutWorkers", func(t *testing.T) {
@@ -1370,7 +1370,7 @@ func Test_Client_InsertManyTx(t *testing.T) {
 			{Args: noOpArgs{}, InsertOpts: &InsertOpts{UniqueOpts: UniqueOpts{ByArgs: true}}},
 		})
 		require.EqualError(t, err, "UniqueOpts are not supported for batch inserts")
-		require.Equal(t, int64(0), count)
+		require.Equal(t, 0, count)
 	})
 }
 

--- a/internal/cmd/producersample/main.go
+++ b/internal/cmd/producersample/main.go
@@ -174,7 +174,7 @@ func (p *producerSample) insertBulkJobs(ctx context.Context, client *river.Clien
 	if err != nil {
 		return fmt.Errorf("error inserting jobs: %w", err)
 	}
-	if int(inserted) != jobCount {
+	if inserted != jobCount {
 		return fmt.Errorf("expected to insert %d jobs, but only inserted %d", jobCount, inserted)
 	}
 

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -701,7 +701,7 @@ func ExerciseExecutorFull[TTx any](ctx context.Context, t *testing.T, driver riv
 
 		count, err := exec.JobInsertFastMany(ctx, insertParams)
 		require.NoError(t, err)
-		require.Len(t, insertParams, int(count))
+		require.Len(t, insertParams, count)
 
 		jobsAfter, err := exec.JobGetByKindMany(ctx, []string{"test_kind"})
 		require.NoError(t, err)

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -85,7 +85,7 @@ type Executor interface {
 	JobGetByKindMany(ctx context.Context, kind []string) ([]*rivertype.JobRow, error)
 	JobGetStuck(ctx context.Context, params *JobGetStuckParams) ([]*rivertype.JobRow, error)
 	JobInsertFast(ctx context.Context, params *JobInsertFastParams) (*rivertype.JobRow, error)
-	JobInsertFastMany(ctx context.Context, params []*JobInsertFastParams) (int64, error)
+	JobInsertFastMany(ctx context.Context, params []*JobInsertFastParams) (int, error)
 	JobInsertFull(ctx context.Context, params *JobInsertFullParams) (*rivertype.JobRow, error)
 	JobList(ctx context.Context, sql string, namedArgs map[string]any) ([]*rivertype.JobRow, error)
 	JobListFields() string

--- a/riverdriver/riverdatabasesql/river_database_sql.go
+++ b/riverdriver/riverdatabasesql/river_database_sql.go
@@ -109,7 +109,7 @@ func (e *Executor) JobInsertFast(ctx context.Context, params *riverdriver.JobIns
 	return nil, riverdriver.ErrNotImplemented
 }
 
-func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.JobInsertFastParams) (int64, error) {
+func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.JobInsertFastParams) (int, error) {
 	return 0, riverdriver.ErrNotImplemented
 }
 

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -172,7 +172,7 @@ func (e *Executor) JobInsertFast(ctx context.Context, params *riverdriver.JobIns
 	return jobRowFromInternal(job), nil
 }
 
-func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.JobInsertFastParams) (int64, error) {
+func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.JobInsertFastParams) (int, error) {
 	insertJobsParams := make([]*dbsqlc.JobInsertManyParams, len(params))
 	now := time.Now()
 
@@ -212,7 +212,7 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 		return 0, fmt.Errorf("error inserting many jobs: %w", err)
 	}
 
-	return numInserted, nil
+	return int(numInserted), nil
 }
 
 func (e *Executor) JobInsertFull(ctx context.Context, params *riverdriver.JobInsertFullParams) (*rivertype.JobRow, error) {


### PR DESCRIPTION
Here, change the type of `Client.InsertMany` functions from `int64`s to
a more conventional `int`. This isn't really super necessary, but the
`int64` was an artifact of an internal value returned by sqlc, and using
`int` instead (which is also an int64 on the vast majority of all
system) is more conventional.

Because callers almost always know the size of the slice they passed to
`InsertMany`, or can ascertain it easily, I expect this change to break
very few integrations in practice. As we can see from our own test
suite, little had to change because `InsertMany`'s return value is
rarely needed.