### PR TITLE
customizable MaxAttempts default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The default max attempts of 25 can now be customized on a per-client basis using `Config.MaxAttempts`. This is in addition to the ability to customize at the job type level with `JobArgs`, or on a per-job basis using `InsertOpts`. [PR #383](https://github.com/riverqueue/river/pull/383).
+
 ## [0.6.1] - 2024-05-21
 
 ### Fixed

--- a/job_executor.go
+++ b/job_executor.go
@@ -247,7 +247,7 @@ func (e *jobExecutor) reportResult(ctx context.Context, res *jobExecutorResult) 
 	if res.Err != nil && errors.As(res.Err, &snoozeErr) {
 		e.Logger.InfoContext(ctx, e.Name+": Job snoozed",
 			slog.Int64("job_id", e.JobRow.ID),
-		        slog.String("job_kind", e.JobRow.Kind),
+			slog.String("job_kind", e.JobRow.Kind),
 			slog.Duration("duration", snoozeErr.duration),
 		)
 		nextAttemptScheduledAt := time.Now().Add(snoozeErr.duration)


### PR DESCRIPTION
This adds a `MaxAttempts` setting to `Config` to enable the default max attempts to be customized (instead of the global default `MaxAttemptsDefault` of 25).

Fixes #381.