### PR TITLE
emit subscription events on pause + resume

### DIFF
--- a/event.go
+++ b/event.go
@@ -25,6 +25,12 @@ const (
 
 	// EventKindJobSnoozed occurs when a job is snoozed.
 	EventKindJobSnoozed EventKind = "job_snoozed"
+
+	// EventKindQueuePaused occurs when a queue is paused.
+	EventKindQueuePaused EventKind = "queue_paused"
+
+	// EventKindQueueResumed occurs when a queue is resumed.
+	EventKindQueueResumed EventKind = "queue_resumed"
 )
 
 // All known event kinds, used to validate incoming kinds. This is purposely not
@@ -35,6 +41,8 @@ var allKinds = map[EventKind]struct{}{ //nolint:gochecknoglobals
 	EventKindJobCompleted: {},
 	EventKindJobFailed:    {},
 	EventKindJobSnoozed:   {},
+	EventKindQueuePaused:  {},
+	EventKindQueueResumed: {},
 }
 
 // Event wraps an event that occurred within a River client, like a job being
@@ -50,6 +58,9 @@ type Event struct {
 
 	// JobStats are statistics about the run of a job.
 	JobStats *JobStatistics
+
+	// Queue contains queue-related information.
+	Queue *rivertype.Queue
 }
 
 // JobStatistics contains information about a single execution of a job.


### PR DESCRIPTION
Following up on https://github.com/riverqueue/river/pull/324#discussion_r1586541810, this adds `Client` subscription events for queue pause and resume. This allows us to make tests and examples free of race conditions, even without access to internal test signals.

Unlike for job events coming from the completer, here it is not straightforward to emit the entire representation of the `Queue` record. That's because we don't always have a fresh version of that record available when handling a pause or resume event. We considered emitting that as part of the pause or resume event, but that doesn't work when operating on all queues via `*`. We also considered doing this at the time the event is emitted by the producer, but that is pretty messy because we'd have to reload the row before emitting the event, leaving an odd gap and race condition before the event emission.

Instead, this approach uses a mostly-unpopulated `Queue` struct with only the `Name` and all other fields left with their default value. It's not ideal but it seems like the best pragmatic compromise at this time.