### PR TITLE
Update `004_pending_and_more` migration to add `pending` value to river_job_state only if it does not exists

### DIFF
--- a/rivermigrate/migration/004_pending_and_more.up.sql
+++ b/rivermigrate/migration/004_pending_and_more.up.sql
@@ -12,7 +12,7 @@ UPDATE river_job SET metadata = '{}' WHERE metadata IS NULL;
 ALTER TABLE river_job ALTER COLUMN metadata SET NOT NULL;
 
 -- The 'pending' job state will be used for upcoming functionality:
-ALTER TYPE river_job_state ADD VALUE 'pending' AFTER 'discarded';
+ALTER TYPE river_job_state ADD VALUE IF NOT EXISTS 'pending' AFTER 'discarded';
 
 ALTER TABLE river_job DROP CONSTRAINT finalized_or_finalized_at_null;
 ALTER TABLE river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (


### PR DESCRIPTION
Hi guys,

`004_pending_and_more.down.sql` migration does not remove `river_job_state`'s `pending` value. It brings us to situation where we can't apply this migration after rollback.

Steps to reproduce:
1. apply migration 004 to database
2. rollback
3. apply migration 004

**Expected behavior:**

All migrations applied without error

**Actual:**
```
failed: error applying version 004 [UP]: ERROR: enum label "pending" already exists (SQLSTATE 42710)
exit status 1
```

This PR is meant to fix this behavior by optionally adding `pending` value during migration application.