### PR TITLE
Prepare release `v0.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2024-04-15
+
 ### Added
 
 - The River client now supports "poll only" mode with `Config.PollOnly` which makes it avoid issuing `LISTEN` statements to wait for new events like a leadership resignation or new job available. The program instead polls periodically to look for changes. A leader resigning or a new job being available will be noticed less quickly, but `PollOnly` potentially makes River operable on systems without listen/notify support, like PgBouncer operating in transaction pooling mode. [PR #281](https://github.com/riverqueue/river/pull/281).

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.2.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.2.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.2.0
-	github.com/riverqueue/river/rivertype v0.2.0
+	github.com/riverqueue/river/riverdriver v0.3.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.3.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.3.0
+	github.com/riverqueue/river/rivertype v0.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.2.0
+require github.com/riverqueue/river/rivertype v0.3.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.2.0
-	github.com/riverqueue/river/rivertype v0.2.0
+	github.com/riverqueue/river/riverdriver v0.3.0
+	github.com/riverqueue/river/rivertype v0.3.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -9,8 +9,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.2.0
-	github.com/riverqueue/river/rivertype v0.2.0
+	github.com/riverqueue/river/riverdriver v0.3.0
+	github.com/riverqueue/river/rivertype v0.3.0
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prep release of `v0.3.0`. This is a relatively small one containing
mainly #281 and #297, but I think it's not a bad idea to cut a release
since we haven't done one in a while, and to get these additive changes
out ahead of the number of breaking changes that'll probably come with
the next release.