### PR TITLE
fix StopAndTest after ongoing Stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The default max attempts of 25 can now be customized on a per-client basis using `Config.MaxAttempts`. This is in addition to the ability to customize at the job type level with `JobArgs`, or on a per-job basis using `InsertOpts`. [PR #383](https://github.com/riverqueue/river/pull/383).
 
+### Fixed
+
+- Fix `StopAndCancel` to not hang if called in parallel to an ongoing `Stop` call. [PR #376](https://github.com/riverqueue/river/pull/376).
+
 ## [0.6.1] - 2024-05-21
 
 ### Fixed

--- a/client.go
+++ b/client.go
@@ -810,13 +810,13 @@ func (c *Client[TTx]) Stop(ctx context.Context) error {
 // no need to call this method if the context passed to Run is cancelled
 // instead.
 func (c *Client[TTx]) StopAndCancel(ctx context.Context) error {
+	c.baseService.Logger.InfoContext(ctx, c.baseService.Name+": Hard stop started; cancelling all work")
+	c.workCancel(rivercommon.ErrShutdown)
+
 	shouldStop, stopped, finalizeStop := c.baseStartStop.StopInit()
 	if !shouldStop {
 		return nil
 	}
-
-	c.baseService.Logger.InfoContext(ctx, c.baseService.Name+": Hard stop started; cancelling all work")
-	c.workCancel(rivercommon.ErrShutdown)
 
 	select {
 	case <-ctx.Done(): // stop context cancelled


### PR DESCRIPTION
@brandur while working on some stuff in the demo tonight, I realized that the hard stop was no longer working correctly if initiated _after_ a soft `Stop()` was ongoing. I believe a regression or at least a change in behavior occurred with https://github.com/riverqueue/river/issues/272, because the shutdown logic in the demo app used to properly handle these shutdown scenarios.

Perhaps this isn't exactly a "bug", though it did used to work this way. In the past you didn't _need_ to cancel the context for `Stop()` prior to calling `StopAndCancel()`, but now it appears that is required. This is because the start/stop service has a mutex which is held while `Stop()` is ongoing and so a subsequent concurrent call to `StopAndCancel()` cannot proceed until that first call has been "released" by cancelling its context.

I didn't have time to get any further on this tonight but figured you might have thoughts.