### PR TITLE
Fix two badly intermittent tests for periodic job enqueuer

### DIFF
--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -362,19 +362,15 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		startService(t, svc)
 
 		svc.Add(
-			&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
+			&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorFunc("periodic_job_5s", false)},
 		)
 		svc.Add(
-			&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
+			&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorFunc("periodic_job_5s_start", false), RunOnStart: true},
 		)
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
-		requireNJobs(t, bundle.exec, "periodic_job_500ms", 0)
-		requireNJobs(t, bundle.exec, "periodic_job_500ms_start", 1)
-
-		svc.TestSignals.InsertedJobs.WaitOrTimeout()
-		requireNJobs(t, bundle.exec, "periodic_job_500ms", 1)
-		requireNJobs(t, bundle.exec, "periodic_job_500ms_start", 2)
+		requireNJobs(t, bundle.exec, "periodic_job_5s", 0)
+		requireNJobs(t, bundle.exec, "periodic_job_5s_start", 1)
 	})
 
 	t.Run("AddManyAfterStart", func(t *testing.T) {
@@ -385,17 +381,13 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		startService(t, svc)
 
 		svc.AddMany([]*PeriodicJob{
-			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
-			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
+			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorFunc("periodic_job_5s", false)},
+			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorFunc("periodic_job_5s_start", false), RunOnStart: true},
 		})
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
-		requireNJobs(t, bundle.exec, "periodic_job_500ms", 0)
-		requireNJobs(t, bundle.exec, "periodic_job_500ms_start", 1)
-
-		svc.TestSignals.InsertedJobs.WaitOrTimeout()
-		requireNJobs(t, bundle.exec, "periodic_job_500ms", 1)
-		requireNJobs(t, bundle.exec, "periodic_job_500ms_start", 2)
+		requireNJobs(t, bundle.exec, "periodic_job_5s", 0)
+		requireNJobs(t, bundle.exec, "periodic_job_5s_start", 1)
 	})
 
 	t.Run("ClearAfterStart", func(t *testing.T) {


### PR DESCRIPTION
We're getting some _really_ bad intermittency from a pair of tests in
the periodic job enqueuer [1] [2] that need fixing ASAP since they're
failing at least one matrix entry in almost every build.

Looking at the tests, they add a pair of jobs after starting the client,
each of which operates on a 500 ms interval, and one with `RunOnStart`.
The test case waits for the initial `RunOnStart` job to appear, then
waits again for the next job that wasn't `RunOnStart`.

I think what's happening is that since 500ms is fairly long for a
computer, it's not _crazy_ long, so it's actually possible for the tests
in CI to be operating slowly enough that by the time the enqueuer gets
around to its first run, it actually has been 500ms already, and
therefore both jobs have been enqueued, even the non-`RunOnStart` one.

Another thing that I realize looking closer at these test cases is that
because of the way they're structured, they're slower than hell. Each
one requires a wait of 500 ms because it's waiting for the
non-`RunOnStart` job, so running them at high `-count` iterations is a
total non-starter.

Here, I'm suggesting that we simplify things by:

* Increase period by 10x from 500ms to 5s.
* Don't bother waiting for the non-`RunOnStart` job to be enqueued.

The fact that the `RunOnStart` job has been confirmed is a pretty good
chance that both jobs were indeed added properly, so I don't think we
have to wait for the other one too. This resolves the intermittency
problem, but also makes each test case probably on the order of 10,000
times faster.

Fixes #409.

[1] https://github.com/riverqueue/river/actions/runs/9770889034/job/26972789182?pr=413
[2] https://github.com/riverqueue/river/actions/runs/9770889034/job/26972789334?pr=413