### PR TITLE
extract shared service logic from maintenance services

### DIFF
--- a/client.go
+++ b/client.go
@@ -524,7 +524,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		// Maintenance services
 		//
 
-		maintenanceServices := []startstop.Service{}
+		maintenanceServices := []maintenance.MaintenanceService{}
 
 		{
 			jobCleaner := maintenance.NewJobCleaner(archetype, &maintenance.JobCleanerConfig{

--- a/job_executor.go
+++ b/job_executor.go
@@ -247,7 +247,7 @@ func (e *jobExecutor) reportResult(ctx context.Context, res *jobExecutorResult) 
 	if res.Err != nil && errors.As(res.Err, &snoozeErr) {
 		e.Logger.InfoContext(ctx, e.Name+": Job snoozed",
 			slog.Int64("job_id", e.JobRow.ID),
-		        slog.String("job_kind", e.JobRow.Kind),
+			slog.String("job_kind", e.JobRow.Kind),
 			slog.Duration("duration", snoozeErr.duration),
 		)
 		nextAttemptScheduledAt := time.Now().Add(snoozeErr.duration)


### PR DESCRIPTION
This attempts to simplify the maintenance service interface to make it more suitable for exposing externally. Rather than requiring the services to be a `startstop.Service` and having each service independently reimplement the semantics of start/stop/closed, these shared bits are extracted into a `maintenanceServiceWrapper` type.

The maintenance services themselves only need to fit a simpler `MaintenanceService` interface, containing a single method `Run(ctx)`. The wrapper is in charge of fulfilling the `startstop.Service` interface and providing common handling for exit scenarios. Maintenance services must run until the provided context is cancelled, and then must exit promptly afterward. The wrapper bridges these behaviors to provide a blocking `Stop()` that waits until the service has exited.

While this has the effect of making maintenance services no longer fulfill the `startstop.Service` interface, they also do not need to leverage the more complex `startstop.BaseStartStop` type to properly fulfill the `Service` interface. This is desirable in terms of extensibility and moving toward allowing maintenance processes to be configured and provided externally, because the only type that _needs_ to be exposed here is the `MaintenanceService` interface. See the follow up PR for an example of how this could be done.

Users or external libraries can provide additional services which implement that one method, and which can then take advantage of being able to run only on the elected leader with automatic start/stop.

This also has the effect of removing the ability of maintenance services to surface an `error` when attempting to start them, however I think this might be a good change. We weren't leveraging this yet anywhere, and I also don't think there's anything useful we could do with these returned errors other than log them. We can still attempt to restart a prematurely exited service if we wish to do so, though at that point the service is not properly implemented.

Individual services also do not need to concern themselves with details like `StaggerStartupDisable` because this is now implemented in the wrapper.