### PR TITLE
Change log message to use a message and arguments instead of a formatting pattern

### DIFF
--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -195,7 +195,7 @@ func (c *AsyncCompleter) Start(ctx context.Context) error {
 		<-ctx.Done()
 
 		if err := c.errGroup.Wait(); err != nil {
-			c.Logger.Error("Error waiting on async completer: %s", err)
+			c.Logger.Error("Error waiting on async completer", "err", err)
 		}
 	}()
 


### PR DESCRIPTION
I'm seeing the following error in the river logs:

```
{"time":"2024-06-10T15:02:54.573951+02:00","level":"ERROR","msg":"Error waiting on async completer: %s","!BADKEY":"context deadline exceeded"}
```

Change the log message to add the error as a log argument (like in the rest of the code base).