### PR TITLE
Idempotent queue pause and resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pausing or resuming a queue that was already paused or not paused respectively no longer returns `rivertype.ErrNotFound`. The same goes for pausing or resuming using the all queues string (`*`) when no queues are in the database (previously that also returned `rivertype.ErrNotFound`). [PR #408](https://github.com/riverqueue/river/pull/408).
+
 ## [0.8.0] - 2024-06-25
 
 ### Added

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -20,6 +20,8 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
+const AllQueuesString = "*"
+
 var (
 	ErrClosedPool        = errors.New("underlying driver pool is closed")
 	ErrNotImplemented    = errors.New("driver does not implement this functionality")

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -524,7 +524,7 @@ func (e *Executor) QueuePause(ctx context.Context, name string) error {
 	if err != nil {
 		return interpretError(err)
 	}
-	if res.RowsAffected() == 0 {
+	if res.RowsAffected() == 0 && name != riverdriver.AllQueuesString {
 		return rivertype.ErrNotFound
 	}
 	return nil
@@ -535,7 +535,7 @@ func (e *Executor) QueueResume(ctx context.Context, name string) error {
 	if err != nil {
 		return interpretError(err)
 	}
-	if res.RowsAffected() == 0 {
+	if res.RowsAffected() == 0 && name != riverdriver.AllQueuesString {
 		return rivertype.ErrNotFound
 	}
 	return nil


### PR DESCRIPTION
I was writing tests for River UI and found that when trying to pause an
already paused queue or resume an unpaused queue, River returns a "not
found" error.

This was quite surprising, so much so that it took me a good half hour
of debugging before I considered the fact that it might actually be a
problem in upstream River. Even if an argument were to be made that
pausing an already paused queue should be an error like "queue already
paused", returning "not found" is misleading and guaranteed to result
in confused people beyond just myself.

I think it's fine for pause and resume to be considered idempotent
operations. If a paused queue is paused again, there's no real damage
done, especially if we keep the original paused time, which we do in
this implementation.

Similarly, make an update so that when pausing or resuming using  the
all queues string (`*`), don't return "not found" error if there are no
queues in the database. Instead, just no-op.