### PR TITLE
Change JobList ergnomics - add filtering by states, return cursor from JobList function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Although it comes with a number of improvements, there's nothing particularly no
 - River uses a new job completer that batches up completion work so that large numbers of them can be performed more efficiently. In a purely synthetic (i.e. mostly unrealistic) benchmark, River's job throughput increases ~4.5x. [PR #258](https://github.com/riverqueue/river/pull/258).
 - Changed default client IDs to be a combination of hostname and the time which the client started. This can still be changed by specifying `Config.ID`. [PR #255](https://github.com/riverqueue/river/pull/255).
 - Notifier refactored for better robustness and testability. [PR #253](https://github.com/riverqueue/river/pull/253).
+- JobList/JobListTx now support querying Jobs by a list of Job Kinds and States (breaking change). Also allows for filtering by specific timestamp values. [PR #236](https://github.com/riverqueue/river/pull/236).
+
 
 ## [0.0.25] - 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking change:** JobList/JobListTx now support querying Jobs by a list of Job Kinds and States. Also allows for filtering by specific timestamp values. Thank you Jos Kraaijeveld (@thatjos)! 🙏🏻 [PR #236](https://github.com/riverqueue/river/pull/236).
+
 ## [0.3.0] - 2024-04-15
 
 ### Added
@@ -46,8 +50,6 @@ Although it comes with a number of improvements, there's nothing particularly no
 - River uses a new job completer that batches up completion work so that large numbers of them can be performed more efficiently. In a purely synthetic (i.e. mostly unrealistic) benchmark, River's job throughput increases ~4.5x. [PR #258](https://github.com/riverqueue/river/pull/258).
 - Changed default client IDs to be a combination of hostname and the time which the client started. This can still be changed by specifying `Config.ID`. [PR #255](https://github.com/riverqueue/river/pull/255).
 - Notifier refactored for better robustness and testability. [PR #253](https://github.com/riverqueue/river/pull/253).
-- JobList/JobListTx now support querying Jobs by a list of Job Kinds and States (breaking change). Also allows for filtering by specific timestamp values. [PR #236](https://github.com/riverqueue/river/pull/236).
-
 
 ## [0.0.25] - 2024-03-01
 

--- a/client.go
+++ b/client.go
@@ -1449,8 +1449,8 @@ func validateQueueName(queueName string) error {
 // JobListResult is the result of a job list operation. It contains a list of
 // jobs and a cursor for fetching the next page of results.
 type JobListResult struct {
-	Jobs   []*rivertype.JobRow
-	Cursor *JobListCursor
+	Jobs       []*rivertype.JobRow
+	LastCursor *JobListCursor
 }
 
 // JobList returns a paginated list of jobs matching the provided filters. The
@@ -1481,7 +1481,7 @@ func (c *Client[TTx]) JobList(ctx context.Context, params *JobListParams) (*JobL
 	}
 	res := &JobListResult{Jobs: jobs}
 	if len(jobs) > 0 {
-		res.Cursor = JobListCursorFromJob(jobs[len(jobs)-1], params.sortField)
+		res.LastCursor = JobListCursorFromJob(jobs[len(jobs)-1], params.sortField)
 	}
 	return res, nil
 }
@@ -1511,7 +1511,7 @@ func (c *Client[TTx]) JobListTx(ctx context.Context, tx TTx, params *JobListPara
 	}
 	res := &JobListResult{Jobs: jobs}
 	if len(jobs) > 0 {
-		res.Cursor = JobListCursorFromJob(jobs[len(jobs)-1], params.sortField)
+		res.LastCursor = JobListCursorFromJob(jobs[len(jobs)-1], params.sortField)
 	}
 	return res, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -702,7 +702,7 @@ func Test_Client_Stop(t *testing.T) {
 
 		require.NoError(t, client.Stop(ctx))
 
-		runningJobs, err := client.JobList(ctx, NewJobListParams().State(rivertype.JobStateRunning))
+		runningJobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
 		require.Empty(t, runningJobs, "expected no jobs to be left running")
 	})
@@ -1449,12 +1449,12 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_1")})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_2")})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().Kinds("test_kind_1"))
+		jobs, _, err := client.JobList(ctx, NewJobListParams().Kinds("test_kind_1"))
 		require.NoError(t, err)
 		// jobs ordered by ScheduledAt ASC by default
 		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().Kinds("test_kind_2"))
+		jobs, _, err = client.JobList(ctx, NewJobListParams().Kinds("test_kind_2"))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job3.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
@@ -1468,12 +1468,12 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_1")})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_2")})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().Queues("queue_1"))
+		jobs, _, err := client.JobList(ctx, NewJobListParams().Queues("queue_1"))
 		require.NoError(t, err)
 		// jobs ordered by ScheduledAt ASC by default
 		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().Queues("queue_2"))
+		jobs, _, err = client.JobList(ctx, NewJobListParams().Queues("queue_2"))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job3.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
@@ -1487,12 +1487,12 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State(JobStateAvailable))
+		jobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateAvailable))
 		require.NoError(t, err)
 		// jobs ordered by ScheduledAt ASC by default
 		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(JobStateRunning))
+		jobs, _, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job3.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
@@ -1513,11 +1513,11 @@ func Test_Client_JobList(t *testing.T) {
 			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), ScheduledAt: &now})
 			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 
-			jobs, err := client.JobList(ctx, NewJobListParams().State(state))
+			jobs, _, err := client.JobList(ctx, NewJobListParams().States(state))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-			jobs, err = client.JobList(ctx, NewJobListParams().State(state).OrderBy(JobListOrderByTime, SortOrderDesc))
+			jobs, _, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 		}
@@ -1539,11 +1539,11 @@ func Test_Client_JobList(t *testing.T) {
 			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), FinalizedAt: ptrutil.Ptr(now.Add(-10 * time.Second))})
 			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), FinalizedAt: ptrutil.Ptr(now.Add(-15 * time.Second))})
 
-			jobs, err := client.JobList(ctx, NewJobListParams().State(state))
+			jobs, _, err := client.JobList(ctx, NewJobListParams().States(state))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-			jobs, err = client.JobList(ctx, NewJobListParams().State(state).OrderBy(JobListOrderByTime, SortOrderDesc))
+			jobs, _, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
 			require.NoError(t, err)
 			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 		}
@@ -1558,17 +1558,17 @@ func Test_Client_JobList(t *testing.T) {
 		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: &now})
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State(JobStateRunning))
+		jobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(JobStateRunning).OrderBy(JobListOrderByTime, SortOrderDesc))
+		jobs, _, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning).OrderBy(JobListOrderByTime, SortOrderDesc))
 		require.NoError(t, err)
 		// Sort order was explicitly reversed:
 		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
-	t.Run("WithNilParamsFiltersToAvailableByDefault", func(t *testing.T) {
+	t.Run("WithNilParamsFiltersToAllStatesByDefault", func(t *testing.T) {
 		t.Parallel()
 
 		client, bundle := setup(t)
@@ -1576,12 +1576,12 @@ func Test_Client_JobList(t *testing.T) {
 		now := time.Now().UTC()
 		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: &now})
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), ScheduledAt: ptrutil.Ptr(now.Add(-2 * time.Second))})
 
-		jobs, err := client.JobList(ctx, nil)
+		jobs, _, err := client.JobList(ctx, nil)
 		require.NoError(t, err)
 		// sort order is switched by ScheduledAt values:
-		require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job2.ID, job3.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("PaginatesWithAfter", func(t *testing.T) {
@@ -1592,22 +1592,31 @@ func Test_Client_JobList(t *testing.T) {
 		now := time.Now().UTC()
 		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: &now})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: &now})
-		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		job6 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: &now})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second)), AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
+		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), ScheduledAt: ptrutil.Ptr(now.Add(-6 * time.Second)), AttemptedAt: &now})
+		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), ScheduledAt: ptrutil.Ptr(now.Add(-7 * time.Second)), FinalizedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
+		job6 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), ScheduledAt: ptrutil.Ptr(now.Add(-7 * time.Second)), FinalizedAt: &now})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().After(JobListCursorFromJob(job1)))
+		jobs, cursor, err := client.JobList(ctx, NewJobListParams().States(rivertype.JobStateAvailable).After(JobListCursorFromJob(job1, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, cursor.id, job2.ID)
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(rivertype.JobStateRunning).After(JobListCursorFromJob(job3)))
+		jobs, cursor, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateRunning).After(JobListCursorFromJob(job3, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job4.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, cursor.id, job4.ID)
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State(rivertype.JobStateCompleted).After(JobListCursorFromJob(job5)))
+		jobs, cursor, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateCompleted).After(JobListCursorFromJob(job5, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job6.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, cursor.id, job6.ID)
+
+		jobs, cursor, err = client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job4, JobListOrderByScheduledAt)))
+		require.NoError(t, err)
+		require.Equal(t, []int64{job1.ID, job3.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, cursor.sortField, JobListOrderByScheduledAt)
+		require.Equal(t, cursor.id, job2.ID)
 	})
 
 	t.Run("MetadataOnly", func(t *testing.T) {
@@ -1619,11 +1628,11 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Metadata: []byte(`{"baz": "value"}`)})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Metadata: []byte(`{"baz": "value"}`)})
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State("").Metadata(`{"foo": "bar"}`))
+		jobs, _, err := client.JobList(ctx, NewJobListParams().Metadata(`{"foo": "bar"}`))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, err = client.JobList(ctx, NewJobListParams().State("").Metadata(`{"baz": "value"}`).OrderBy(JobListOrderByTime, SortOrderDesc))
+		jobs, _, err = client.JobList(ctx, NewJobListParams().Metadata(`{"baz": "value"}`).OrderBy(JobListOrderByTime, SortOrderDesc))
 		require.NoError(t, err)
 		// Sort order was explicitly reversed:
 		require.Equal(t, []int64{job3.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
@@ -1637,7 +1646,7 @@ func Test_Client_JobList(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel() // cancel immediately
 
-		jobs, err := client.JobList(ctx, NewJobListParams().State(JobStateRunning))
+		jobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.ErrorIs(t, context.Canceled, err)
 		require.Empty(t, jobs)
 	})

--- a/client_test.go
+++ b/client_test.go
@@ -1600,23 +1600,23 @@ func Test_Client_JobList(t *testing.T) {
 		res, err := client.JobList(ctx, NewJobListParams().States(rivertype.JobStateAvailable).After(JobListCursorFromJob(job1, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, res.Cursor.id, job2.ID)
+		require.Equal(t, job2.ID, res.Cursor.id)
 
 		res, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateRunning).After(JobListCursorFromJob(job3, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job4.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, res.Cursor.id, job4.ID)
+		require.Equal(t, job4.ID, res.Cursor.id)
 
 		res, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateCompleted).After(JobListCursorFromJob(job5, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job6.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, res.Cursor.id, job6.ID)
+		require.Equal(t, job6.ID, res.Cursor.id)
 
 		res, err = client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job4, JobListOrderByScheduledAt)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job1.ID, job3.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, res.Cursor.sortField, JobListOrderByScheduledAt)
-		require.Equal(t, res.Cursor.id, job2.ID)
+		require.Equal(t, JobListOrderByScheduledAt, res.Cursor.sortField)
+		require.Equal(t, job2.ID, res.Cursor.id)
 	})
 
 	t.Run("MetadataOnly", func(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -1600,23 +1600,23 @@ func Test_Client_JobList(t *testing.T) {
 		res, err := client.JobList(ctx, NewJobListParams().States(rivertype.JobStateAvailable).After(JobListCursorFromJob(job1, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, job2.ID, res.Cursor.id)
+		require.Equal(t, job2.ID, res.LastCursor.id)
 
 		res, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateRunning).After(JobListCursorFromJob(job3, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job4.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, job4.ID, res.Cursor.id)
+		require.Equal(t, job4.ID, res.LastCursor.id)
 
 		res, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateCompleted).After(JobListCursorFromJob(job5, JobListOrderByTime)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job6.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, job6.ID, res.Cursor.id)
+		require.Equal(t, job6.ID, res.LastCursor.id)
 
 		res, err = client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job4, JobListOrderByScheduledAt)))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job1.ID, job3.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, JobListOrderByScheduledAt, res.Cursor.sortField)
-		require.Equal(t, job2.ID, res.Cursor.id)
+		require.Equal(t, JobListOrderByScheduledAt, res.LastCursor.sortField)
+		require.Equal(t, job2.ID, res.LastCursor.id)
 	})
 
 	t.Run("MetadataOnly", func(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -702,9 +702,9 @@ func Test_Client_Stop(t *testing.T) {
 
 		require.NoError(t, client.Stop(ctx))
 
-		runningJobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
+		res, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
-		require.Empty(t, runningJobs, "expected no jobs to be left running")
+		require.Empty(t, res.Jobs, "expected no jobs to be left running")
 	})
 
 	t.Run("WithSubscriber", func(t *testing.T) {
@@ -1449,14 +1449,14 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_1")})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_2")})
 
-		jobs, _, err := client.JobList(ctx, NewJobListParams().Kinds("test_kind_1"))
+		res, err := client.JobList(ctx, NewJobListParams().Kinds("test_kind_1"))
 		require.NoError(t, err)
 		// jobs ordered by ScheduledAt ASC by default
-		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, _, err = client.JobList(ctx, NewJobListParams().Kinds("test_kind_2"))
+		res, err = client.JobList(ctx, NewJobListParams().Kinds("test_kind_2"))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job3.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job3.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("FiltersByQueue", func(t *testing.T) { //nolint:dupl
@@ -1468,14 +1468,14 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_1")})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_2")})
 
-		jobs, _, err := client.JobList(ctx, NewJobListParams().Queues("queue_1"))
+		res, err := client.JobList(ctx, NewJobListParams().Queues("queue_1"))
 		require.NoError(t, err)
 		// jobs ordered by ScheduledAt ASC by default
-		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, _, err = client.JobList(ctx, NewJobListParams().Queues("queue_2"))
+		res, err = client.JobList(ctx, NewJobListParams().Queues("queue_2"))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job3.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job3.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("FiltersByState", func(t *testing.T) {
@@ -1487,14 +1487,14 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
 
-		jobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateAvailable))
+		res, err := client.JobList(ctx, NewJobListParams().States(JobStateAvailable))
 		require.NoError(t, err)
 		// jobs ordered by ScheduledAt ASC by default
-		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, _, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning))
+		res, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job3.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job3.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("SortsAvailableRetryableAndScheduledJobsByScheduledAt", func(t *testing.T) {
@@ -1513,13 +1513,13 @@ func Test_Client_JobList(t *testing.T) {
 			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), ScheduledAt: &now})
 			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 
-			jobs, _, err := client.JobList(ctx, NewJobListParams().States(state))
+			res, err := client.JobList(ctx, NewJobListParams().States(state))
 			require.NoError(t, err)
-			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-			jobs, _, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
+			res, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
 			require.NoError(t, err)
-			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 		}
 	})
 
@@ -1539,13 +1539,13 @@ func Test_Client_JobList(t *testing.T) {
 			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), FinalizedAt: ptrutil.Ptr(now.Add(-10 * time.Second))})
 			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(dbState), FinalizedAt: ptrutil.Ptr(now.Add(-15 * time.Second))})
 
-			jobs, _, err := client.JobList(ctx, NewJobListParams().States(state))
+			res, err := client.JobList(ctx, NewJobListParams().States(state))
 			require.NoError(t, err)
-			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+			require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-			jobs, _, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
+			res, err = client.JobList(ctx, NewJobListParams().States(state).OrderBy(JobListOrderByTime, SortOrderDesc))
 			require.NoError(t, err)
-			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+			require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 		}
 	})
 
@@ -1558,14 +1558,14 @@ func Test_Client_JobList(t *testing.T) {
 		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: &now})
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 
-		jobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
+		res, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job2.ID, job1.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, _, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning).OrderBy(JobListOrderByTime, SortOrderDesc))
+		res, err = client.JobList(ctx, NewJobListParams().States(JobStateRunning).OrderBy(JobListOrderByTime, SortOrderDesc))
 		require.NoError(t, err)
 		// Sort order was explicitly reversed:
-		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job1.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("WithNilParamsFiltersToAllStatesByDefault", func(t *testing.T) {
@@ -1578,10 +1578,10 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), ScheduledAt: ptrutil.Ptr(now.Add(-2 * time.Second))})
 
-		jobs, _, err := client.JobList(ctx, nil)
+		res, err := client.JobList(ctx, nil)
 		require.NoError(t, err)
 		// sort order is switched by ScheduledAt values:
-		require.Equal(t, []int64{job2.ID, job3.ID, job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job2.ID, job3.ID, job1.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("PaginatesWithAfter", func(t *testing.T) {
@@ -1597,26 +1597,26 @@ func Test_Client_JobList(t *testing.T) {
 		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), ScheduledAt: ptrutil.Ptr(now.Add(-7 * time.Second)), FinalizedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
 		job6 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), ScheduledAt: ptrutil.Ptr(now.Add(-7 * time.Second)), FinalizedAt: &now})
 
-		jobs, cursor, err := client.JobList(ctx, NewJobListParams().States(rivertype.JobStateAvailable).After(JobListCursorFromJob(job1, JobListOrderByTime)))
+		res, err := client.JobList(ctx, NewJobListParams().States(rivertype.JobStateAvailable).After(JobListCursorFromJob(job1, JobListOrderByTime)))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, cursor.id, job2.ID)
+		require.Equal(t, []int64{job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, res.Cursor.id, job2.ID)
 
-		jobs, cursor, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateRunning).After(JobListCursorFromJob(job3, JobListOrderByTime)))
+		res, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateRunning).After(JobListCursorFromJob(job3, JobListOrderByTime)))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job4.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, cursor.id, job4.ID)
+		require.Equal(t, []int64{job4.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, res.Cursor.id, job4.ID)
 
-		jobs, cursor, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateCompleted).After(JobListCursorFromJob(job5, JobListOrderByTime)))
+		res, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateCompleted).After(JobListCursorFromJob(job5, JobListOrderByTime)))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job6.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, cursor.id, job6.ID)
+		require.Equal(t, []int64{job6.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, res.Cursor.id, job6.ID)
 
-		jobs, cursor, err = client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job4, JobListOrderByScheduledAt)))
+		res, err = client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job4, JobListOrderByScheduledAt)))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job1.ID, job3.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
-		require.Equal(t, cursor.sortField, JobListOrderByScheduledAt)
-		require.Equal(t, cursor.id, job2.ID)
+		require.Equal(t, []int64{job1.ID, job3.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, res.Cursor.sortField, JobListOrderByScheduledAt)
+		require.Equal(t, res.Cursor.id, job2.ID)
 	})
 
 	t.Run("MetadataOnly", func(t *testing.T) {
@@ -1628,14 +1628,14 @@ func Test_Client_JobList(t *testing.T) {
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Metadata: []byte(`{"baz": "value"}`)})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Metadata: []byte(`{"baz": "value"}`)})
 
-		jobs, _, err := client.JobList(ctx, NewJobListParams().Metadata(`{"foo": "bar"}`))
+		res, err := client.JobList(ctx, NewJobListParams().Metadata(`{"foo": "bar"}`))
 		require.NoError(t, err)
-		require.Equal(t, []int64{job1.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job1.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 
-		jobs, _, err = client.JobList(ctx, NewJobListParams().Metadata(`{"baz": "value"}`).OrderBy(JobListOrderByTime, SortOrderDesc))
+		res, err = client.JobList(ctx, NewJobListParams().Metadata(`{"baz": "value"}`).OrderBy(JobListOrderByTime, SortOrderDesc))
 		require.NoError(t, err)
 		// Sort order was explicitly reversed:
-		require.Equal(t, []int64{job3.ID, job2.ID}, sliceutil.Map(jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+		require.Equal(t, []int64{job3.ID, job2.ID}, sliceutil.Map(res.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("WithCancelledContext", func(t *testing.T) {
@@ -1646,9 +1646,9 @@ func Test_Client_JobList(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel() // cancel immediately
 
-		jobs, _, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
+		res, err := client.JobList(ctx, NewJobListParams().States(JobStateRunning))
 		require.ErrorIs(t, context.Canceled, err)
-		require.Empty(t, jobs)
+		require.Nil(t, res)
 	})
 }
 

--- a/internal/dblist/db_list.go
+++ b/internal/dblist/db_list.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/lib/pq"
+
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivertype"
 )

--- a/internal/dblist/db_list.go
+++ b/internal/dblist/db_list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lib/pq"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -42,7 +43,7 @@ type JobListParams struct {
 	OrderBy    []JobListOrderBy
 	Priorities []int16
 	Queues     []string
-	State      rivertype.JobState
+	States     []rivertype.JobState
 }
 
 func JobList(ctx context.Context, exec riverdriver.Executor, params *JobListParams) ([]*rivertype.JobRow, error) {
@@ -81,10 +82,10 @@ func JobList(ctx context.Context, exec riverdriver.Executor, params *JobListPara
 		namedArgs["queues"] = params.Queues
 	}
 
-	if params.State != "" {
+	if len(params.States) > 0 {
 		writeWhereOrAnd()
-		conditionsBuilder.WriteString("state = @state::river_job_state")
-		namedArgs["state"] = params.State
+		conditionsBuilder.WriteString("state = any(@states::river_job_state[])")
+		namedArgs["states"] = pq.Array(params.States)
 	}
 
 	if params.Conditions != "" {

--- a/internal/dblist/db_list_test.go
+++ b/internal/dblist/db_list_test.go
@@ -40,7 +40,7 @@ func TestJobListNoJobs(t *testing.T) {
 		bundle := setup()
 
 		_, err := JobList(ctx, bundle.exec, &JobListParams{
-			State:      rivertype.JobStateCompleted,
+			States:     []rivertype.JobState{rivertype.JobStateCompleted},
 			LimitCount: 1,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderAsc}},
 		})
@@ -55,7 +55,7 @@ func TestJobListNoJobs(t *testing.T) {
 		_, err := JobList(ctx, bundle.exec, &JobListParams{
 			Conditions: "queue = 'test' AND priority = 1 AND args->>'foo' = @foo",
 			NamedArgs:  pgx.NamedArgs{"foo": "bar"},
-			State:      rivertype.JobStateCompleted,
+			States:     []rivertype.JobState{rivertype.JobStateCompleted},
 			LimitCount: 1,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderAsc}},
 		})
@@ -123,7 +123,7 @@ func TestJobListWithJobs(t *testing.T) {
 		params := &JobListParams{
 			LimitCount: 3,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderDesc}},
-			State:      rivertype.JobStateAvailable,
+			States:     []rivertype.JobState{rivertype.JobStateAvailable},
 		}
 
 		execTest(ctx, t, bundle, params, func(jobs []*rivertype.JobRow, err error) {
@@ -150,7 +150,7 @@ func TestJobListWithJobs(t *testing.T) {
 			LimitCount: 2,
 			NamedArgs:  map[string]any{"paths1": []string{"job_num"}, "value1": 2},
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderDesc}},
-			State:      rivertype.JobStateAvailable,
+			States:     []rivertype.JobState{rivertype.JobStateAvailable},
 		}
 
 		execTest(ctx, t, bundle, params, func(jobs []*rivertype.JobRow, err error) {
@@ -172,7 +172,7 @@ func TestJobListWithJobs(t *testing.T) {
 			LimitCount: 2,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderDesc}},
 			Kinds:      []string{"alternate_kind"},
-			State:      rivertype.JobStateAvailable,
+			States:     []rivertype.JobState{rivertype.JobStateAvailable},
 		}
 
 		execTest(ctx, t, bundle, params, func(jobs []*rivertype.JobRow, err error) {
@@ -194,7 +194,7 @@ func TestJobListWithJobs(t *testing.T) {
 			LimitCount: 2,
 			OrderBy:    []JobListOrderBy{{Expr: "id", Order: SortOrderDesc}},
 			Queues:     []string{"priority"},
-			State:      rivertype.JobStateAvailable,
+			States:     []rivertype.JobState{rivertype.JobStateAvailable},
 		}
 
 		execTest(ctx, t, bundle, params, func(jobs []*rivertype.JobRow, err error) {

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -38,6 +38,9 @@ func JobListCursorFromJob(job *rivertype.JobRow, sortField JobListOrderByField) 
 		}
 	case JobListOrderByScheduledAt:
 		time = job.ScheduledAt
+	case JobListOrderByCreatedAt:
+	default:
+		// stick with created_at
 	}
 	return &JobListCursor{
 		id:        job.ID,
@@ -190,7 +193,7 @@ func (p *JobListParams) toDBParams() (*dblist.JobListParams, error) {
 		return nil, errors.New("invalid sort order")
 	}
 
-	timeField := "created_at"
+	var timeField string
 	if len(p.states) > 0 && p.sortField == JobListOrderByTime {
 		timeField = jobListTimeFieldForState(p.states[0])
 	} else {

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -116,17 +116,17 @@ const (
 type JobListOrderByField string
 
 const (
+	// JobListOrderByAttemptedAt specifies that the sort should be by attempted_at.
+	JobListOrderByAttemptedAt JobListOrderByField = "attempted_at"
+	// JobListOrderByCreatedAt specifies that the sort should be by created_at.
+	JobListOrderByCreatedAt JobListOrderByField = "created_at"
+	// JobListOrderByFinalizedAt specifies that the sort should be by finalized_at.
+	JobListOrderByFinalizedAt JobListOrderByField = "finalized_at"
+	// JobListOrderByScheduledAt specifies that the sort should be by scheduled_at.
+	JobListOrderByScheduledAt JobListOrderByField = "scheduled_at"
 	// JobListOrderByTime specifies that the sort should be by time. The specific
 	// time field used will vary by the first specified job state.
 	JobListOrderByTime JobListOrderByField = "time"
-	// JobListOrderByCreatedAt specifies that the sort should be by created_at.
-	JobListOrderByCreatedAt JobListOrderByField = "created_at"
-	// JobListOrderByScheduledAt specifies that the sort should be by scheduled_at.
-	JobListOrderByScheduledAt JobListOrderByField = "scheduled_at"
-	// JobListOrderByAttemptedAt specifies that the sort should be by attempted_at.
-	JobListOrderByAttemptedAt JobListOrderByField = "attempted_at"
-	// JobListOrderByFinalizedAt specifies that the sort should be by finalized_at.
-	JobListOrderByFinalizedAt JobListOrderByField = "finalized_at"
 )
 
 // JobListParams specifies the parameters for a JobList query. It must be

--- a/job_list_params_test.go
+++ b/job_list_params_test.go
@@ -35,7 +35,7 @@ func Test_JobListCursor_JobListCursorFromJob(t *testing.T) {
 				ScheduledAt: now.Add(-10 * time.Second),
 			}
 
-			cursor := JobListCursorFromJob(jobRow)
+			cursor := JobListCursorFromJob(jobRow, JobListOrderByTime)
 			require.Equal(t, jobRow.ID, cursor.id)
 			require.Equal(t, jobRow.Kind, cursor.kind)
 			require.Equal(t, jobRow.Queue, cursor.queue)
@@ -65,7 +65,7 @@ func Test_JobListCursor_JobListCursorFromJob(t *testing.T) {
 				ScheduledAt: now.Add(-10 * time.Second),
 			}
 
-			cursor := JobListCursorFromJob(jobRow)
+			cursor := JobListCursorFromJob(jobRow, JobListOrderByTime)
 			require.Equal(t, jobRow.ID, cursor.id)
 			require.Equal(t, jobRow.Kind, cursor.kind)
 			require.Equal(t, jobRow.Queue, cursor.queue)
@@ -87,7 +87,7 @@ func Test_JobListCursor_JobListCursorFromJob(t *testing.T) {
 			ScheduledAt: now.Add(-10 * time.Second),
 		}
 
-		cursor := JobListCursorFromJob(jobRow)
+		cursor := JobListCursorFromJob(jobRow, JobListOrderByTime)
 		require.Equal(t, jobRow.ID, cursor.id)
 		require.Equal(t, jobRow.Kind, cursor.kind)
 		require.Equal(t, jobRow.Queue, cursor.queue)
@@ -107,7 +107,7 @@ func Test_JobListCursor_JobListCursorFromJob(t *testing.T) {
 			ScheduledAt: now.Add(-10 * time.Second),
 		}
 
-		cursor := JobListCursorFromJob(jobRow)
+		cursor := JobListCursorFromJob(jobRow, JobListOrderByTime)
 		require.Equal(t, jobRow.ID, cursor.id)
 		require.Equal(t, jobRow.Kind, cursor.kind)
 		require.Equal(t, jobRow.Queue, cursor.queue)


### PR DESCRIPTION
A tweaked version of https://github.com/riverqueue/river/pull/236, removing queries which cannot be efficient on a large `river_job` table due to the lack of indexes.

Users are of course free to add their own indexes and write their own query functions, but we're a bit uncomfortable offering official APIs which will scale poorly.