### PR TITLE
extract Client subscriptions into service

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -2957,7 +2957,7 @@ func Test_Client_Subscribe(t *testing.T) {
 		// Drops through immediately because the channel is closed.
 		riverinternaltest.WaitOrTimeout(t, subscribeChan)
 
-		require.Empty(t, client.subscriptions)
+		require.Empty(t, client.subscriptionManager.subscriptions)
 	})
 }
 

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -56,7 +56,7 @@ type Driver[TTx any] interface {
 	// API is not stable. DO NOT USE.
 	HasPool() bool
 
-	// UnwrapExecutor gets unwraps executor from a driver transaction.
+	// UnwrapExecutor gets an executor from a driver transaction.
 	//
 	// API is not stable. DO NOT USE.
 	UnwrapExecutor(tx TTx) ExecutorTx

--- a/subscription_manager.go
+++ b/subscription_manager.go
@@ -1,0 +1,242 @@
+package river
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/riverqueue/river/internal/baseservice"
+	"github.com/riverqueue/river/internal/jobcompleter"
+	"github.com/riverqueue/river/internal/jobstats"
+	"github.com/riverqueue/river/internal/maintenance/startstop"
+	"github.com/riverqueue/river/internal/util/sliceutil"
+	"github.com/riverqueue/river/rivertype"
+)
+
+type subscriptionManager struct {
+	baseservice.BaseService
+	startstop.BaseStartStop
+
+	subscribeCh <-chan []jobcompleter.CompleterJobUpdated
+
+	statsMu        sync.Mutex // protects stats fields
+	statsAggregate jobstats.JobStatistics
+	statsNumJobs   int
+
+	mu               sync.Mutex // protects subscription fields
+	subscriptions    map[int]*eventSubscription
+	subscriptionsSeq int // used for generating simple IDs
+}
+
+func newSubscriptionManager(archetype *baseservice.Archetype, subscribeCh <-chan []jobcompleter.CompleterJobUpdated) *subscriptionManager {
+	return baseservice.Init(archetype, &subscriptionManager{
+		subscribeCh:   subscribeCh,
+		subscriptions: make(map[int]*eventSubscription),
+	})
+}
+
+// ResetSubscribeChan is used to change the channel that the subscription
+// manager listens on. It must only be called when the subscription manager is
+// stopped.
+func (sm *subscriptionManager) ResetSubscribeChan(subscribeCh <-chan []jobcompleter.CompleterJobUpdated) {
+	sm.subscribeCh = subscribeCh
+}
+
+func (sm *subscriptionManager) Start(ctx context.Context) error {
+	_, shouldStart, stopped := sm.StartInit(ctx)
+	if !shouldStart {
+		return nil
+	}
+
+	go func() {
+		// This defer should come first so that it's last out, thereby avoiding
+		// races.
+		defer close(stopped)
+
+		for updates := range sm.subscribeCh {
+			sm.distributeJobUpdates(updates)
+		}
+	}()
+
+	return nil
+}
+
+func (sm *subscriptionManager) Stop() {
+	shouldStop, stopped, finalizeStop := sm.StopInit()
+	if !shouldStop {
+		return
+	}
+
+	<-stopped
+
+	// Remove all subscriptions and close corresponding channels.
+	func() {
+		sm.mu.Lock()
+		defer sm.mu.Unlock()
+
+		for subID, sub := range sm.subscriptions {
+			close(sub.Chan)
+			delete(sm.subscriptions, subID)
+		}
+	}()
+
+	finalizeStop(true)
+}
+
+func (sm *subscriptionManager) logStats(ctx context.Context, svcName string) {
+	sm.statsMu.Lock()
+	defer sm.statsMu.Unlock()
+
+	sm.Logger.InfoContext(ctx, svcName+": Job stats (since last stats line)",
+		"num_jobs_run", sm.statsNumJobs,
+		"average_complete_duration", sm.safeDurationAverage(sm.statsAggregate.CompleteDuration, sm.statsNumJobs),
+		"average_queue_wait_duration", sm.safeDurationAverage(sm.statsAggregate.QueueWaitDuration, sm.statsNumJobs),
+		"average_run_duration", sm.safeDurationAverage(sm.statsAggregate.RunDuration, sm.statsNumJobs))
+
+	sm.statsAggregate = jobstats.JobStatistics{}
+	sm.statsNumJobs = 0
+}
+
+// Handles a potential divide by zero.
+func (sm *subscriptionManager) safeDurationAverage(d time.Duration, n int) time.Duration {
+	if n == 0 {
+		return 0
+	}
+	return d / time.Duration(n)
+}
+
+// Receives updates from the completer and prompts the client to update
+// statistics and distribute jobs into any listening subscriber channels.
+// (Subscriber channels are non-blocking so this should be quite fast.)
+func (sm *subscriptionManager) distributeJobUpdates(updates []jobcompleter.CompleterJobUpdated) {
+	func() {
+		sm.statsMu.Lock()
+		defer sm.statsMu.Unlock()
+
+		for _, update := range updates {
+			stats := update.JobStats
+			sm.statsAggregate.CompleteDuration += stats.CompleteDuration
+			sm.statsAggregate.QueueWaitDuration += stats.QueueWaitDuration
+			sm.statsAggregate.RunDuration += stats.RunDuration
+			sm.statsNumJobs++
+		}
+	}()
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	// Quick path so we don't need to allocate anything if no one is listening.
+	if len(sm.subscriptions) < 1 {
+		return
+	}
+
+	for _, update := range updates {
+		sm.distributeJobEvent(update.Job, jobStatisticsFromInternal(update.JobStats))
+	}
+}
+
+// Distribute a single event into any listening subscriber channels.
+//
+// Job events should specify the job and stats, while queue events should only specify
+// the queue.
+//
+// MUST be called with sm.mu already held.
+func (sm *subscriptionManager) distributeJobEvent(job *rivertype.JobRow, stats *JobStatistics) {
+	var event *Event
+	switch job.State {
+	case rivertype.JobStateCancelled:
+		event = &Event{Kind: EventKindJobCancelled, Job: job, JobStats: stats}
+	case rivertype.JobStateCompleted:
+		event = &Event{Kind: EventKindJobCompleted, Job: job, JobStats: stats}
+	case rivertype.JobStateScheduled:
+		event = &Event{Kind: EventKindJobSnoozed, Job: job, JobStats: stats}
+	case rivertype.JobStateAvailable, rivertype.JobStateDiscarded, rivertype.JobStateRetryable, rivertype.JobStateRunning:
+		event = &Event{Kind: EventKindJobFailed, Job: job, JobStats: stats}
+	case rivertype.JobStatePending:
+		panic("completion subscriber unexpectedly received job in pending state, river bug")
+	default:
+		// linter exhaustive rule prevents this from being reached
+		panic("unreachable state to distribute, river bug")
+	}
+
+	// All subscription channels are non-blocking so this is always fast and
+	// there's no risk of falling behind what producers are sending.
+	for _, sub := range sm.subscriptions {
+		if sub.ListensFor(event.Kind) {
+			// TODO: THIS IS UNSAFE AND WILL LEAD TO DROPPED EVENTS.
+			//
+			// We are allocating subscriber channels with a fixed size of 1000, but
+			// potentially processing job events in batches of 5000 (batch completer
+			// max batch size). It's probably not possible for the subscriber to keep
+			// up with these bursts.
+			select {
+			case sub.Chan <- event:
+			default:
+			}
+		}
+	}
+}
+
+func (sm *subscriptionManager) distributeQueueEvent(event *Event) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	// All subscription channels are non-blocking so this is always fast and
+	// there's no risk of falling behind what producers are sending.
+	for _, sub := range sm.subscriptions {
+		if sub.ListensFor(event.Kind) {
+			select {
+			case sub.Chan <- event:
+			default:
+			}
+		}
+	}
+}
+
+// Special internal variant that lets us inject an overridden size.
+func (sm *subscriptionManager) SubscribeConfig(config *SubscribeConfig) (<-chan *Event, func()) {
+	if config.ChanSize < 0 {
+		panic("SubscribeConfig.ChanSize must be greater or equal to 1")
+	}
+	if config.ChanSize == 0 {
+		config.ChanSize = subscribeChanSizeDefault
+	}
+
+	for _, kind := range config.Kinds {
+		if _, ok := allKinds[kind]; !ok {
+			panic(fmt.Errorf("unknown event kind: %s", kind))
+		}
+	}
+
+	subChan := make(chan *Event, config.ChanSize)
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	// Just gives us an easy way of removing the subscription again later.
+	subID := sm.subscriptionsSeq
+	sm.subscriptionsSeq++
+
+	sm.subscriptions[subID] = &eventSubscription{
+		Chan:  subChan,
+		Kinds: sliceutil.KeyBy(config.Kinds, func(k EventKind) (EventKind, struct{}) { return k, struct{}{} }),
+	}
+
+	cancel := func() {
+		sm.mu.Lock()
+		defer sm.mu.Unlock()
+
+		// May no longer be present in case this was called after a stop.
+		sub, ok := sm.subscriptions[subID]
+		if !ok {
+			return
+		}
+
+		close(sub.Chan)
+
+		delete(sm.subscriptions, subID)
+	}
+
+	return subChan, cancel
+}

--- a/subscription_manager_test.go
+++ b/subscription_manager_test.go
@@ -1,0 +1,126 @@
+package river
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river/internal/jobcompleter"
+	"github.com/riverqueue/river/internal/jobstats"
+	"github.com/riverqueue/river/internal/riverinternaltest"
+	"github.com/riverqueue/river/internal/riverinternaltest/testfactory"
+	"github.com/riverqueue/river/internal/util/ptrutil"
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SubscriptionManager(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		exec        riverdriver.Executor
+		subscribeCh chan []jobcompleter.CompleterJobUpdated
+		tx          pgx.Tx
+	}
+
+	setup := func(t *testing.T) (*subscriptionManager, *testBundle) {
+		t.Helper()
+
+		tx := riverinternaltest.TestTx(ctx, t)
+		exec := riverpgxv5.New(nil).UnwrapExecutor(tx)
+
+		subscribeCh := make(chan []jobcompleter.CompleterJobUpdated, 1)
+		manager := newSubscriptionManager(riverinternaltest.BaseServiceArchetype(t), subscribeCh)
+
+		require.NoError(t, manager.Start(ctx))
+		t.Cleanup(manager.Stop)
+
+		return manager, &testBundle{
+			exec:        exec,
+			subscribeCh: subscribeCh,
+			tx:          tx,
+		}
+	}
+
+	t.Run("DistributesRequestedEventsToSubscribers", func(t *testing.T) {
+		t.Parallel()
+
+		manager, bundle := setup(t)
+		t.Cleanup(func() { close(bundle.subscribeCh) })
+
+		sub, cancelSub := manager.SubscribeConfig(&SubscribeConfig{ChanSize: 10, Kinds: []EventKind{EventKindJobCompleted, EventKindJobSnoozed}})
+		t.Cleanup(cancelSub)
+
+		// Send some events
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(time.Now())})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(time.Now())})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRetryable)})
+		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled)})
+
+		makeStats := func(complete, wait, run time.Duration) *jobstats.JobStatistics {
+			return &jobstats.JobStatistics{
+				CompleteDuration:  complete,
+				QueueWaitDuration: wait,
+				RunDuration:       run,
+			}
+		}
+
+		bundle.subscribeCh <- []jobcompleter.CompleterJobUpdated{
+			{Job: job1, JobStats: makeStats(101, 102, 103)}, // completed, should be sent
+			{Job: job2, JobStats: makeStats(201, 202, 203)}, // cancelled, should be skipped
+		}
+		bundle.subscribeCh <- []jobcompleter.CompleterJobUpdated{
+			{Job: job3, JobStats: makeStats(301, 302, 303)}, // retryable, should be skipped
+			{Job: job4, JobStats: makeStats(401, 402, 403)}, // snoozed/scheduled, should be sent
+		}
+
+		received := riverinternaltest.WaitOrTimeoutN(t, sub, 2)
+		require.Equal(t, job1.ID, received[0].Job.ID)
+		require.Equal(t, rivertype.JobStateCompleted, received[0].Job.State)
+		require.Equal(t, time.Duration(101), received[0].JobStats.CompleteDuration)
+		require.Equal(t, time.Duration(102), received[0].JobStats.QueueWaitDuration)
+		require.Equal(t, time.Duration(103), received[0].JobStats.RunDuration)
+		require.Equal(t, job4.ID, received[1].Job.ID)
+		require.Equal(t, rivertype.JobStateScheduled, received[1].Job.State)
+		require.Equal(t, time.Duration(401), received[1].JobStats.CompleteDuration)
+		require.Equal(t, time.Duration(402), received[1].JobStats.QueueWaitDuration)
+		require.Equal(t, time.Duration(403), received[1].JobStats.RunDuration)
+
+		cancelSub()
+		select {
+		case value, stillOpen := <-sub:
+			require.False(t, stillOpen, "subscription channel should be closed")
+			require.Nil(t, value, "subscription channel should be closed")
+		default:
+			require.Fail(t, "subscription channel should have been closed")
+		}
+	})
+
+	t.Run("StartStopRepeatedly", func(t *testing.T) {
+		// This service does not use the typical `startstoptest.Stress()` test
+		// because there are some additional steps required after a `Stop` for the
+		// subsequent `Start` to succeed. It's also not friendly for multiple
+		// concurrent calls to `Start` and `Stop`, but this is fine because the only
+		// usage within `Client` is already protected by a mutex.
+		t.Parallel()
+
+		manager, bundle := setup(t)
+
+		subscribeCh := bundle.subscribeCh
+		for i := 0; i < 100; i++ {
+			go func() { close(subscribeCh) }()
+			manager.Stop()
+
+			subscribeCh = make(chan []jobcompleter.CompleterJobUpdated, 1)
+			manager.ResetSubscribeChan(subscribeCh)
+
+			require.NoError(t, manager.Start(ctx))
+		}
+		close(subscribeCh)
+	})
+}


### PR DESCRIPTION
This change extracts the Client subscriptions logic into a separate `startstop.Service` which can be started and stopped along with the other services. The important change that enables this is switching from a _callback_ for job events to a _channel_ for job events. The channel is passed to the completer during init, and the completer then owns it as the sole sender. When the completer is stopped, it must close the channel to indicate that there are no more job completion events to be processed.

This moves us closer to having all the key client services be able to be managed as a single pool of services, and they can all have their shutdown initiated in parallel (even though some must still wait for others to shut down first). Importantly, this paves the way for additional services to be added (even by external libraries) without needing to deal with more complex startup & shutdown ordering scenarios. I leveraged the `startstop.StartStopBase` type in all the completers to make this work cleanly.

Additionally, I updated the payload type for completer callbacks/notifications. Rather than sending a single job each time, they can now send slices of events. This is great for the batch completer, because it doesn't have to deal with mutexes or channel sends for every individual job it completed—instead it can send the whole batch through at once.

Currently based on #377.