### PR TITLE
Track started state of start/stop services + cleaner functions instead of channels

### DIFF
--- a/client_monitor.go
+++ b/client_monitor.go
@@ -30,15 +30,14 @@ func newClientMonitor() *clientMonitor {
 }
 
 func (m *clientMonitor) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := m.StartInit(ctx)
+	ctx, shouldStart, started, stopped := m.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		for {
 			select {

--- a/internal/jobcompleter/job_completer_test.go
+++ b/internal/jobcompleter/job_completer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/internal/jobstats"
+	"github.com/riverqueue/river/internal/maintenance/startstop"
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/riverinternaltest/testfactory"
@@ -356,7 +357,7 @@ func TestBatchCompleter(t *testing.T) {
 		require.NoError(t, completer.Start(ctx))
 		t.Cleanup(completer.Stop)
 
-		riverinternaltest.WaitOrTimeout(t, completer.WaitStarted())
+		riverinternaltest.WaitOrTimeout(t, completer.Started())
 
 		return completer, &testBundle{
 			exec:        exec,
@@ -839,8 +840,8 @@ func testCompleter[TCompleter JobCompleter](
 		completer, _ := setup(t)
 
 		var completerInterface JobCompleter = completer
-		if withWait, ok := completerInterface.(withWaitStarted); ok {
-			riverinternaltest.WaitOrTimeout(t, withWait.WaitStarted())
+		if withWait, ok := completerInterface.(startstop.Service); ok {
+			riverinternaltest.WaitOrTimeout(t, withWait.Started())
 		}
 	})
 }
@@ -902,8 +903,8 @@ func benchmarkCompleter(
 		require.NoError(b, completer.Start(ctx))
 		b.Cleanup(completer.Stop)
 
-		if withWait, ok := completer.(withWaitStarted); ok {
-			riverinternaltest.WaitOrTimeout(b, withWait.WaitStarted())
+		if withWait, ok := completer.(startstop.Service); ok {
+			riverinternaltest.WaitOrTimeout(b, withWait.Started())
 		}
 
 		insertParams := make([]*riverdriver.JobInsertFastParams, b.N)

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -94,7 +94,7 @@ func NewJobCleaner(archetype *baseservice.Archetype, config *JobCleanerConfig, e
 }
 
 func (s *JobCleaner) Start(ctx context.Context) error { //nolint:dupl
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
@@ -102,9 +102,8 @@ func (s *JobCleaner) Start(ctx context.Context) error { //nolint:dupl
 	s.StaggerStart(ctx)
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
 		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -100,7 +100,7 @@ func NewRescuer(archetype *baseservice.Archetype, config *JobRescuerConfig, exec
 }
 
 func (s *JobRescuer) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
@@ -108,9 +108,8 @@ func (s *JobRescuer) Start(ctx context.Context) error {
 	s.StaggerStart(ctx)
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
 		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -86,7 +86,7 @@ func NewJobScheduler(archetype *baseservice.Archetype, config *JobSchedulerConfi
 }
 
 func (s *JobScheduler) Start(ctx context.Context) error { //nolint:dupl
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
@@ -94,9 +94,8 @@ func (s *JobScheduler) Start(ctx context.Context) error { //nolint:dupl
 	s.StaggerStart(ctx)
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
 		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -202,7 +202,7 @@ type insertParamsAndUniqueOpts struct {
 }
 
 func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
@@ -210,9 +210,8 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 	s.StaggerStart(ctx)
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
 		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/internal/dbunique"
+	"github.com/riverqueue/river/internal/maintenance/startstop"
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/riverinternaltest/startstoptest"
@@ -94,6 +95,8 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		require.NoError(t, svc.Start(ctx))
 		t.Cleanup(svc.Stop)
+
+		riverinternaltest.WaitOrTimeout(t, startstop.WaitAllStartedC(svc))
 	}
 
 	t.Run("StartStopStress", func(t *testing.T) {

--- a/internal/maintenance/queue_cleaner.go
+++ b/internal/maintenance/queue_cleaner.go
@@ -76,7 +76,7 @@ func NewQueueCleaner(archetype *baseservice.Archetype, config *QueueCleanerConfi
 }
 
 func (s *QueueCleaner) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
@@ -84,9 +84,8 @@ func (s *QueueCleaner) Start(ctx context.Context) error {
 	s.StaggerStart(ctx)
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
 		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -36,13 +36,14 @@ func newTestService(tb testing.TB) *testService {
 }
 
 func (s *testService) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
 
 	go func() {
-		defer close(stopped)
+		started()
+		defer stopped()
 
 		s.testSignals.started.Signal(struct{}{})
 		<-ctx.Done()

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -90,7 +90,7 @@ func NewReindexer(archetype *baseservice.Archetype, config *ReindexerConfig, exe
 }
 
 func (s *Reindexer) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
@@ -98,9 +98,8 @@ func (s *Reindexer) Start(ctx context.Context) error {
 	s.StaggerStart(ctx)
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
 		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)

--- a/internal/riverinternaltest/startstoptest/startstoptest_test.go
+++ b/internal/riverinternaltest/startstoptest/startstoptest_test.go
@@ -20,18 +20,19 @@ type MyService struct {
 }
 
 func (s *MyService) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := s.StartInit(ctx)
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
 
 	if s.startErr != nil {
-		close(stopped)
+		stopped()
 		return s.startErr
 	}
 
 	go func() {
-		defer close(stopped)
+		started()
+		defer stopped()
 
 		s.logger.InfoContext(ctx, "Service started")
 		defer s.logger.InfoContext(ctx, "Service stopped")

--- a/subscription_manager.go
+++ b/subscription_manager.go
@@ -44,15 +44,14 @@ func (sm *subscriptionManager) ResetSubscribeChan(subscribeCh <-chan []jobcomple
 }
 
 func (sm *subscriptionManager) Start(ctx context.Context) error {
-	ctx, shouldStart, stopped := sm.StartInit(ctx)
+	ctx, shouldStart, started, stopped := sm.StartInit(ctx)
 	if !shouldStart {
 		return nil
 	}
 
 	go func() {
-		// This defer should come first so that it's last out, thereby avoiding
-		// races.
-		defer close(stopped)
+		started()
+		defer stopped() // this defer should come first so it's last out
 
 		sm.Logger.DebugContext(ctx, sm.Name+": Run loop started")
 		defer sm.Logger.DebugContext(ctx, sm.Name+": Run loop stopped")


### PR DESCRIPTION
This is one that I've had on the backburner for a while, but
deprioritized since it'll take review bandwidth and we had more
important things going on. I pulled it up to the top because we've seen
seeing a crazy rate of intermittent failures out of `AddManyAfterStart`
in the periodic job enqueuer [1] [2]. I'm not entirely sure yet because
I'm having trouble reproducing it locally, but reading the code I
believe the problem is that we start the client and then start adding
periodic jobs, but the start is a race condition because we're not
guaranteed that the service performed a loop before the periodic jobs
were added.

    startService(t, svc)

    svc.Add(
            &PeriodicJob{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
    )
    svc.Add(
            &PeriodicJob{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
    )

If that is the case, I believe this change can help with that.

Its main feature is that it adds a `Started` channel to the start/stop
infrastructure that's closed when a service finishes starting up:

    type Service interface {
        ...

        // Started returns a channel that's closed when a service finishes starting,
        // or if failed to start and is stopped instead. It can be used in
        // conjunction with WaitAllStarted to verify startup of a constellation of
        // services.
        Started() <-chan struct{}

We then provide an easy helper called `WaitAllStarted` that lets callers
easily wait for a series of startups to come up:

    // WaitAllStarted waits until all the given services are started (or stopped in
    // a degenerate start scenario, like if context is cancelled while starting up).
    //
    // Unlike StopAllParallel, WaitAllStarted doesn't bother with parallelism
    // because the services themselves have already backgrounded themselves, and we
    // have to wait until the slowest service has started anyway.
    func WaitAllStarted(services ...Service) {
        ...

This allows us to modify tests like the periodic job enqueuer above to
wait on a service start, thereby hopefully fixing our intermittency
problems:

    startService := func(t *testing.T, svc *PeriodicJobEnqueuer) {
        t.Helper()

        require.NoError(t, svc.Start(ctx))
        t.Cleanup(svc.Stop)

        startstop.WaitAllStarted(svc)
    }

We also modify start/stop's returns slightly so that a `started`
function is added to enable this new feature, but also changes `stopped`
from a channel to a function, which looks a bit nicer and has better
ergonomics compared to closing a channel:

    func (m *QueueMaintainer) Start(ctx context.Context) error {
        ctx, shouldStart, started, stopped := m.StartInit(ctx)
        if !shouldStart {
            return nil
        }

        go func() {
            started()
            defer stopped() // this defer should come first so it's last out

            ...

[1] https://github.com/riverqueue/river/actions/runs/9770889034/job/26972789182?pr=413
[2] https://github.com/riverqueue/river/actions/runs/9770889034/job/26972789334?pr=413