### PR TITLE
elector: resign leadership w/ WithoutCancel ctx, not background

### DIFF
--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -177,7 +177,7 @@ func (e *Elector) Start(ctx context.Context) error {
 					continue // lost leadership reelection; unusual but not a problem; don't log
 				}
 
-				e.Logger.Error(e.Name+": Error keeping leadership", "client_id", e.config.ClientID, "err", err)
+				e.Logger.ErrorContext(ctx, e.Name+": Error keeping leadership", "client_id", e.config.ClientID, "err", err)
 			}
 		}
 	}()
@@ -202,7 +202,7 @@ func (e *Elector) attemptGainLeadershipLoop(ctx context.Context) error {
 
 			numErrors++
 			sleepDuration := e.ExponentialBackoff(numErrors, baseservice.MaxAttemptsBeforeResetDefault)
-			e.Logger.Error(e.Name+": Error attempting to elect", "client_id", e.config.ClientID, "err", err, "num_errors", numErrors, "sleep_duration", sleepDuration)
+			e.Logger.ErrorContext(ctx, e.Name+": Error attempting to elect", "client_id", e.config.ClientID, "err", err, "num_errors", numErrors, "sleep_duration", sleepDuration)
 			e.CancellableSleep(ctx, sleepDuration)
 			continue
 		}
@@ -237,13 +237,13 @@ func (e *Elector) attemptGainLeadershipLoop(ctx context.Context) error {
 func (e *Elector) handleLeadershipNotification(ctx context.Context, topic notifier.NotificationTopic, payload string) {
 	if topic != notifier.NotificationTopicLeadership {
 		// This should not happen unless the notifier is broken.
-		e.Logger.Error(e.Name+": Received unexpected notification", "client_id", e.config.ClientID, "topic", topic, "payload", payload)
+		e.Logger.ErrorContext(ctx, e.Name+": Received unexpected notification", "client_id", e.config.ClientID, "topic", topic, "payload", payload)
 		return
 	}
 
 	notification := dbLeadershipNotification{}
 	if err := json.Unmarshal([]byte(payload), &notification); err != nil {
-		e.Logger.Error(e.Name+": Unable to unmarshal leadership notification", "client_id", e.config.ClientID, "err", err)
+		e.Logger.ErrorContext(ctx, e.Name+": Unable to unmarshal leadership notification", "client_id", e.config.ClientID, "err", err)
 		return
 	}
 
@@ -379,10 +379,10 @@ func (e *Elector) attemptResignLoop(ctx context.Context) {
 
 	for attempt := 1; attempt <= maxNumErrors; attempt++ {
 		if err := e.attemptResign(ctx, attempt); err != nil { //nolint:contextcheck
-			e.Logger.Error(e.Name+": Error attempting to resign", "attempt", attempt, "client_id", e.config.ClientID, "err", err)
+			e.Logger.ErrorContext(ctx, e.Name+": Error attempting to resign", "attempt", attempt, "client_id", e.config.ClientID, "err", err)
 
 			sleepDuration := e.ExponentialBackoff(attempt, baseservice.MaxAttemptsBeforeResetDefault)
-			e.Logger.Error(e.Name+": Error attempting to resign",
+			e.Logger.ErrorContext(ctx, e.Name+": Error attempting to resign",
 				"client_id", e.config.ClientID, "err", err, "num_errors", attempt, "sleep_duration", sleepDuration)
 			e.CancellableSleep(ctx, sleepDuration) //nolint:contextcheck
 


### PR DESCRIPTION
Borrowing an idea from #401, rather than using a background context for a shutdown operation that we don't want to be prematurely immediately cancelled, we can instead use a `context.WithoutCancel(ctx)` to maintain non-cancel parts of the context.

I also updated logger calls in here to use the `Context` variants for consitency.