### PR TITLE
add JobDelete / JobDeleteTx APIs to Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The default max attempts of 25 can now be customized on a per-client basis using `Config.MaxAttempts`. This is in addition to the ability to customize at the job type level with `JobArgs`, or on a per-job basis using `InsertOpts`. [PR #383](https://github.com/riverqueue/river/pull/383).
+- Add `JobDelete` / `JobDeleteTx` APIs on `Client` to allow permanently deleting any job that's not currently running. [PR #390](https://github.com/riverqueue/river/pull/390).
 
 ### Fixed
 

--- a/client.go
+++ b/client.go
@@ -1047,6 +1047,23 @@ func (c *Client[TTx]) jobCancel(ctx context.Context, exec riverdriver.Executor, 
 	})
 }
 
+// JobDelete deletes the job with the given ID from the database, returning the
+// deleted row if it was deleted. Jobs in the running state are not deleted,
+// instead returning rivertype.ErrJobRunning.
+func (c *Client[TTx]) JobDelete(ctx context.Context, id int64) (*rivertype.JobRow, error) {
+	return c.driver.GetExecutor().JobDelete(ctx, id)
+}
+
+// JobDelete deletes the job with the given ID from the database, returning the
+// deleted row if it was deleted. Jobs in the running state are not deleted,
+// instead returning rivertype.ErrJobRunning. This variant lets a caller retry a
+// job atomically alongside other database changes. A deleted job isn't deleted
+// until the transaction commits, and if the transaction rolls back, so too is
+// the deleted job.
+func (c *Client[TTx]) JobDeleteTx(ctx context.Context, tx TTx, id int64) (*rivertype.JobRow, error) {
+	return c.driver.UnwrapExecutor(tx).JobDelete(ctx, id)
+}
+
 // JobGet fetches a single job by its ID. Returns the up-to-date JobRow for the
 // specified jobID if it exists. Returns ErrNotFound if the job doesn't exist.
 func (c *Client[TTx]) JobGet(ctx context.Context, id int64) (*rivertype.JobRow, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -1010,6 +1010,114 @@ func Test_Client_ClientFromContext(t *testing.T) {
 	require.Equal(t, client, clientResult)
 }
 
+func Test_Client_JobDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		dbPool *pgxpool.Pool
+	}
+
+	setup := func(t *testing.T) (*Client[pgx.Tx], *testBundle) {
+		t.Helper()
+
+		dbPool := riverinternaltest.TestDB(ctx, t)
+		config := newTestConfig(t, nil)
+		client := newTestClient(t, dbPool, config)
+
+		return client, &testBundle{dbPool: dbPool}
+	}
+
+	t.Run("DeletesANonRunningJob", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		insertRes, err := client.Insert(ctx, noOpArgs{}, &InsertOpts{ScheduledAt: time.Now().Add(time.Hour)})
+		require.NoError(t, err)
+		require.Equal(t, rivertype.JobStateScheduled, insertRes.Job.State)
+
+		jobAfter, err := client.JobDelete(ctx, insertRes.Job.ID)
+		require.NoError(t, err)
+		require.NotNil(t, jobAfter)
+		require.Equal(t, rivertype.JobStateScheduled, jobAfter.State)
+
+		_, err = client.JobGet(ctx, insertRes.Job.ID)
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("DoesNotDeleteARunningJob", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		doneCh := make(chan struct{})
+		startedCh := make(chan int64)
+
+		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, job *Job[callbackArgs]) error {
+			close(startedCh)
+			<-doneCh
+			return nil
+		}))
+
+		require.NoError(t, client.Start(ctx))
+		t.Cleanup(func() { require.NoError(t, client.Stop(ctx)) })
+		t.Cleanup(func() { close(doneCh) }) // must close before stopping client
+
+		insertRes, err := client.Insert(ctx, callbackArgs{}, nil)
+		require.NoError(t, err)
+
+		// Wait for the job to start:
+		riverinternaltest.WaitOrTimeout(t, startedCh)
+
+		jobAfter, err := client.JobDelete(ctx, insertRes.Job.ID)
+		require.ErrorIs(t, err, rivertype.ErrJobRunning)
+		require.Nil(t, jobAfter)
+
+		jobFromGet, err := client.JobGet(ctx, insertRes.Job.ID)
+		require.NoError(t, err)
+		require.Equal(t, rivertype.JobStateRunning, jobFromGet.State)
+	})
+
+	t.Run("TxVariantAlsoDeletesANonRunningJob", func(t *testing.T) {
+		t.Parallel()
+
+		client, bundle := setup(t)
+
+		insertRes, err := client.Insert(ctx, noOpArgs{}, &InsertOpts{ScheduledAt: time.Now().Add(time.Hour)})
+		require.NoError(t, err)
+		require.Equal(t, rivertype.JobStateScheduled, insertRes.Job.State)
+
+		var jobAfter *rivertype.JobRow
+
+		err = pgx.BeginFunc(ctx, bundle.dbPool, func(tx pgx.Tx) error {
+			var err error
+			jobAfter, err = client.JobDeleteTx(ctx, tx, insertRes.Job.ID)
+			return err
+		})
+		require.NoError(t, err)
+		require.NotNil(t, jobAfter)
+		require.Equal(t, insertRes.Job.ID, jobAfter.ID)
+		require.Equal(t, rivertype.JobStateScheduled, jobAfter.State)
+
+		jobFromGet, err := client.JobGet(ctx, insertRes.Job.ID)
+		require.ErrorIs(t, ErrNotFound, err)
+		require.Nil(t, jobFromGet)
+	})
+
+	t.Run("ReturnsErrNotFoundIfJobDoesNotExist", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		jobAfter, err := client.JobDelete(ctx, 0)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNotFound)
+		require.Nil(t, jobAfter)
+	})
+}
+
 func Test_Client_Insert(t *testing.T) {
 	t.Parallel()
 

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -77,6 +77,7 @@ type Executor interface {
 
 	JobCancel(ctx context.Context, params *JobCancelParams) (*rivertype.JobRow, error)
 	JobCountByState(ctx context.Context, state rivertype.JobState) (int, error)
+	JobDelete(ctx context.Context, id int64) (*rivertype.JobRow, error)
 	JobDeleteBefore(ctx context.Context, params *JobDeleteBeforeParams) (int, error)
 	JobGetAvailable(ctx context.Context, params *JobGetAvailableParams) ([]*rivertype.JobRow, error)
 	JobGetByID(ctx context.Context, id int64) (*rivertype.JobRow, error)

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -100,6 +100,55 @@ func (q *Queries) JobCountByState(ctx context.Context, db DBTX, state JobState) 
 	return count, err
 }
 
+const jobDelete = `-- name: JobDelete :one
+WITH job_to_delete AS (
+    SELECT id
+    FROM river_job
+    WHERE river_job.id = $1
+    FOR UPDATE
+),
+deleted_job AS (
+    DELETE
+    FROM river_job
+    USING job_to_delete
+    WHERE river_job.id = job_to_delete.id
+        -- Do not touch running jobs:
+        AND river_job.state != 'running'::river_job_state
+    RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags
+)
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
+FROM river_job
+WHERE id = $1::bigint
+    AND id NOT IN (SELECT id FROM deleted_job)
+UNION
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
+FROM deleted_job
+`
+
+func (q *Queries) JobDelete(ctx context.Context, db DBTX, id int64) (*RiverJob, error) {
+	row := db.QueryRowContext(ctx, jobDelete, id)
+	var i RiverJob
+	err := row.Scan(
+		&i.ID,
+		&i.Args,
+		&i.Attempt,
+		&i.AttemptedAt,
+		pq.Array(&i.AttemptedBy),
+		&i.CreatedAt,
+		pq.Array(&i.Errors),
+		&i.FinalizedAt,
+		&i.Kind,
+		&i.MaxAttempts,
+		&i.Metadata,
+		&i.Priority,
+		&i.Queue,
+		&i.State,
+		&i.ScheduledAt,
+		pq.Array(&i.Tags),
+	)
+	return &i, err
+}
+
 const jobDeleteBefore = `-- name: JobDeleteBefore :one
 WITH deleted_jobs AS (
     DELETE FROM river_job

--- a/riverdriver/riverdatabasesql/river_database_sql.go
+++ b/riverdriver/riverdatabasesql/river_database_sql.go
@@ -77,6 +77,10 @@ func (e *Executor) JobCountByState(ctx context.Context, state rivertype.JobState
 	return 0, riverdriver.ErrNotImplemented
 }
 
+func (e *Executor) JobDelete(ctx context.Context, id int64) (*rivertype.JobRow, error) {
+	return nil, riverdriver.ErrNotImplemented
+}
+
 func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobDeleteBeforeParams) (int, error) {
 	return 0, riverdriver.ErrNotImplemented
 }

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -97,6 +97,55 @@ func (q *Queries) JobCountByState(ctx context.Context, db DBTX, state RiverJobSt
 	return count, err
 }
 
+const jobDelete = `-- name: JobDelete :one
+WITH job_to_delete AS (
+    SELECT id
+    FROM river_job
+    WHERE river_job.id = $1
+    FOR UPDATE
+),
+deleted_job AS (
+    DELETE
+    FROM river_job
+    USING job_to_delete
+    WHERE river_job.id = job_to_delete.id
+        -- Do not touch running jobs:
+        AND river_job.state != 'running'::river_job_state
+    RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags
+)
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
+FROM river_job
+WHERE id = $1::bigint
+    AND id NOT IN (SELECT id FROM deleted_job)
+UNION
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
+FROM deleted_job
+`
+
+func (q *Queries) JobDelete(ctx context.Context, db DBTX, id int64) (*RiverJob, error) {
+	row := db.QueryRow(ctx, jobDelete, id)
+	var i RiverJob
+	err := row.Scan(
+		&i.ID,
+		&i.Args,
+		&i.Attempt,
+		&i.AttemptedAt,
+		&i.AttemptedBy,
+		&i.CreatedAt,
+		&i.Errors,
+		&i.FinalizedAt,
+		&i.Kind,
+		&i.MaxAttempts,
+		&i.Metadata,
+		&i.Priority,
+		&i.Queue,
+		&i.State,
+		&i.ScheduledAt,
+		&i.Tags,
+	)
+	return &i, err
+}
+
 const jobDeleteBefore = `-- name: JobDeleteBefore :one
 WITH deleted_jobs AS (
     DELETE FROM river_job

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -99,6 +99,17 @@ func (e *Executor) JobCountByState(ctx context.Context, state rivertype.JobState
 	return int(numJobs), nil
 }
 
+func (e *Executor) JobDelete(ctx context.Context, id int64) (*rivertype.JobRow, error) {
+	job, err := e.queries.JobDelete(ctx, e.dbtx, id)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	if job.State == dbsqlc.RiverJobStateRunning {
+		return nil, rivertype.ErrJobRunning
+	}
+	return jobRowFromInternal(job), nil
+}
+
 func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobDeleteBeforeParams) (int, error) {
 	numDeleted, err := e.queries.JobDeleteBefore(ctx, e.dbtx, &dbsqlc.JobDeleteBeforeParams{
 		CancelledFinalizedAtHorizon: params.CancelledFinalizedAtHorizon,

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -13,6 +13,10 @@ import (
 // return this error.
 var ErrNotFound = errors.New("not found")
 
+// ErrJobRunning is returned when a job is attempted to be deleted while it's
+// running.
+var ErrJobRunning = errors.New("job is running")
+
 // JobInsertResult is the result of a job insert, containing the inserted job
 // along with some other useful metadata.
 type JobInsertResult struct {

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -15,7 +15,7 @@ var ErrNotFound = errors.New("not found")
 
 // ErrJobRunning is returned when a job is attempted to be deleted while it's
 // running.
-var ErrJobRunning = errors.New("job is running")
+var ErrJobRunning = errors.New("running jobs cannot be deleted")
 
 // JobInsertResult is the result of a job insert, containing the inserted job
 // along with some other useful metadata.

--- a/subscription_manager_test.go
+++ b/subscription_manager_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
 	"github.com/riverqueue/river/internal/jobcompleter"
 	"github.com/riverqueue/river/internal/jobstats"
 	"github.com/riverqueue/river/internal/riverinternaltest"
@@ -15,7 +17,6 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivertype"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_SubscriptionManager(t *testing.T) {


### PR DESCRIPTION
This adds new APIs to permanently delete a job from the job table, so long as it is not currently running.