### PR TITLE
Fix `river.JobStateAvailable` reference in `cmd/river/`

### DIFF
--- a/client.go
+++ b/client.go
@@ -1465,7 +1465,7 @@ type JobListResult struct {
 // provided context is used for the underlying Postgres query and can be used to
 // cancel the operation or apply a timeout.
 //
-//	params := river.NewJobListParams().WithLimit(10).State(river.JobStateCompleted)
+//	params := river.NewJobListParams().WithLimit(10).State(rivertype.JobStateCompleted)
 //	jobRows, err := client.JobList(ctx, params)
 //	if err != nil {
 //		// handle error
@@ -1498,7 +1498,7 @@ func (c *Client[TTx]) JobList(ctx context.Context, params *JobListParams) (*JobL
 // provided context is used for the underlying Postgres query and can be used to
 // cancel the operation or apply a timeout.
 //
-//	params := river.NewJobListParams().WithLimit(10).State(river.JobStateCompleted)
+//	params := river.NewJobListParams().WithLimit(10).State(rivertype.JobStateCompleted)
 //	jobRows, err := client.JobListTx(ctx, tx, params)
 //	if err != nil {
 //		// handle error

--- a/cmd/river/riverbench/river_bench.go
+++ b/cmd/river/riverbench/river_bench.go
@@ -194,7 +194,7 @@ func (b *Benchmarker[TTx]) Run(ctx context.Context) error {
 				return
 
 			case <-ticker.C:
-				numJobs, err := b.driver.GetExecutor().JobCountByState(ctx, river.JobStateAvailable)
+				numJobs, err := b.driver.GetExecutor().JobCountByState(ctx, rivertype.JobStateAvailable)
 				if err != nil {
 					b.logger.ErrorContext(ctx, "Error counting jobs", "err", err)
 					continue


### PR DESCRIPTION
- Should be `rivertype`
- I discovered this while trying to pull in `0.4.0` release this morning (thanks @dependabot!); `cmd/river/` won't build in the release (didn't realize these aliases were still until #300)