### PR TITLE
fix: use the constructor function every time a periodic job is scheduled, instead of when its registered

### DIFF
--- a/periodic_job.go
+++ b/periodic_job.go
@@ -180,7 +180,6 @@ func (b *PeriodicJobBundle) toInternal(periodicJob *PeriodicJob) *maintenance.Pe
 	if periodicJob.opts != nil {
 		opts = periodicJob.opts
 	}
-
 	return &maintenance.PeriodicJob{
 		ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
 			args, options := periodicJob.constructorFunc()

--- a/periodic_job.go
+++ b/periodic_job.go
@@ -180,10 +180,10 @@ func (b *PeriodicJobBundle) toInternal(periodicJob *PeriodicJob) *maintenance.Pe
 	if periodicJob.opts != nil {
 		opts = periodicJob.opts
 	}
-	args, options := periodicJob.constructorFunc()
 
 	return &maintenance.PeriodicJob{
 		ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
+			args, options := periodicJob.constructorFunc()
 			return insertParamsFromConfigArgsAndOptions(&b.periodicJobEnqueuer.Archetype, b.clientConfig, args, options)
 		},
 		RunOnStart:   opts.RunOnStart,


### PR DESCRIPTION
right now, the constructor gets called when converting to an internal job, which causes the constructor to use the value at add time.

however, the comments say
```
// The constructor function is invoked each time a periodic job's schedule
// elapses, returning job arguments to insert along with optional insertion
// options.
```
so im assuming this is whats intended?