### PR TITLE
Prepare version 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - River now considers per-worker timeout overrides when rescuing jobs so that jobs with a long custom timeout won't be rescued prematurely. [PR #350](https://github.com/riverqueue/river/pull/350).
+- River CLI now exits with status 1 in the case of a problem with commands or flags, like an unknown command or missing required flag. [PR #363](https://github.com/riverqueue/river/pull/363).
+- Fix migration version 4 (from 0.5.0) so that the up migration can be re-run after it was originally rolled back. [PR #364](https://github.com/riverqueue/river/pull/364).
 
 ## [0.6.0] - 2024-05-08
 

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.6.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.6.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.6.0
-	github.com/riverqueue/river/rivertype v0.6.0
+	github.com/riverqueue/river/riverdriver v0.6.1
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.6.1
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.6.1
+	github.com/riverqueue/river/rivertype v0.6.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.6.0
+require github.com/riverqueue/river/rivertype v0.6.1

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.6.0
-	github.com/riverqueue/river/rivertype v0.6.0
+	github.com/riverqueue/river/riverdriver v0.6.1
+	github.com/riverqueue/river/rivertype v0.6.1
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -9,8 +9,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.6.0
-	github.com/riverqueue/river/rivertype v0.6.0
+	github.com/riverqueue/river/riverdriver v0.6.1
+	github.com/riverqueue/river/rivertype v0.6.1
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prepare version 0.6.1 for release, including the changes from #350 (no
premature rescue for jobs with long custom timeouts), #363 (exit with
status 1 in case of bad command/flags) in CLI, and #364 (fix migration
version 4 to be re-runnable).