### PR TITLE
Periodic job enqueuer: Set `scheduled_at` according to expected next run time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `RequireNotInserted` test helper (in addition to the existing `RequireInserted`) that verifies that a job with matching conditions was _not_ inserted. [PR #237](https://github.com/riverqueue/river/pull/237).
 
+### Changed
+
+- The periodic job enqueuer now sets `scheduled_at` of inserted jobs to the more precise time of when they were scheduled to run, as opposed to when they were inserted. [PR #341](https://github.com/riverqueue/river/pull/341).
+
 ### Fixed
 
 - Remove use of `github.com/lib/pq`, making it once again a test-only dependency. [PR #337](https://github.com/riverqueue/river/pull/337).


### PR DESCRIPTION
Currently, a periodic job that's inserted gets a value in `scheduled_at`
that defaults to the database's `now()`. Here, we alter this with a
minor nicety requested in #340 wherein we set `scheduled_at` to the
precise time we expected a periodic job to be scheduled. This value is
will be very close to `now()`, but likely a little sooner because
there's some lag in the insert loop between when job insert params are
generated and when the insert happens.

Jobs are inserted with state `available` (rather than `scheduled`), so
this should have very little functional effect. In a busy system it may
cause the periodic jobs to be favored slightly because when locking
available jobs, `scheduled_at` is one of the fields we order on for
priority.