### PR TITLE
fix flaky insert notify limiter test

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1353,7 +1353,13 @@ func Test_Client_InsertMany(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
-		client, _ := setup(t)
+
+		_, bundle := setup(t)
+
+		config := newTestConfig(t, nil)
+		config.FetchCooldown = 5 * time.Second
+		config.FetchPollInterval = 5 * time.Second
+		client := newTestClient(t, bundle.dbPool, config)
 		statusUpdateCh := client.monitor.RegisterUpdates()
 
 		startClient(ctx, t, client)


### PR DESCRIPTION
The insert notify limiter uses the FetchCooldown setting for its own debounce interval. This defaults to 100ms, which is short enough to occasionally fail in GitHub Actions when testing two trigger attempts back to back.

Failed on [this run](https://github.com/riverqueue/river/actions/runs/9476488955/job/26109455144?pr=390):

```
        client_test.go:1480: 
            	Error Trace:	/home/runner/work/river/river/client_test.go:1480
            	Error:      	Should be false
            	Test:       	Test_Client_InsertMany/DoesNotTriggerInsertNotificationForNonAvailableJob
```