### PR TITLE
Add AddQueue to the Client

### DIFF
--- a/client_monitor.go
+++ b/client_monitor.go
@@ -67,6 +67,13 @@ func (m *clientMonitor) SetProducerStatus(queueName string, status componentstat
 	m.bufferStatusUpdate()
 }
 
+func (m *clientMonitor) RemoveProducerStatus(queueName string) {
+	m.statusSnapshotMu.Lock()
+	defer m.statusSnapshotMu.Unlock()
+	delete(m.currentSnapshot.Producers, queueName)
+	m.bufferStatusUpdate()
+}
+
 func (m *clientMonitor) SetElectorStatus(newStatus componentstatus.ElectorStatus) {
 	m.statusSnapshotMu.Lock()
 	defer m.statusSnapshotMu.Unlock()

--- a/client_monitor.go
+++ b/client_monitor.go
@@ -67,13 +67,6 @@ func (m *clientMonitor) SetProducerStatus(queueName string, status componentstat
 	m.bufferStatusUpdate()
 }
 
-func (m *clientMonitor) RemoveProducerStatus(queueName string) {
-	m.statusSnapshotMu.Lock()
-	defer m.statusSnapshotMu.Unlock()
-	delete(m.currentSnapshot.Producers, queueName)
-	m.bufferStatusUpdate()
-}
-
 func (m *clientMonitor) SetElectorStatus(newStatus componentstatus.ElectorStatus) {
 	m.statusSnapshotMu.Lock()
 	defer m.statusSnapshotMu.Unlock()

--- a/internal/maintenance/startstop/start_stop.go
+++ b/internal/maintenance/startstop/start_stop.go
@@ -55,6 +55,7 @@ type serviceWithStopped interface {
 // override it.
 type BaseStartStop struct {
 	cancelFunc context.CancelCauseFunc
+	context    context.Context
 	mu         sync.Mutex
 	started    bool
 	stopped    chan struct{}
@@ -107,9 +108,13 @@ func (s *BaseStartStop) StartInit(ctx context.Context) (context.Context, bool, c
 
 	s.started = true
 	s.stopped = make(chan struct{})
-	ctx, s.cancelFunc = context.WithCancelCause(ctx)
+	s.context, s.cancelFunc = context.WithCancelCause(ctx)
 
-	return ctx, true, s.stopped
+	return s.context, true, s.stopped
+}
+
+func (s *BaseStartStop) IsStarted() (context.Context, bool) {
+	return s.context, s.started
 }
 
 // Stop is an automatically provided implementation for the maintenance Service


### PR DESCRIPTION
Closes #396 

Based on the proposal I added AddQueue/RemoveQueue. This won't do anything just add the queues, so we need to "Restart" the client after that. 

What do you think about to add StartWorkContext in the AddQueue section

```go
if err := producer.StartWorkContext(fetchCtx, workCtx); err != nil {
	stopProducers()
	stopServicesOnError()
	return err
}
```