### PR TITLE
ability to add custom maintenance services to Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -524,7 +524,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		// Maintenance services
 		//
 
-		maintenanceServices := []maintenance.MaintenanceService{}
+		maintenanceServices := []rivertype.MaintenanceService{}
 
 		{
 			jobCleaner := maintenance.NewJobCleaner(archetype, &maintenance.JobCleanerConfig{
@@ -822,6 +822,17 @@ func (c *Client[TTx]) StopAndCancel(ctx context.Context) error {
 // It is not affected by any contexts passed to Stop or StopAndCancel.
 func (c *Client[TTx]) Stopped() <-chan struct{} {
 	return c.stopped
+}
+
+// AddMaintenanceService adds a custom maintenance service to the client.
+// Maintenance services are custom chunks of logic that will be run only on the
+// elected leader client. The service will be run if this client becomes the
+// leader, and stopped if it loses leadership.
+//
+// Must be called before the client is started. Services must immediately exit
+// after context cancellation to avoid impacting other maintenance services.
+func (c *Client[TTx]) AddMaintenanceService(service rivertype.MaintenanceService) {
+	c.queueMaintainer.AddService(service)
 }
 
 // Subscribe subscribes to the provided kinds of events that occur within the

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -16,9 +16,10 @@ import (
 	"github.com/riverqueue/river/internal/riverinternaltest/startstoptest"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
 )
 
-func runMaintenanceService(ctx context.Context, t *testing.T, svc MaintenanceService) {
+func runMaintenanceService(ctx context.Context, t *testing.T, svc rivertype.MaintenanceService) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -71,7 +72,7 @@ func TestQueueMaintainer(t *testing.T) {
 
 	ctx := context.Background()
 
-	setup := func(t *testing.T, services []MaintenanceService) *QueueMaintainer {
+	setup := func(t *testing.T, services []rivertype.MaintenanceService) *QueueMaintainer {
 		t.Helper()
 
 		maintainer := NewQueueMaintainer(riverinternaltest.BaseServiceArchetype(t), services)
@@ -84,7 +85,7 @@ func TestQueueMaintainer(t *testing.T) {
 		t.Parallel()
 
 		testSvc := newTestService(t)
-		maintainer := setup(t, []MaintenanceService{testSvc})
+		maintainer := setup(t, []rivertype.MaintenanceService{testSvc})
 
 		require.NoError(t, maintainer.Start(ctx))
 		testSvc.testSignals.started.WaitOrTimeout()
@@ -105,7 +106,7 @@ func TestQueueMaintainer(t *testing.T) {
 
 		// Use realistic services in this one so we can verify stress not only
 		// on the queue maintainer, but it and all its subservices together.
-		maintainer := setup(t, []MaintenanceService{
+		maintainer := setup(t, []rivertype.MaintenanceService{
 			NewJobCleaner(archetype, &JobCleanerConfig{}, driver),
 			NewPeriodicJobEnqueuer(archetype, &PeriodicJobEnqueuerConfig{
 				PeriodicJobs: []*PeriodicJob{
@@ -128,7 +129,7 @@ func TestQueueMaintainer(t *testing.T) {
 		t.Parallel()
 
 		testSvc := newTestService(t)
-		maintainer := setup(t, []MaintenanceService{testSvc})
+		maintainer := setup(t, []rivertype.MaintenanceService{testSvc})
 
 		// Tolerate being stopped without having been started, without blocking:
 		maintainer.Stop()
@@ -142,7 +143,7 @@ func TestQueueMaintainer(t *testing.T) {
 		t.Parallel()
 
 		testSvc := newTestService(t)
-		maintainer := setup(t, []MaintenanceService{testSvc})
+		maintainer := setup(t, []rivertype.MaintenanceService{testSvc})
 
 		runOnce := func() {
 			require.NoError(t, maintainer.Start(ctx))
@@ -160,7 +161,7 @@ func TestQueueMaintainer(t *testing.T) {
 		t.Parallel()
 
 		testSvc := newTestService(t)
-		maintainer := setup(t, []MaintenanceService{testSvc})
+		maintainer := setup(t, []rivertype.MaintenanceService{testSvc})
 
 		ctx, cancelFunc := context.WithCancel(ctx)
 
@@ -180,7 +181,7 @@ func TestQueueMaintainer(t *testing.T) {
 
 		testSvc := newTestService(t)
 
-		maintainer := setup(t, []MaintenanceService{testSvc})
+		maintainer := setup(t, []rivertype.MaintenanceService{testSvc})
 
 		require.NoError(t, maintainer.Start(ctx))
 		testSvc.testSignals.started.WaitOrTimeout()
@@ -195,7 +196,7 @@ func TestQueueMaintainer(t *testing.T) {
 	})
 }
 
-func MaintenanceServiceStopsImmediately(ctx context.Context, t *testing.T, svc MaintenanceService) {
+func MaintenanceServiceStopsImmediately(ctx context.Context, t *testing.T, svc rivertype.MaintenanceService) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -4,6 +4,7 @@
 package rivertype
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -207,6 +208,10 @@ type AttemptError struct {
 	// Trace contains a stack trace from a job that panicked. The trace is
 	// produced by invoking `debug.Trace()`.
 	Trace string `json:"trace"`
+}
+
+type MaintenanceService interface {
+	Run(ctx context.Context)
 }
 
 // PeriodicJobHandle is a reference to a dynamically added periodic job


### PR DESCRIPTION
This exposes an interface for a `rivertype.MaintenanceService`, along with a way to add custom maintenance services to the `Client` using a new `Config.MaintenanceServices` field. See #372 for a bit more background on the underlying change—this one is merely illustrating how that PR makes it straightforward to expose a minimal interface for adding custom maintenance services.