### PR TITLE
Rename function `NewScheduler` to `NewJobScheduler`

### DIFF
--- a/client.go
+++ b/client.go
@@ -545,7 +545,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		}
 
 		{
-			jobScheduler := maintenance.NewScheduler(archetype, &maintenance.JobSchedulerConfig{
+			jobScheduler := maintenance.NewJobScheduler(archetype, &maintenance.JobSchedulerConfig{
 				Interval:     config.schedulerInterval,
 				NotifyInsert: client.maybeNotifyInsertForQueues,
 			}, driver.GetExecutor())

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -74,7 +74,7 @@ type JobScheduler struct {
 	exec   riverdriver.Executor
 }
 
-func NewScheduler(archetype *baseservice.Archetype, config *JobSchedulerConfig, exec riverdriver.Executor) *JobScheduler {
+func NewJobScheduler(archetype *baseservice.Archetype, config *JobSchedulerConfig, exec riverdriver.Executor) *JobScheduler {
 	return baseservice.Init(archetype, &JobScheduler{
 		config: (&JobSchedulerConfig{
 			Interval:     valutil.ValOrDefault(config.Interval, JobSchedulerIntervalDefault),

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -37,7 +37,7 @@ func TestJobScheduler(t *testing.T) {
 			notificationsByQueue: make(map[string]int),
 		}
 
-		scheduler := NewScheduler(
+		scheduler := NewJobScheduler(
 			archetype,
 			&JobSchedulerConfig{
 				Interval: JobSchedulerIntervalDefault,
@@ -80,7 +80,7 @@ func TestJobScheduler(t *testing.T) {
 	t.Run("Defaults", func(t *testing.T) {
 		t.Parallel()
 
-		scheduler := NewScheduler(riverinternaltest.BaseServiceArchetype(t), &JobSchedulerConfig{}, nil)
+		scheduler := NewJobScheduler(riverinternaltest.BaseServiceArchetype(t), &JobSchedulerConfig{}, nil)
 
 		require.Equal(t, JobSchedulerIntervalDefault, scheduler.config.Interval)
 		require.Equal(t, JobSchedulerLimitDefault, scheduler.config.Limit)

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -114,7 +114,7 @@ func TestQueueMaintainer(t *testing.T) {
 				},
 			}, driver),
 			NewQueueCleaner(archetype, &QueueCleanerConfig{}, driver),
-			NewScheduler(archetype, &JobSchedulerConfig{}, driver),
+			NewJobScheduler(archetype, &JobSchedulerConfig{}, driver),
 		})
 		maintainer.Logger = riverinternaltest.LoggerWarn(t) // loop started/stop log is very noisy; suppress
 		startstoptest.Stress(ctx, t, maintainer)


### PR DESCRIPTION
A while back we renamed `Scheduler` to `JobScheduler`, but forgot to
also rename the service's constructor, which remained `NewScheduler`.
Here, finish the job and rename the function to `NewJobScheduler`.