### PR TITLE
Add capacity to list jobs by ID + make default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking change:** JobList/JobListTx now support querying Jobs by a list of Job Kinds and States. Also allows for filtering by specific timestamp values. Thank you Jos Kraaijeveld (@thatjos)! 🙏🏻 [PR #236](https://github.com/riverqueue/river/pull/236).
+- **Breaking change:**  There are a number of small breaking changes in the job list API using `JobList`/`JobListTx`:
+    - Now support querying jobs by a list of Job Kinds and States. Also allows for filtering by specific timestamp values. Thank you Jos Kraaijeveld (@thatjos)! 🙏🏻 [PR #236](https://github.com/riverqueue/river/pull/236).
+    - Job listing now defaults to ordering by job ID (`JobListOrderByID`) instead of a job timestamp dependent on on requested job state. The previous ordering behavior is still available with `NewJobListParams().OrderBy(JobListOrderByTime, SortOrderAsc)`. [PR #XXX](https://github.com/riverqueue/river/pull/XXX).
+    - The function `JobListCursorFromJob` no longer needs a sort order parameter. Instead, sort order is determined based on the job list parameters that the cursor is subsequently used with. [PR #XXX](https://github.com/riverqueue/river/pull/XXX).
 - **Breaking change:** Client `Insert` and `InsertTx` functions now return a `JobInsertResult` struct instead of a `JobRow`. This allows the result to include metadata like the new `UniqueSkippedAsDuplicate` property, so callers can tell whether an inserted job was skipped due to unique constraint. [PR #292](https://github.com/riverqueue/river/pull/292).
 - **Breaking change:** Client `InsertMany` and `InsertManyTx` now return number of jobs inserted as `int` instead of `int64`. This change was made to make the type in use a little more idiomatic. [PR #293](https://github.com/riverqueue/river/pull/293).
 - **Breaking change:** `river.JobState*` type aliases have been removed. All job state constants should be accessed through `rivertype.JobState*` instead. [PR #300](https://github.com/riverqueue/river/pull/300).

--- a/client.go
+++ b/client.go
@@ -1489,7 +1489,7 @@ func (c *Client[TTx]) JobList(ctx context.Context, params *JobListParams) (*JobL
 	}
 	res := &JobListResult{Jobs: jobs}
 	if len(jobs) > 0 {
-		res.LastCursor = JobListCursorFromJob(jobs[len(jobs)-1], params.sortField)
+		res.LastCursor = jobListCursorFromJobAndParams(jobs[len(jobs)-1], params)
 	}
 	return res, nil
 }
@@ -1519,7 +1519,7 @@ func (c *Client[TTx]) JobListTx(ctx context.Context, tx TTx, params *JobListPara
 	}
 	res := &JobListResult{Jobs: jobs}
 	if len(jobs) > 0 {
-		res.LastCursor = JobListCursorFromJob(jobs[len(jobs)-1], params.sortField)
+		res.LastCursor = jobListCursorFromJobAndParams(jobs[len(jobs)-1], params)
 	}
 	return res, nil
 }


### PR DESCRIPTION
Here, in addition to the new job list sort orders added by #304, add one
more for sorting by job ID, and make it the default.

This is another breaking change in the job list API, and I wouldn't
normally make it at this point, but our next release will contain a
number of breaking changes, including to the job list API, so the time
is now.

My rationale for the change:

* Listing and paginating by ID is an overwhelmingly common pattern in
  web and database APIs, and I think it being the default would be more
  intuitive for more people.

* Ordering by ID is more ergonomic because no `JobListParams.States`
  invocation needs to made. It's shorter, and especially when a fairly
  normal use case will be to iterate across all job rows, this is a
  minor nicety.

* Ordering by ID allows the entire job collection to be iterated
  regardless of job state. `JobListOrderByTime` requires a state, and
  some order is needed for cursors to work.

* The behavior of `JobListOrderByTime` is a little odd in that it
  changes dynamically based on the requested list states, and there's no
  way to intuit what the order will be without knowing a lot about River
  internals and thinking very carefully about it. Furthermore, the time
  that'd be chosen wasn't documented anywhere, so the only way to know
  for sure what it would be was to read River's source code.

* With the inclusion of #304, `JobListOrderByTime`'s behavior has gotten
  even a little more surprising because the state to be chosen to select
  a timestamp was the _first_ value sent to `JobListParams.States`, with
  any additional values sent ignored, also creating a somewhat nonsensical
  result (e.g. `States(running, available)` would select `attempted_at`,
  but would be `NULL` for any jobs in the `available` state). This
  behavior was not documented.

I also found a bug that was a hold over from #304 as more than one sort
order became available. The function `JobListCursorFromJob` took a sort
order, but would produce the wrong result unless the user remembered to
set the exact same sort order on their job list parameters. For example,
this would do the wrong thing:

    res, err = client.JobList(ctx, NewJobListParams().After(JobListCursorFromJob(job4, JobListOrderByScheduledAt)))

`JobListCursorFromJob` would extract `scheduled_at` from `job4`, but
then list using to the default job list order. Previously that was based
on time, so this result would've been wrong _unless_ the job list
parameters filtered to state `available`, `retryable`, or `scheduled` so
that `scheduled_at` was also used when comparing to other jobs.

A caller could compensate by specifying sort order in both places, but
this is pretty ugly, and there was no check to make sure that the list
paramaters and cursor shared the same order:

    res, err = client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job4, JobListOrderByScheduledAt)))

The corrected version of this doesn't use an order when initializing the
cursor, instead using the one from the job list params, meaning that the
same time field is always used between list query and what's extracted
from the cursor's job row.

    res, err = client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job4)))

This also makes the invocation shorter and more ergonomic to call.

Along with the above, we also make a few tweaks to documentation.
`JobListOrderByTime` now documents which timestamps it uses, and
indicates that only the first value sent to `JobListParams.States` will
be respected.