### PR TITLE
Add v0.6.1 banner to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2024-05-21
+
 ### Fixed
 
 - River now considers per-worker timeout overrides when rescuing jobs so that jobs with a long custom timeout won't be rescued prematurely. [PR #350](https://github.com/riverqueue/river/pull/350).


### PR DESCRIPTION
Tiny fix for #365 in which we add a forgotten header in the changelog
for v0.6.1.