### PR TITLE
Prepare version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2024-06-25
+
 ### Added
 
 - Add transaction variants for queue-related client functions: `QueueGetTx`, `QueueListTx`, `QueuePauseTx`, and `QueueResumeTx`. [PR #402](https://github.com/riverqueue/river/pull/402).

--- a/go.mod
+++ b/go.mod
@@ -14,10 +14,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.7.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.7.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.7.0
-	github.com/riverqueue/river/rivertype v0.7.0
+	github.com/riverqueue/river/riverdriver v0.8.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.8.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.8.0
+	github.com/riverqueue/river/rivertype v0.8.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.7.0
+require github.com/riverqueue/river/rivertype v0.8.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -8,8 +8,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.7.0
-	github.com/riverqueue/river/rivertype v0.7.0
+	github.com/riverqueue/river/riverdriver v0.8.0
+	github.com/riverqueue/river/rivertype v0.8.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -9,8 +9,8 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.7.0
-	github.com/riverqueue/river/rivertype v0.7.0
+	github.com/riverqueue/river/riverdriver v0.8.0
+	github.com/riverqueue/river/rivertype v0.8.0
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prepare release for version 0.8.0 which includes some additions and
fixes like #402 and #401.