### PR TITLE
Remove all in-code use of leadership "instance name" + constrain column to single value

### DIFF
--- a/internal/riverinternaltest/testfactory/test_factory.go
+++ b/internal/riverinternaltest/testfactory/test_factory.go
@@ -82,7 +82,6 @@ type LeaderOpts struct {
 	ElectedAt *time.Time
 	ExpiresAt *time.Time
 	LeaderID  *string
-	Name      *string
 }
 
 func Leader(ctx context.Context, tb testing.TB, exec riverdriver.Executor, opts *LeaderOpts) *riverdriver.Leader {
@@ -92,7 +91,6 @@ func Leader(ctx context.Context, tb testing.TB, exec riverdriver.Executor, opts 
 		ElectedAt: opts.ElectedAt,
 		ExpiresAt: opts.ExpiresAt,
 		LeaderID:  ptrutil.ValOrDefault(opts.LeaderID, "test-client-id"),
-		Name:      ptrutil.ValOrDefault(opts.Name, "default"),
 		TTL:       10 * time.Second,
 	})
 	require.NoError(tb, err)

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -97,8 +97,8 @@ type Executor interface {
 	JobUpdate(ctx context.Context, params *JobUpdateParams) (*rivertype.JobRow, error)
 	LeaderAttemptElect(ctx context.Context, params *LeaderElectParams) (bool, error)
 	LeaderAttemptReelect(ctx context.Context, params *LeaderElectParams) (bool, error)
-	LeaderDeleteExpired(ctx context.Context, name string) (int, error)
-	LeaderGetElectedLeader(ctx context.Context, name string) (*Leader, error)
+	LeaderDeleteExpired(ctx context.Context) (int, error)
+	LeaderGetElectedLeader(ctx context.Context) (*Leader, error)
 	LeaderInsert(ctx context.Context, params *LeaderInsertParams) (*Leader, error)
 	LeaderResign(ctx context.Context, params *LeaderResignParams) (bool, error)
 
@@ -313,20 +313,17 @@ type JobUpdateParams struct {
 type Leader struct {
 	ElectedAt time.Time
 	ExpiresAt time.Time
-	Name      string
 	LeaderID  string
 }
 
 type LeaderInsertParams struct {
 	ElectedAt *time.Time
 	ExpiresAt *time.Time
-	Name      string
 	LeaderID  string
 	TTL       time.Duration
 }
 
 type LeaderElectParams struct {
-	Name     string
 	LeaderID string
 	TTL      time.Duration
 }
@@ -334,7 +331,6 @@ type LeaderElectParams struct {
 type LeaderResignParams struct {
 	LeaderID        string
 	LeadershipTopic string
-	Name            string
 }
 
 // Migration represents a River migration.

--- a/riverdriver/riverdatabasesql/river_database_sql.go
+++ b/riverdriver/riverdatabasesql/river_database_sql.go
@@ -157,11 +157,11 @@ func (e *Executor) LeaderAttemptReelect(ctx context.Context, params *riverdriver
 	return false, riverdriver.ErrNotImplemented
 }
 
-func (e *Executor) LeaderDeleteExpired(ctx context.Context, name string) (int, error) {
+func (e *Executor) LeaderDeleteExpired(ctx context.Context) (int, error) {
 	return 0, riverdriver.ErrNotImplemented
 }
 
-func (e *Executor) LeaderGetElectedLeader(ctx context.Context, name string) (*riverdriver.Leader, error) {
+func (e *Executor) LeaderGetElectedLeader(ctx context.Context) (*riverdriver.Leader, error) {
 	return nil, riverdriver.ErrNotImplemented
 }
 

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
@@ -11,20 +11,19 @@ import (
 )
 
 const leaderAttemptElect = `-- name: LeaderAttemptElect :execrows
-INSERT INTO river_leader(name, leader_id, elected_at, expires_at)
-    VALUES ($1::text, $2::text, now(), now() + $3::interval)
+INSERT INTO river_leader(leader_id, elected_at, expires_at)
+    VALUES ($1::text, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO NOTHING
 `
 
 type LeaderAttemptElectParams struct {
-	Name     string
 	LeaderID string
 	TTL      time.Duration
 }
 
 func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAttemptElectParams) (int64, error) {
-	result, err := db.Exec(ctx, leaderAttemptElect, arg.Name, arg.LeaderID, arg.TTL)
+	result, err := db.Exec(ctx, leaderAttemptElect, arg.LeaderID, arg.TTL)
 	if err != nil {
 		return 0, err
 	}
@@ -32,23 +31,22 @@ func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAt
 }
 
 const leaderAttemptReelect = `-- name: LeaderAttemptReelect :execrows
-INSERT INTO river_leader(name, leader_id, elected_at, expires_at)
-    VALUES ($1::text, $2::text, now(), now() + $3::interval)
+INSERT INTO river_leader(leader_id, elected_at, expires_at)
+    VALUES ($1::text, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO UPDATE SET
-        expires_at = now() + $3::interval
+        expires_at = now() + $2::interval
     WHERE
-        river_leader.leader_id = $2::text
+        river_leader.leader_id = $1::text
 `
 
 type LeaderAttemptReelectParams struct {
-	Name     string
 	LeaderID string
 	TTL      time.Duration
 }
 
 func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg *LeaderAttemptReelectParams) (int64, error) {
-	result, err := db.Exec(ctx, leaderAttemptReelect, arg.Name, arg.LeaderID, arg.TTL)
+	result, err := db.Exec(ctx, leaderAttemptReelect, arg.LeaderID, arg.TTL)
 	if err != nil {
 		return 0, err
 	}
@@ -57,12 +55,11 @@ func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg *Leader
 
 const leaderDeleteExpired = `-- name: LeaderDeleteExpired :execrows
 DELETE FROM river_leader
-WHERE name = $1::text
-    AND expires_at < now()
+WHERE expires_at < now()
 `
 
-func (q *Queries) LeaderDeleteExpired(ctx context.Context, db DBTX, name string) (int64, error) {
-	result, err := db.Exec(ctx, leaderDeleteExpired, name)
+func (q *Queries) LeaderDeleteExpired(ctx context.Context, db DBTX) (int64, error) {
+	result, err := db.Exec(ctx, leaderDeleteExpired)
 	if err != nil {
 		return 0, err
 	}
@@ -72,11 +69,10 @@ func (q *Queries) LeaderDeleteExpired(ctx context.Context, db DBTX, name string)
 const leaderGetElectedLeader = `-- name: LeaderGetElectedLeader :one
 SELECT elected_at, expires_at, leader_id, name
 FROM river_leader
-WHERE name = $1
 `
 
-func (q *Queries) LeaderGetElectedLeader(ctx context.Context, db DBTX, name string) (*RiverLeader, error) {
-	row := db.QueryRow(ctx, leaderGetElectedLeader, name)
+func (q *Queries) LeaderGetElectedLeader(ctx context.Context, db DBTX) (*RiverLeader, error) {
+	row := db.QueryRow(ctx, leaderGetElectedLeader)
 	var i RiverLeader
 	err := row.Scan(
 		&i.ElectedAt,
@@ -91,13 +87,11 @@ const leaderInsert = `-- name: LeaderInsert :one
 INSERT INTO river_leader(
     elected_at,
     expires_at,
-    leader_id,
-    name
+    leader_id
 ) VALUES (
     coalesce($1::timestamptz, now()),
     coalesce($2::timestamptz, now() + $3::interval),
-    $4,
-    $5
+    $4
 ) RETURNING elected_at, expires_at, leader_id, name
 `
 
@@ -106,7 +100,6 @@ type LeaderInsertParams struct {
 	ExpiresAt *time.Time
 	TTL       time.Duration
 	LeaderID  string
-	Name      string
 }
 
 func (q *Queries) LeaderInsert(ctx context.Context, db DBTX, arg *LeaderInsertParams) (*RiverLeader, error) {
@@ -115,7 +108,6 @@ func (q *Queries) LeaderInsert(ctx context.Context, db DBTX, arg *LeaderInsertPa
 		arg.ExpiresAt,
 		arg.TTL,
 		arg.LeaderID,
-		arg.Name,
 	)
 	var i RiverLeader
 	err := row.Scan(
@@ -131,32 +123,26 @@ const leaderResign = `-- name: LeaderResign :execrows
 WITH currently_held_leaders AS (
   SELECT elected_at, expires_at, leader_id, name
   FROM river_leader
-  WHERE
-      name = $1::text
-      AND leader_id = $2::text
+  WHERE leader_id = $1::text
   FOR UPDATE
 ),
 notified_resignations AS (
-  SELECT
-      pg_notify(
-          concat(current_schema(), '.', $3::text),
-          json_build_object('name', name, 'leader_id', leader_id, 'action', 'resigned')::text
-      ),
-      currently_held_leaders.name
-  FROM currently_held_leaders
+    SELECT pg_notify(
+        concat(current_schema(), '.', $2::text),
+        json_build_object('leader_id', leader_id, 'action', 'resigned')::text
+    )
+    FROM currently_held_leaders
 )
 DELETE FROM river_leader USING notified_resignations
-WHERE river_leader.name = notified_resignations.name
 `
 
 type LeaderResignParams struct {
-	Name            string
 	LeaderID        string
 	LeadershipTopic string
 }
 
 func (q *Queries) LeaderResign(ctx context.Context, db DBTX, arg *LeaderResignParams) (int64, error) {
-	result, err := db.Exec(ctx, leaderResign, arg.Name, arg.LeaderID, arg.LeadershipTopic)
+	result, err := db.Exec(ctx, leaderResign, arg.LeaderID, arg.LeadershipTopic)
 	if err != nil {
 		return 0, err
 	}

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -361,7 +361,6 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 
 func (e *Executor) LeaderAttemptElect(ctx context.Context, params *riverdriver.LeaderElectParams) (bool, error) {
 	numElectionsWon, err := e.queries.LeaderAttemptElect(ctx, e.dbtx, &dbsqlc.LeaderAttemptElectParams{
-		Name:     params.Name,
 		LeaderID: params.LeaderID,
 		TTL:      params.TTL,
 	})
@@ -373,7 +372,6 @@ func (e *Executor) LeaderAttemptElect(ctx context.Context, params *riverdriver.L
 
 func (e *Executor) LeaderAttemptReelect(ctx context.Context, params *riverdriver.LeaderElectParams) (bool, error) {
 	numElectionsWon, err := e.queries.LeaderAttemptReelect(ctx, e.dbtx, &dbsqlc.LeaderAttemptReelectParams{
-		Name:     params.Name,
 		LeaderID: params.LeaderID,
 		TTL:      params.TTL,
 	})
@@ -383,16 +381,16 @@ func (e *Executor) LeaderAttemptReelect(ctx context.Context, params *riverdriver
 	return numElectionsWon > 0, nil
 }
 
-func (e *Executor) LeaderDeleteExpired(ctx context.Context, name string) (int, error) {
-	numDeleted, err := e.queries.LeaderDeleteExpired(ctx, e.dbtx, name)
+func (e *Executor) LeaderDeleteExpired(ctx context.Context) (int, error) {
+	numDeleted, err := e.queries.LeaderDeleteExpired(ctx, e.dbtx)
 	if err != nil {
 		return 0, interpretError(err)
 	}
 	return int(numDeleted), nil
 }
 
-func (e *Executor) LeaderGetElectedLeader(ctx context.Context, name string) (*riverdriver.Leader, error) {
-	leader, err := e.queries.LeaderGetElectedLeader(ctx, e.dbtx, name)
+func (e *Executor) LeaderGetElectedLeader(ctx context.Context) (*riverdriver.Leader, error) {
+	leader, err := e.queries.LeaderGetElectedLeader(ctx, e.dbtx)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -404,7 +402,6 @@ func (e *Executor) LeaderInsert(ctx context.Context, params *riverdriver.LeaderI
 		ElectedAt: params.ElectedAt,
 		ExpiresAt: params.ExpiresAt,
 		LeaderID:  params.LeaderID,
-		Name:      params.Name,
 		TTL:       params.TTL,
 	})
 	if err != nil {
@@ -417,7 +414,6 @@ func (e *Executor) LeaderResign(ctx context.Context, params *riverdriver.LeaderR
 	numResigned, err := e.queries.LeaderResign(ctx, e.dbtx, &dbsqlc.LeaderResignParams{
 		LeaderID:        params.LeaderID,
 		LeadershipTopic: params.LeadershipTopic,
-		Name:            params.Name,
 	})
 	if err != nil {
 		return false, interpretError(err)
@@ -699,7 +695,6 @@ func leaderFromInternal(internal *dbsqlc.RiverLeader) *riverdriver.Leader {
 		ElectedAt: internal.ElectedAt.UTC(),
 		ExpiresAt: internal.ExpiresAt.UTC(),
 		LeaderID:  internal.LeaderID,
-		Name:      internal.Name,
 	}
 }
 

--- a/rivermigrate/migration/004_pending_and_more.down.sql
+++ b/rivermigrate/migration/004_pending_and_more.down.sql
@@ -35,3 +35,8 @@ CREATE TRIGGER river_notify
   EXECUTE PROCEDURE river_job_notify();
 
 DROP TABLE river_queue;
+
+ALTER TABLE river_leader
+    ALTER COLUMN name DROP DEFAULT,
+    DROP CONSTRAINT name_length,
+    ADD CONSTRAINT name_length CHECK (char_length(name) > 0 AND char_length(name) < 128);

--- a/rivermigrate/migration/004_pending_and_more.up.sql
+++ b/rivermigrate/migration/004_pending_and_more.up.sql
@@ -30,3 +30,8 @@ CREATE TABLE river_queue(
   paused_at timestamptz,
   updated_at timestamptz NOT NULL
 );
+
+ALTER TABLE river_leader
+    ALTER COLUMN name SET DEFAULT 'default',
+    DROP CONSTRAINT name_length,
+    ADD CONSTRAINT name_length CHECK (name = 'default');


### PR DESCRIPTION
With the addition of #301, and more specifically the schema-based
namespacing that it brings in around listen/notify, we're fully moving
towards a world where the recommendation for running multiple Rivers in
a single database is very definitive: isolate them by schema.

The elector's had a long-standing parameter called "instance name"
that's stored into the `river_leader` table, and which was prospectively
going to be used for River namespacing, but something we never made use
of it. In a world of schema isolation, each schema will have its own
`river_leader` table, and no kind of additional namespacing is needed
within the table.

I was originally going to try and approach herein we drop `name` out of
`river_leader` completely, but looking more closely, it's the table's
primary key. We could add a new column that'd act as a primary key
instead (e.g. imagine a boolean primary key column with a check
constraint that makes sure it's always true), but nothing we'd add would
be that much better. Instead, I elected to give `name` a default value
of `default` (matching the previous default instance name), and add a
check constraint verifying that it's always `default`, making it
effectively a single row table. The nice part about this approach is
that we can put these changes into the V4 migration in #301, and we
won't require any additional changes in any future migration.

With `name` now constrained to a single value, we can simplify all the
`river_leader`-based queries by removing their name parameters, then
remove instance name completely from elector code and drivers, giving us
a thorough overall cleanup.