### PR TITLE
Bump `WithinDuration` check up to two seconds

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -3927,7 +3927,7 @@ func Test_Client_JobCompletion(t *testing.T) {
 		require.NotNil(updatedJob.FinalizedAt)
 
 		// Make sure the FinalizedAt is approximately ~now:
-		require.WithinDuration(now, *updatedJob.FinalizedAt, time.Second)
+		require.WithinDuration(now, *updatedJob.FinalizedAt, 2*time.Second)
 
 		// Make sure we're getting the same timestamp back from the event and the
 		// updated job inside the txn:


### PR DESCRIPTION
This fixes an intermittent failure. It's a fairly rare one, but one that
does appear on the order of ~dozens of test runs in GitHub Actions. I'd
originally lumped this into #438, but since I'm likely to discard that
pull request, breaking this change out separately since it's still
useful.

Most of the other time comparisons in this file already use two seconds
for `WithinDuration` instead of one, so the change also serves to make
things a little more consistent.