### PR TITLE
Use longer `WaitTimeout` for test manager pool acquisition context timeout

### DIFF
--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -164,7 +164,7 @@ func DrainContinuously[T any](drainChan <-chan T) func() []T {
 func TestDB(ctx context.Context, tb testing.TB) *pgxpool.Pool {
 	tb.Helper()
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, riversharedtest.WaitTimeout())
 	defer cancel()
 
 	testPool, err := dbManager.Acquire(ctx)


### PR DESCRIPTION
I'm not sure what changed exactly, but about 25% of my builds have been
failing for the last couple days on the context deadline set when
acquiring a test database.

Here, attempt to resolve the problem by changing the hard-coded 5 second
wait timeout to acquire a test database manager to the timeout specified
by `WaitTimeout`, which is a tight 3 seconds locally, but which allows
more time for GitHub Actions, which seems to regularly be quite slow.

    func WaitTimeout() time.Duration {
        if os.Getenv("GITHUB_ACTIONS") == "true" {
                return 10 * time.Second
        }

        return 3 * time.Second
    }
