### PR TITLE
Exit with status 1 on Cobra problems like a missing required flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,6 +168,13 @@ jobs:
           fi
         working-directory: ./cmd/river
 
+      - name: river unknown command (expect failure)
+        run: |
+          if ./river not-a-command; then
+            echo "expected non-zero exit code" && exit 1
+          fi
+        working-directory: ./cmd/river
+
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/cmd/river/main.go
+++ b/cmd/river/main.go
@@ -234,10 +234,12 @@ migrations that need to be run, but without running them.
 		rootCmd.AddCommand(cmd)
 	}
 
-	// Cobra will already print an error on an uknown command, and there aren't
-	// really any other important top-level error cases to worry about as far as
-	// I can tell, so ignore a returned error here so we don't double print it.
-	_ = rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		// Cobra will already print an error on problems like an unknown command
+		// or missing required flag. Set an exit status of 1 on error, but don't
+		// print it again.
+		os.Exit(1)
+	}
 }
 
 func openDBPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {


### PR DESCRIPTION
Here, exit with status 1 from the River CLI when a problem intrinsic to
Cobra occurred like the user entered an unknown command, or didn't pass
required flag.

Cobra is a little odd in its behavior in that it already prints such a
problem to the terminal, but also returns an error with the same
information. This change looks for the presence of an error and exits
with status 1 if one occurred, but doesn't double print any additional
information about it.

Fixes #362.