### PR TITLE
Add link in README to docs on inserting from Ruby

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -146,6 +146,12 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Work functions] for simplified worker implementation.
 
+## Cross language enqueueing
+
+River supports inserting jobs in some non-Go languages which are then be worked by Go implementations. This may be desirable in performance sensitive cases so that jobs can take advantage of Go's fast runtime.
+
+  - [Inserting jobs from Ruby](https://riverqueue.com/docs/ruby).
+
 ## Development
 
 See [developing River].


### PR DESCRIPTION
A tiny one to add a link in the README to docs on inserting jobs from
Ruby [1]. The GitHub repo probably gets more traffic than the docs site,
so it's useful to make this feature visible from it.

[1] https://riverqueue.com/docs/ruby