### PR TITLE
Include `rivershared` in `update-submodule-versions` script

### DIFF
--- a/internal/cmd/update-submodule-versions/main.go
+++ b/internal/cmd/update-submodule-versions/main.go
@@ -24,6 +24,7 @@ var allProjectModules = []string{ //nolint:gochecknoglobals
 	"./riverdriver",
 	"./riverdriver/riverdatabasesql",
 	"./riverdriver/riverpgxv5",
+	"./rivershared",
 	"./rivertype",
 }
 


### PR DESCRIPTION
Small change to follow up #429 that makes sure that we also update
`rivershared`'s `go.mod` with changing internal package versions prior
to release.