### PR TITLE
Use `TestOnly` property in example tests

### DIFF
--- a/example_batch_insert_test.go
+++ b/example_batch_insert_test.go
@@ -52,7 +52,8 @@ func Example_batchInsert() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_complete_job_within_tx_test.go
+++ b/example_complete_job_within_tx_test.go
@@ -78,7 +78,8 @@ func Example_completeJobWithinTx() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_cron_job_test.go
+++ b/example_cron_job_test.go
@@ -68,7 +68,8 @@ func Example_cronJob() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_custom_insert_opts_test.go
+++ b/example_custom_insert_opts_test.go
@@ -77,7 +77,8 @@ func Example_customInsertOpts() {
 			river.QueueDefault: {MaxWorkers: 100},
 			"high_priority":    {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_error_handler_test.go
+++ b/example_error_handler_test.go
@@ -81,7 +81,8 @@ func Example_errorHandler() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -72,7 +72,8 @@ func Example_gracefulShutdown() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_insert_and_work_test.go
+++ b/example_insert_and_work_test.go
@@ -55,7 +55,8 @@ func Example_insertAndWork() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_job_cancel_from_client_test.go
+++ b/example_job_cancel_from_client_test.go
@@ -59,7 +59,8 @@ func Example_jobCancelFromClient() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_job_cancel_test.go
+++ b/example_job_cancel_test.go
@@ -56,7 +56,8 @@ func Example_jobCancel() { //nolint:dupl
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_job_snooze_test.go
+++ b/example_job_snooze_test.go
@@ -58,7 +58,8 @@ func Example_jobSnooze() { //nolint:dupl
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_periodic_job_test.go
+++ b/example_periodic_job_test.go
@@ -61,7 +61,8 @@ func Example_periodicJob() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_queue_pause_test.go
+++ b/example_queue_pause_test.go
@@ -63,7 +63,8 @@ func Example_queuePause() {
 			unreliableQueue: {MaxWorkers: 10},
 			reliableQueue:   {MaxWorkers: 10},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_scheduled_job_test.go
+++ b/example_scheduled_job_test.go
@@ -53,7 +53,8 @@ func Example_scheduledJob() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_subscription_test.go
+++ b/example_subscription_test.go
@@ -61,7 +61,8 @@ func Example_subscription() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_unique_job_test.go
+++ b/example_unique_job_test.go
@@ -83,7 +83,8 @@ func Example_uniqueJob() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)

--- a/example_work_func_test.go
+++ b/example_work_func_test.go
@@ -47,7 +47,8 @@ func Example_workFunc() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Workers: workers,
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I was looking into what was making the example tests so slow (some like
the periodic job enqueuer one often take 3 seconds to run), and it turns
out that the lion's share of it is from from service start up jitter.

Example tests aren't in the main `river` package (they're in
`river_test`) so they didn't previously have a way of interacting with
the client in such a way as to disable stagger. Luckily, we do have a
way now. Take advantage of the recently introduced `TestOnly` client
property from #414 to make all the examples faster.