### PR TITLE
Prepare version `v0.5.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2024-05-03
+
 ⚠️ Version 0.5.0 contains a new database migration, version 4. This migration is backward compatible with any River installation running the v3 migration. Be sure to run the v4 migration prior to deploying the code from this release.
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.4.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.4.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.4.0
-	github.com/riverqueue/river/rivertype v0.4.0
+	github.com/riverqueue/river/riverdriver v0.5.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.5.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.5.0
+	github.com/riverqueue/river/rivertype v0.5.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.4.0
+require github.com/riverqueue/river/rivertype v0.5.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.4.0
-	github.com/riverqueue/river/rivertype v0.4.0
+	github.com/riverqueue/river/riverdriver v0.5.0
+	github.com/riverqueue/river/rivertype v0.5.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -9,8 +9,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.4.0
-	github.com/riverqueue/river/rivertype v0.4.0
+	github.com/riverqueue/river/riverdriver v0.5.0
+	github.com/riverqueue/river/rivertype v0.5.0
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Tees up version `v0.5.0`, which mainly contains the changes in #301, but
is notably because it also contains the first ever new database
migration beyond the original line.