### PR TITLE
add links to River UI in Readme

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -2,7 +2,7 @@
 Package river is a robust high-performance job processing system for Go and
 Postgres.
 
-See [homepage], [docs], and [godoc].
+See [homepage], [docs], and [godoc], as well as the [River UI][riverui].
 
 Being built for Postgres, River encourages the use of the same database for
 application data and job queue. By enqueueing jobs transactionally along with
@@ -147,6 +147,8 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Unique jobs] by args, period, queue, and state.
 
+  - [Web UI][riverui] for inspecting and interacting with jobs and queues.
+
   - [Work functions] for simplified worker implementation.
 
 # Development
@@ -175,6 +177,7 @@ See [developing River].
 [graceful shutdown]: https://riverqueue.com/docs/graceful-shutdown
 [homepage]: https://riverqueue.com
 [maintenance services]: https://riverqueue.com/docs/maintenance-services
+[riverui]: https://github.com/riverqueue/riverui
 [transactional enqueueing]: https://riverqueue.com/docs/transactional-enqueueing
 */
 package river

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 River is a robust high-performance job processing system for Go and Postgres.
 
-See [homepage], [docs], and [godoc].
+See [homepage], [docs], and [godoc], as well as the [River UI][riverui].
 
 Being built for Postgres, River encourages the use of the same database for
 application data and job queue. By enqueueing jobs transactionally along with
@@ -159,6 +159,8 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Unique jobs] by args, period, queue, and state.
 
+  - [Web UI][riverui] for inspecting and interacting with jobs and queues.
+
   - [Work functions] for simplified worker implementation.
 
 ## Cross language enqueueing
@@ -205,4 +207,5 @@ Thank you for driving the software ecosystem forward.
 [graceful shutdown]: https://riverqueue.com/docs/graceful-shutdown
 [homepage]: https://riverqueue.com
 [maintenance services]: https://riverqueue.com/docs/maintenance-services
+[riverui]: https://github.com/riverqueue/riverui
 [transactional enqueueing]: https://riverqueue.com/docs/transactional-enqueueing


### PR DESCRIPTION
Realized we should probably cross-link to the UI from the main readme. Open to other ways or changes here, just wanted to get something in place.