### PR TITLE
Docs: Fix comma in README that should be a period

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 River is a robust high-performance job processing system for Go and Postgres.
 
-See [homepage], [docs], and [godoc], as well as the [River UI],
+See [homepage], [docs], and [godoc], as well as the [River UI].
 
 Being built for Postgres, River encourages the use of the same database for
 application data and job queue. By enqueueing jobs transactionally along with


### PR DESCRIPTION
Tiny, tiny fix in which we take a problematic comma and turn it into the
period it was meant to be. Amazingly this is a problem only in the
README and not in its mirror in `doc.go`.