### PR TITLE
Remove `river.JobState*` aliases in favor of using `rivertype` directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking change:** JobList/JobListTx now support querying Jobs by a list of Job Kinds and States. Also allows for filtering by specific timestamp values. Thank you Jos Kraaijeveld (@thatjos)! 🙏🏻 [PR #236](https://github.com/riverqueue/river/pull/236).
+- **Breaking change:** `river.JobState*` type aliases have been removed. All job state constants should be accessed through `rivertype.JobState*` instead. [PR #300](https://github.com/riverqueue/river/pull/300).
 
 ## [0.3.0] - 2024-04-15
 

--- a/client.go
+++ b/client.go
@@ -904,13 +904,13 @@ func (c *Client[TTx]) distributeJob(job *rivertype.JobRow, stats *JobStatistics)
 
 	var event *Event
 	switch job.State {
-	case JobStateCancelled:
+	case rivertype.JobStateCancelled:
 		event = &Event{Kind: EventKindJobCancelled, Job: job, JobStats: stats}
-	case JobStateCompleted:
+	case rivertype.JobStateCompleted:
 		event = &Event{Kind: EventKindJobCompleted, Job: job, JobStats: stats}
-	case JobStateScheduled:
+	case rivertype.JobStateScheduled:
 		event = &Event{Kind: EventKindJobSnoozed, Job: job, JobStats: stats}
-	case JobStateAvailable, JobStateDiscarded, JobStateRetryable, JobStateRunning:
+	case rivertype.JobStateAvailable, rivertype.JobStateDiscarded, rivertype.JobStateRetryable, rivertype.JobStateRunning:
 		event = &Event{Kind: EventKindJobFailed, Job: job, JobStats: stats}
 	default:
 		// linter exhaustive rule prevents this from being reached

--- a/job.go
+++ b/job.go
@@ -4,17 +4,6 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-const (
-	JobStateAvailable = rivertype.JobStateAvailable
-	JobStateCancelled = rivertype.JobStateCancelled
-	JobStateCompleted = rivertype.JobStateCompleted
-	JobStateDiscarded = rivertype.JobStateDiscarded
-	JobStateRetryable = rivertype.JobStateRetryable
-	JobStateRunning   = rivertype.JobStateRunning
-	JobStateScheduled = rivertype.JobStateScheduled
-)
-
-// Job represents a single unit of work, holding both the arguments and
 // information for a job with args of type T.
 type Job[T JobArgs] struct {
 	*rivertype.JobRow

--- a/job_complete_tx.go
+++ b/job_complete_tx.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/rivertype"
 )
 
 // JobCompleteTx marks the job as completed as part of transaction tx. If tx is
@@ -23,7 +24,7 @@ import (
 //
 // Returns the updated, completed job.
 func JobCompleteTx[TDriver riverdriver.Driver[TTx], TTx any, TArgs JobArgs](ctx context.Context, tx TTx, job *Job[TArgs]) (*Job[TArgs], error) {
-	if job.State != JobStateRunning {
+	if job.State != rivertype.JobStateRunning {
 		return nil, errors.New("job must be running")
 	}
 

--- a/job_complete_tx_test.go
+++ b/job_complete_tx_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/riverqueue/river/internal/util/ptrutil"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
 )
 
 func TestJobCompleteTx(t *testing.T) {
@@ -46,17 +47,17 @@ func TestJobCompleteTx(t *testing.T) {
 		bundle := setup(t)
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(JobStateRunning),
+			State: ptrutil.Ptr(rivertype.JobStateRunning),
 		})
 
 		completedJob, err := JobCompleteTx[*riverpgxv5.Driver](ctx, bundle.tx, &Job[JobArgs]{JobRow: job})
 		require.NoError(t, err)
-		require.Equal(t, JobStateCompleted, completedJob.State)
+		require.Equal(t, rivertype.JobStateCompleted, completedJob.State)
 		require.WithinDuration(t, time.Now(), *completedJob.FinalizedAt, 2*time.Second)
 
 		updatedJob, err := bundle.exec.JobGetByID(ctx, job.ID)
 		require.NoError(t, err)
-		require.Equal(t, JobStateCompleted, updatedJob.State)
+		require.Equal(t, rivertype.JobStateCompleted, updatedJob.State)
 	})
 
 	t.Run("ErrorIfNotRunning", func(t *testing.T) {

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -149,13 +149,13 @@ func NewJobListParams() *JobListParams {
 		sortField:       JobListOrderByTime,
 		sortOrder:       SortOrderAsc,
 		states: []rivertype.JobState{
-			JobStateAvailable,
-			JobStateCancelled,
-			JobStateCompleted,
-			JobStateDiscarded,
-			JobStateRetryable,
-			JobStateRunning,
-			JobStateScheduled,
+			rivertype.JobStateAvailable,
+			rivertype.JobStateCancelled,
+			rivertype.JobStateCompleted,
+			rivertype.JobStateDiscarded,
+			rivertype.JobStateRetryable,
+			rivertype.JobStateRunning,
+			rivertype.JobStateScheduled,
 		},
 	}
 }
@@ -195,7 +195,7 @@ func (p *JobListParams) toDBParams() (*dblist.JobListParams, error) {
 		for _, state := range p.states {
 			//nolint:exhaustive
 			switch state {
-			case JobStateCancelled, JobStateCompleted, JobStateDiscarded:
+			case rivertype.JobStateCancelled, rivertype.JobStateCompleted, rivertype.JobStateDiscarded:
 			default:
 				currentNonFinalizedStates = append(currentNonFinalizedStates, state)
 			}
@@ -317,9 +317,9 @@ func (p *JobListParams) OrderBy(field JobListOrderByField, direction SortOrder) 
 		result.sortField = field
 		if !p.overrodeState {
 			result.states = []rivertype.JobState{
-				JobStateCancelled,
-				JobStateCompleted,
-				JobStateDiscarded,
+				rivertype.JobStateCancelled,
+				rivertype.JobStateCompleted,
+				rivertype.JobStateDiscarded,
 			}
 		}
 	default:

--- a/job_test.go
+++ b/job_test.go
@@ -16,5 +16,5 @@ func TestJobUniqueOpts_isEmpty(t *testing.T) {
 	require.False(t, (&UniqueOpts{ByArgs: true}).isEmpty())
 	require.False(t, (&UniqueOpts{ByPeriod: 1 * time.Nanosecond}).isEmpty())
 	require.False(t, (&UniqueOpts{ByQueue: true}).isEmpty())
-	require.False(t, (&UniqueOpts{ByState: []rivertype.JobState{JobStateAvailable}}).isEmpty())
+	require.False(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobStateAvailable}}).isEmpty())
 }

--- a/rivertest/rivertest_test.go
+++ b/rivertest/rivertest_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
 )
 
 // Gives us a nice, stable time to test against.
@@ -251,7 +252,7 @@ func TestRequireInsertedTx(t *testing.T) {
 				Priority:    2,
 				Queue:       "another_queue",
 				ScheduledAt: testTime,
-				State:       river.JobStateScheduled,
+				State:       rivertype.JobStateScheduled,
 				Tags:        []string{"tag1"},
 			})
 			require.True(t, mockT.Failed)
@@ -268,7 +269,7 @@ func TestRequireInsertedTx(t *testing.T) {
 				Priority:    3,
 				Queue:       "another_queue",
 				ScheduledAt: testTime,
-				State:       river.JobStateScheduled,
+				State:       rivertype.JobStateScheduled,
 				Tags:        []string{"tag1"},
 			})
 			require.True(t, mockT.Failed)
@@ -285,7 +286,7 @@ func TestRequireInsertedTx(t *testing.T) {
 				Priority:    2,
 				Queue:       "wrong-queue",
 				ScheduledAt: testTime,
-				State:       river.JobStateScheduled,
+				State:       rivertype.JobStateScheduled,
 				Tags:        []string{"tag1"},
 			})
 			require.True(t, mockT.Failed)
@@ -302,7 +303,7 @@ func TestRequireInsertedTx(t *testing.T) {
 				Priority:    2,
 				Queue:       "another_queue",
 				ScheduledAt: testTime.Add(3*time.Minute + 23*time.Second + 123*time.Microsecond),
-				State:       river.JobStateScheduled,
+				State:       rivertype.JobStateScheduled,
 				Tags:        []string{"tag1"},
 			})
 			require.True(t, mockT.Failed)
@@ -319,7 +320,7 @@ func TestRequireInsertedTx(t *testing.T) {
 				Priority:    2,
 				Queue:       "another_queue",
 				ScheduledAt: testTime,
-				State:       river.JobStateCancelled,
+				State:       rivertype.JobStateCancelled,
 				Tags:        []string{"tag1"},
 			})
 			require.True(t, mockT.Failed)
@@ -336,7 +337,7 @@ func TestRequireInsertedTx(t *testing.T) {
 				Priority:    2,
 				Queue:       "another_queue",
 				ScheduledAt: testTime,
-				State:       river.JobStateScheduled,
+				State:       rivertype.JobStateScheduled,
 				Tags:        []string{"tag2"},
 			})
 			require.True(t, mockT.Failed)
@@ -674,7 +675,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 						Priority:    2,
 						Queue:       "another_queue",
 						ScheduledAt: testTime,
-						State:       river.JobStateScheduled,
+						State:       rivertype.JobStateScheduled,
 						Tags:        []string{"tag1"},
 					},
 				},
@@ -696,7 +697,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 						Priority:    3,
 						Queue:       "another_queue",
 						ScheduledAt: testTime,
-						State:       river.JobStateScheduled,
+						State:       rivertype.JobStateScheduled,
 						Tags:        []string{"tag1"},
 					},
 				},
@@ -718,7 +719,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 						Priority:    2,
 						Queue:       "wrong-queue",
 						ScheduledAt: testTime,
-						State:       river.JobStateScheduled,
+						State:       rivertype.JobStateScheduled,
 						Tags:        []string{"tag1"},
 					},
 				},
@@ -740,7 +741,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 						Priority:    2,
 						Queue:       "another_queue",
 						ScheduledAt: testTime.Add(3*time.Minute + 23*time.Second + 123*time.Microsecond),
-						State:       river.JobStateScheduled,
+						State:       rivertype.JobStateScheduled,
 						Tags:        []string{"tag1"},
 					},
 				},
@@ -761,7 +762,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 						MaxAttempts: 78,
 						Priority:    2,
 						Queue:       "another_queue",
-						State:       river.JobStateCancelled,
+						State:       rivertype.JobStateCancelled,
 						ScheduledAt: testTime,
 						Tags:        []string{"tag1"},
 					},
@@ -784,7 +785,7 @@ func TestRequireManyInsertedTx(t *testing.T) {
 						Priority:    2,
 						Queue:       "another_queue",
 						ScheduledAt: testTime,
-						State:       river.JobStateScheduled,
+						State:       rivertype.JobStateScheduled,
 						Tags:        []string{"tag2"},
 					},
 				},


### PR DESCRIPTION
One of the accidental API misdesigns I forgot to address on the initial
version of River was that type aliases for `JobState*` had been left in
the top-level `river` namespace.

Having them in `river` may make use slightly more convenient, but makes
"jump to definition" worse because it requires an additional redirect,
and the decision to use `river` or `rivertype` ambiguous in that there's
no canonically correct answer. The aliases also make adding a new state
a little more risky because the alias may be forgotten.

I wouldn't normally make this change post-ship, but given we're doing a
couple breaking changes all at once, it's our last, best opportunity to
fix the (mild) problem.