### PR TITLE
Drop `lib/pq` use in job listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `RequireNotInserted` test helper (in addition to the existing `RequireInserted`) that verifies that a job with matching conditions was _not_ inserted. [PR #237](https://github.com/riverqueue/river/pull/237).
 
+### Fixed
+
+- Remove use of `github.com/lib/pq`, making it once again a test-only dependency. [PR #337](https://github.com/riverqueue/river/pull/337).
+
 ## [0.5.0] - 2024-05-03
 
 ⚠️ Version 0.5.0 contains a new database migration, version 4. This migration is backward compatible with any River installation running the v3 migration. Be sure to run the v4 migration prior to deploying the code from this release.

--- a/internal/dblist/db_list.go
+++ b/internal/dblist/db_list.go
@@ -6,8 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/lib/pq"
-
+	"github.com/riverqueue/river/internal/util/sliceutil"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -86,7 +85,7 @@ func JobList(ctx context.Context, exec riverdriver.Executor, params *JobListPara
 	if len(params.States) > 0 {
 		writeWhereOrAnd()
 		conditionsBuilder.WriteString("state = any(@states::river_job_state[])")
-		namedArgs["states"] = pq.Array(params.States)
+		namedArgs["states"] = sliceutil.Map(params.States, func(s rivertype.JobState) string { return string(s) })
 	}
 
 	if params.Conditions != "" {


### PR DESCRIPTION
I missed this before, but while working on something else I noticed
randomly that apparently we use `lib/pq` in the job list module to
encode an array of job states.

I think it was an oversight to have brought this in as a hard
dependency, so here remove the use of `pg.Array` in favor of just using
a normal Go slice instead.