### PR TITLE
Replace list of all job states with `rivertype.JobStates()`

### DIFF
--- a/insert_opts.go
+++ b/insert_opts.go
@@ -140,16 +140,7 @@ func (o *UniqueOpts) isEmpty() bool {
 		o.ByState == nil
 }
 
-var jobStateAll = []rivertype.JobState{ //nolint:gochecknoglobals
-	rivertype.JobStateAvailable,
-	rivertype.JobStateCancelled,
-	rivertype.JobStateCompleted,
-	rivertype.JobStateDiscarded,
-	rivertype.JobStatePending,
-	rivertype.JobStateRetryable,
-	rivertype.JobStateRunning,
-	rivertype.JobStateScheduled,
-}
+var jobStateAll = rivertype.JobStates() //nolint:gochecknoglobals
 
 func (o *UniqueOpts) validate() error {
 	if o.isEmpty() {


### PR DESCRIPTION
A small change that removes a list of all job states defined in
`insert_opts.go` that was used to validate states sent into `UniqueOpts`
with `rivertype.JobStates()` which was introduced recently n #297.
Removing one of the lists means we only need to maintain one of them.

I left the variable in place instead of invoking `rivertype.JobStates()`
so that we don't need to initialize a new slice every time we validate.