### PR TITLE
Fix broken links from Godoc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -2,7 +2,7 @@
 Package river is a robust high-performance job processing system for Go and
 Postgres.
 
-See [homepage], [docs], and [godoc], as well as the [River UI][riverui].
+See [homepage], [docs], and [godoc], as well as the [River UI].
 
 Being built for Postgres, River encourages the use of the same database for
 application data and job queue. By enqueueing jobs transactionally along with
@@ -147,7 +147,7 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Unique jobs] by args, period, queue, and state.
 
-  - [Web UI][riverui] for inspecting and interacting with jobs and queues.
+  - [Web UI] for inspecting and interacting with jobs and queues.
 
   - [Work functions] for simplified worker implementation.
 
@@ -163,12 +163,16 @@ See [developing River].
 [Batch job insertion]: https://riverqueue.com/docs/batch-job-insertion
 [Cancelling jobs]: https://riverqueue.com/docs/cancelling-jobs
 [Error and panic handling]: https://riverqueue.com/docs/error-handling
+[Multiple queues]: https://riverqueue.com/docs/multiple-queues
 [Periodic and cron jobs]: https://riverqueue.com/docs/periodic-jobs
+[River UI]: https://github.com/riverqueue/riverui
 [Scheduled jobs]: https://riverqueue.com/docs/scheduled-jobs
 [Snoozing jobs]: https://riverqueue.com/docs/snoozing-jobs
 [Subscriptions]: https://riverqueue.com/docs/subscriptions
+[Test helpers]: https://riverqueue.com/docs/testing
 [Transactional job completion]: https://riverqueue.com/docs/transactional-job-completion
 [Unique jobs]: https://riverqueue.com/docs/unique-jobs
+[Web UI]: https://github.com/riverqueue/riverui
 [Work functions]: https://riverqueue.com/docs/work-functions
 [docs]: https://riverqueue.com/docs
 [developing River]: https://github.com/riverqueue/river/blob/master/docs/development.md
@@ -177,7 +181,6 @@ See [developing River].
 [graceful shutdown]: https://riverqueue.com/docs/graceful-shutdown
 [homepage]: https://riverqueue.com
 [maintenance services]: https://riverqueue.com/docs/maintenance-services
-[riverui]: https://github.com/riverqueue/riverui
 [transactional enqueueing]: https://riverqueue.com/docs/transactional-enqueueing
 */
 package river

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 River is a robust high-performance job processing system for Go and Postgres.
 
-See [homepage], [docs], and [godoc], as well as the [River UI][riverui].
+See [homepage], [docs], and [godoc], as well as the [River UI],
 
 Being built for Postgres, River encourages the use of the same database for
 application data and job queue. By enqueueing jobs transactionally along with
@@ -159,7 +159,7 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Unique jobs] by args, period, queue, and state.
 
-  - [Web UI][riverui] for inspecting and interacting with jobs and queues.
+  - [Web UI] for inspecting and interacting with jobs and queues.
 
   - [Work functions] for simplified worker implementation.
 
@@ -193,12 +193,14 @@ Thank you for driving the software ecosystem forward.
 [Error and panic handling]: https://riverqueue.com/docs/error-handling
 [Multiple queues]: https://riverqueue.com/docs/multiple-queues
 [Periodic and cron jobs]: https://riverqueue.com/docs/periodic-jobs
+[River UI]: https://github.com/riverqueue/riverui
 [Scheduled jobs]: https://riverqueue.com/docs/scheduled-jobs
 [Snoozing jobs]: https://riverqueue.com/docs/snoozing-jobs
 [Subscriptions]: https://riverqueue.com/docs/subscriptions
 [Test helpers]: https://riverqueue.com/docs/testing
 [Transactional job completion]: https://riverqueue.com/docs/transactional-job-completion
 [Unique jobs]: https://riverqueue.com/docs/unique-jobs
+[Web UI]: https://github.com/riverqueue/riverui
 [Work functions]: https://riverqueue.com/docs/work-functions
 [developing River]: https://github.com/riverqueue/river/blob/master/docs/development.md
 [docs]: https://riverqueue.com/docs


### PR DESCRIPTION
I just happened to be looking at our Godoc and noticed that some of the
links are broken [1]. Some were missing their definitions, but the new
River UI ones use a Markdown syntax that's not supported by Godoc.

I also updated the README with the same changes. They're not necessary
there, but IMO better to keep these two docs as synchronized as possible
so if we need to make wider changes later it's easy to change both.

[1] https://pkg.go.dev/github.com/riverqueue/river