### PR TITLE
Update add queue feature with a more changes and concurrent safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Fully functional driver for `database/sql` for use with packages like Bun and GORM. [PR #351](https://github.com/riverqueue/river/pull/351).
+- Queues can be added after a client is initialized using `client.Queues().Add(queueName string, queueConfig QueueConfig)`. [PR #410](https://github.com/riverqueue/river/pull/410).
 
 ### Changed
 

--- a/client.go
+++ b/client.go
@@ -264,10 +264,7 @@ func (c *Config) validate() error {
 	}
 
 	for queue, queueConfig := range c.Queues {
-		if queueConfig.MaxWorkers < 1 || queueConfig.MaxWorkers > QueueNumWorkersMax {
-			return fmt.Errorf("invalid number of workers for queue %q: %d", queue, queueConfig.MaxWorkers)
-		}
-		if err := validateQueueName(queue); err != nil {
+		if err := queueConfig.validate(queue); err != nil {
 			return err
 		}
 	}
@@ -299,6 +296,17 @@ type QueueConfig struct {
 	//
 	// Requires a minimum of 1, and a maximum of 10,000.
 	MaxWorkers int
+}
+
+func (c QueueConfig) validate(queueName string) error {
+	if c.MaxWorkers < 1 || c.MaxWorkers > QueueNumWorkersMax {
+		return fmt.Errorf("invalid number of workers for queue %q: %d", queueName, c.MaxWorkers)
+	}
+	if err := validateQueueName(queueName); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Client is a single isolated instance of River. Your application may use
@@ -518,23 +526,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		client.services = append(client.services, client.elector)
 
 		for queue, queueConfig := range config.Queues {
-			client.producersByQueueName[queue] = newProducer(archetype, driver.GetExecutor(), &producerConfig{
-				ClientID:           config.ID,
-				Completer:          client.completer,
-				ErrorHandler:       config.ErrorHandler,
-				FetchCooldown:      config.FetchCooldown,
-				FetchPollInterval:  config.FetchPollInterval,
-				JobTimeout:         config.JobTimeout,
-				MaxWorkers:         queueConfig.MaxWorkers,
-				Notifier:           client.notifier,
-				Queue:              queue,
-				QueueEventCallback: client.subscriptionManager.distributeQueueEvent,
-				RetryPolicy:        config.RetryPolicy,
-				SchedulerInterval:  config.schedulerInterval,
-				StatusFunc:         client.monitor.SetProducerStatus,
-				Workers:            config.Workers,
-			})
-			client.monitor.InitializeProducerStatus(queue)
+			client.producersByQueueName[queue] = client.addProducer(queue, queueConfig)
 		}
 
 		client.services = append(client.services,
@@ -626,34 +618,16 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 	return client, nil
 }
 
-func (c *Client[TTx]) AddQueue(queueName string, queueConfig QueueConfig) {
+func (c *Client[TTx]) AddQueue(queueName string, queueConfig QueueConfig) error {
+	if err := queueConfig.validate(queueName); err != nil {
+		return err
+	}
+
 	c.producersByQueueNameMu.Lock()
 	defer c.producersByQueueNameMu.Unlock()
-	c.producersByQueueName[queueName] = newProducer(&c.baseService.Archetype, c.driver.GetExecutor(), &producerConfig{
-		ClientID:          c.config.ID,
-		Completer:         c.completer,
-		ErrorHandler:      c.config.ErrorHandler,
-		FetchCooldown:     c.config.FetchCooldown,
-		FetchPollInterval: c.config.FetchPollInterval,
-		JobTimeout:        c.config.JobTimeout,
-		MaxWorkers:        queueConfig.MaxWorkers,
-		Notifier:          c.notifier,
-		Queue:             queueName,
-		RetryPolicy:       c.config.RetryPolicy,
-		SchedulerInterval: c.config.schedulerInterval,
-		StatusFunc:        c.monitor.SetProducerStatus,
-		Workers:           c.config.Workers,
-	})
-	c.monitor.InitializeProducerStatus(queueName)
-}
+	c.producersByQueueName[queueName] = c.addProducer(queueName, queueConfig)
 
-func (c *Client[TTx]) RemoveQueue(queueName string) {
-	c.producersByQueueNameMu.Lock()
-	defer c.producersByQueueNameMu.Unlock()
-	delete(c.producersByQueueName, queueName)
-
-	// Remove queue from currentSnapshot.Producers
-	c.monitor.RemoveProducerStatus(queueName)
+	return nil
 }
 
 // Start starts the client's job fetching and working loops. Once this is called,
@@ -1565,6 +1539,26 @@ func (c *Client[TTx]) validateJobArgs(args JobArgs) error {
 	}
 
 	return nil
+}
+
+func (c *Client[TTx]) addProducer(queueName string, queueConfig QueueConfig) *producer {
+	producerInstance := newProducer(&c.baseService.Archetype, c.driver.GetExecutor(), &producerConfig{
+		ClientID:          c.config.ID,
+		Completer:         c.completer,
+		ErrorHandler:      c.config.ErrorHandler,
+		FetchCooldown:     c.config.FetchCooldown,
+		FetchPollInterval: c.config.FetchPollInterval,
+		JobTimeout:        c.config.JobTimeout,
+		MaxWorkers:        queueConfig.MaxWorkers,
+		Notifier:          c.notifier,
+		Queue:             queueName,
+		RetryPolicy:       c.config.RetryPolicy,
+		SchedulerInterval: c.config.schedulerInterval,
+		StatusFunc:        c.monitor.SetProducerStatus,
+		Workers:           c.config.Workers,
+	})
+	c.monitor.InitializeProducerStatus(queueName)
+	return producerInstance
 }
 
 var nameRegex = regexp.MustCompile(`^(?:[a-z0-9])+(?:[_|\-]?[a-z0-9]+)*$`)

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/riverqueue/river/internal/baseservice"
@@ -309,21 +310,22 @@ type Client[TTx any] struct {
 	baseService   baseservice.BaseService
 	baseStartStop startstop.BaseStartStop
 
-	completer            jobcompleter.JobCompleter
-	config               *Config
-	driver               riverdriver.Driver[TTx]
-	elector              *leadership.Elector
-	insertNotifyLimiter  *notifylimiter.Limiter
-	monitor              *clientMonitor
-	notifier             *notifier.Notifier // may be nil in poll-only mode
-	periodicJobs         *PeriodicJobBundle
-	producersByQueueName map[string]*producer
-	queueMaintainer      *maintenance.QueueMaintainer
-	services             []startstop.Service
-	subscriptionManager  *subscriptionManager
-	stopped              <-chan struct{}
-	testSignals          clientTestSignals
-	uniqueInserter       *dbunique.UniqueInserter
+	completer              jobcompleter.JobCompleter
+	config                 *Config
+	driver                 riverdriver.Driver[TTx]
+	elector                *leadership.Elector
+	insertNotifyLimiter    *notifylimiter.Limiter
+	monitor                *clientMonitor
+	notifier               *notifier.Notifier // may be nil in poll-only mode
+	periodicJobs           *PeriodicJobBundle
+	producersByQueueName   map[string]*producer
+	producersByQueueNameMu sync.Mutex
+	queueMaintainer        *maintenance.QueueMaintainer
+	services               []startstop.Service
+	subscriptionManager    *subscriptionManager
+	stopped                <-chan struct{}
+	testSignals            clientTestSignals
+	uniqueInserter         *dbunique.UniqueInserter
 
 	// workCancel cancels the context used for all work goroutines. Normal Stop
 	// does not cancel that context.
@@ -622,6 +624,36 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 	}
 
 	return client, nil
+}
+
+func (c *Client[TTx]) AddQueue(queueName string, queueConfig QueueConfig) {
+	c.producersByQueueNameMu.Lock()
+	defer c.producersByQueueNameMu.Unlock()
+	c.producersByQueueName[queueName] = newProducer(&c.baseService.Archetype, c.driver.GetExecutor(), &producerConfig{
+		ClientID:          c.config.ID,
+		Completer:         c.completer,
+		ErrorHandler:      c.config.ErrorHandler,
+		FetchCooldown:     c.config.FetchCooldown,
+		FetchPollInterval: c.config.FetchPollInterval,
+		JobTimeout:        c.config.JobTimeout,
+		MaxWorkers:        queueConfig.MaxWorkers,
+		Notifier:          c.notifier,
+		Queue:             queueName,
+		RetryPolicy:       c.config.RetryPolicy,
+		SchedulerInterval: c.config.schedulerInterval,
+		StatusFunc:        c.monitor.SetProducerStatus,
+		Workers:           c.config.Workers,
+	})
+	c.monitor.InitializeProducerStatus(queueName)
+}
+
+func (c *Client[TTx]) RemoveQueue(queueName string) {
+	c.producersByQueueNameMu.Lock()
+	defer c.producersByQueueNameMu.Unlock()
+	delete(c.producersByQueueName, queueName)
+
+	// Remove queue from currentSnapshot.Producers
+	c.monitor.RemoveProducerStatus(queueName)
 }
 
 // Start starts the client's job fetching and working loops. Once this is called,

--- a/client.go
+++ b/client.go
@@ -337,7 +337,8 @@ type Client[TTx any] struct {
 
 	// workCancel cancels the context used for all work goroutines. Normal Stop
 	// does not cancel that context.
-	workCancel context.CancelCauseFunc
+	workCancel  context.CancelCauseFunc
+	workContext context.Context
 }
 
 // Test-only signals.
@@ -618,14 +619,22 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 	return client, nil
 }
 
-func (c *Client[TTx]) AddQueue(queueName string, queueConfig QueueConfig) error {
+func (c *Client[TTx]) AddQueue(ctx context.Context, queueName string, queueConfig QueueConfig) error {
 	if err := queueConfig.validate(queueName); err != nil {
 		return err
 	}
 
+	producerInstance := c.addProducer(queueName, queueConfig)
 	c.producersByQueueNameMu.Lock()
-	defer c.producersByQueueNameMu.Unlock()
-	c.producersByQueueName[queueName] = c.addProducer(queueName, queueConfig)
+	c.producersByQueueName[queueName] = producerInstance
+	c.producersByQueueNameMu.Unlock()
+
+	fetchCtx, started := c.baseStartStop.IsStarted()
+	if started {
+		if err := producerInstance.StartWorkContext(fetchCtx, c.workContext); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }
@@ -656,8 +665,6 @@ func (c *Client[TTx]) Start(ctx context.Context) error {
 			func(p *producer) startstop.Service { return p },
 		)
 	}
-
-	var workCtx context.Context
 
 	// Startup code. Wrapped in a closure so it doesn't have to remember to
 	// close the stopped channel if returning with an error.
@@ -720,7 +727,7 @@ func (c *Client[TTx]) Start(ctx context.Context) error {
 		// We use separate contexts for fetching and working to allow for a graceful
 		// stop. Both inherit from the provided context, so if it's cancelled, a
 		// more aggressive stop will be initiated.
-		workCtx, c.workCancel = context.WithCancelCause(withClient[TTx](ctx, c))
+		c.workContext, c.workCancel = context.WithCancelCause(withClient[TTx](ctx, c))
 
 		for _, service := range c.services {
 			if err := service.Start(fetchCtx); err != nil {
@@ -732,7 +739,7 @@ func (c *Client[TTx]) Start(ctx context.Context) error {
 		for _, producer := range c.producersByQueueName {
 			producer := producer
 
-			if err := producer.StartWorkContext(fetchCtx, workCtx); err != nil {
+			if err := producer.StartWorkContext(fetchCtx, c.workContext); err != nil {
 				startstop.StopAllParallel(producersAsServices())
 				stopServicesOnError()
 				return err

--- a/client_monitor.go
+++ b/client_monitor.go
@@ -56,6 +56,8 @@ func (m *clientMonitor) Start(ctx context.Context) error {
 // uninitialized.  Unlike SetProducerStatus, it does not broadcast the change
 // and is only meant to be used during initial client startup.
 func (m *clientMonitor) InitializeProducerStatus(queueName string) {
+	m.statusSnapshotMu.Lock()
+	defer m.statusSnapshotMu.Unlock()
 	m.currentSnapshot.Producers[queueName] = componentstatus.Uninitialized
 }
 

--- a/client_monitor.go
+++ b/client_monitor.go
@@ -66,6 +66,13 @@ func (m *clientMonitor) SetProducerStatus(queueName string, status componentstat
 	m.bufferStatusUpdate()
 }
 
+func (m *clientMonitor) RemoveProducerStatus(queueName string) {
+	m.statusSnapshotMu.Lock()
+	defer m.statusSnapshotMu.Unlock()
+	delete(m.currentSnapshot.Producers, queueName)
+	m.bufferStatusUpdate()
+}
+
 func (m *clientMonitor) SetElectorStatus(newStatus componentstatus.ElectorStatus) {
 	m.statusSnapshotMu.Lock()
 	defer m.statusSnapshotMu.Unlock()

--- a/client_monitor.go
+++ b/client_monitor.go
@@ -66,13 +66,6 @@ func (m *clientMonitor) SetProducerStatus(queueName string, status componentstat
 	m.bufferStatusUpdate()
 }
 
-func (m *clientMonitor) RemoveProducerStatus(queueName string) {
-	m.statusSnapshotMu.Lock()
-	defer m.statusSnapshotMu.Unlock()
-	delete(m.currentSnapshot.Producers, queueName)
-	m.bufferStatusUpdate()
-}
-
 func (m *clientMonitor) SetElectorStatus(newStatus componentstatus.ElectorStatus) {
 	m.statusSnapshotMu.Lock()
 	defer m.statusSnapshotMu.Unlock()

--- a/client_test.go
+++ b/client_test.go
@@ -258,6 +258,72 @@ func Test_Client(t *testing.T) {
 		riverinternaltest.WaitOrTimeout(t, workedChan)
 	})
 
+	t.Run("StartInsertAndWorkAddQueue_BeforeStart", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		type JobArgs struct {
+			JobArgsReflectKind[JobArgs]
+		}
+
+		workedChan := make(chan struct{})
+
+		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, job *Job[JobArgs]) error {
+			workedChan <- struct{}{}
+			return nil
+		}))
+
+		queueName := "new_queue"
+		err := client.AddQueue(ctx, queueName, QueueConfig{
+			MaxWorkers: 2,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		startClient(ctx, t, client)
+
+		_, err = client.Insert(ctx, &JobArgs{}, &InsertOpts{
+			Queue: queueName,
+		})
+		require.NoError(t, err)
+
+		riverinternaltest.WaitOrTimeout(t, workedChan)
+	})
+
+	t.Run("StartInsertAndWorkAddQueue_AfterStart", func(t *testing.T) {
+		t.Parallel()
+
+		client, _ := setup(t)
+
+		type JobArgs struct {
+			JobArgsReflectKind[JobArgs]
+		}
+
+		workedChan := make(chan struct{})
+
+		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, job *Job[JobArgs]) error {
+			workedChan <- struct{}{}
+			return nil
+		}))
+
+		startClient(ctx, t, client)
+		queueName := "new_queue"
+		err := client.AddQueue(ctx, queueName, QueueConfig{
+			MaxWorkers: 2,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = client.Insert(ctx, &JobArgs{}, &InsertOpts{
+			Queue: queueName,
+		})
+		require.NoError(t, err)
+
+		riverinternaltest.WaitOrTimeout(t, workedChan)
+	})
+
 	t.Run("JobCancelErrorReturned", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/startstop/start_stop.go
+++ b/internal/startstop/start_stop.go
@@ -61,7 +61,6 @@ type serviceWithStopped interface {
 // override it.
 type BaseStartStop struct {
 	cancelFunc context.CancelCauseFunc
-	context    context.Context
 	mu         sync.Mutex
 	started    chan struct{}
 	stopped    chan struct{}
@@ -114,7 +113,7 @@ func (s *BaseStartStop) StartInit(ctx context.Context) (context.Context, bool, f
 
 	s.started = make(chan struct{})
 	s.stopped = make(chan struct{})
-	s.context, s.cancelFunc = context.WithCancelCause(ctx)
+	ctx, s.cancelFunc = context.WithCancelCause(ctx)
 
 	closeStartedOnce := sync.OnceFunc(func() { close(s.started) })
 
@@ -135,10 +134,6 @@ func (s *BaseStartStop) Started() <-chan struct{} {
 	defer s.mu.Unlock()
 
 	return s.started
-}
-
-func (s *BaseStartStop) IsStarted() (context.Context, bool) {
-	return s.context, s.started != nil
 }
 
 // Stop is an automatically provided implementation for the maintenance Service

--- a/internal/startstop/start_stop.go
+++ b/internal/startstop/start_stop.go
@@ -61,6 +61,7 @@ type serviceWithStopped interface {
 // override it.
 type BaseStartStop struct {
 	cancelFunc context.CancelCauseFunc
+	context    context.Context
 	mu         sync.Mutex
 	started    chan struct{}
 	stopped    chan struct{}
@@ -113,7 +114,7 @@ func (s *BaseStartStop) StartInit(ctx context.Context) (context.Context, bool, f
 
 	s.started = make(chan struct{})
 	s.stopped = make(chan struct{})
-	ctx, s.cancelFunc = context.WithCancelCause(ctx)
+	s.context, s.cancelFunc = context.WithCancelCause(ctx)
 
 	closeStartedOnce := sync.OnceFunc(func() { close(s.started) })
 
@@ -134,6 +135,10 @@ func (s *BaseStartStop) Started() <-chan struct{} {
 	defer s.mu.Unlock()
 
 	return s.started
+}
+
+func (s *BaseStartStop) IsStarted() (context.Context, bool) {
+	return s.context, s.started != nil
 }
 
 // Stop is an automatically provided implementation for the maintenance Service

--- a/periodic_job.go
+++ b/periodic_job.go
@@ -91,7 +91,7 @@ func (s *periodicIntervalSchedule) Next(t time.Time) time.Time {
 
 // PeriodicJobBundle is a bundle of currently configured periodic jobs. It's
 // made accessible through Client, where new periodic jobs can be configured,
-// and only ones removed.
+// and old ones removed.
 type PeriodicJobBundle struct {
 	clientConfig        *Config
 	periodicJobEnqueuer *maintenance.PeriodicJobEnqueuer


### PR DESCRIPTION
A feature to make it possible to add a new queue using an invocation like
`client.Queues().Add(name, config)`, similar to the API for adding a new
periodic job. If the client is started already, the new producer is also
started. Fetch and work context are the same ones created for other
producers during `Start`.

For now we totally punt on the problem of removing queues, which is more 
complicated because it's a fairly hard problem on how producer stop context
cancellation should work.

A problem I was having while writing a stress test for the feature is that
test signal channels were being filled which was difficult to solve because
test signals were always initialized by `newTestClient` and because the
init also initializes each maintenance service's test signals in turn, it's
not possible to deinit them again. I had to refactor tests such that test
signals are only initialized when they're used, which is probably better
anyway.