### PR TITLE
Tighten up schema of the migrations table a little more

### DIFF
--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -1972,7 +1972,6 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 		// Check the full properties of one of the migrations.
 		migration1Fetched := migrations[0]
-		require.Equal(t, migration1.ID, migration1Fetched.ID)
 		requireEqualTime(t, migration1.CreatedAt, migration1Fetched.CreatedAt)
 		require.Equal(t, riverdriver.MigrationLineMain, migration1Fetched.Line)
 		require.Equal(t, migration1.Version, migration1Fetched.Version)
@@ -1999,7 +1998,6 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 		// Check the full properties of one of the migrations.
 		migration1Fetched := migrations[0]
-		require.Equal(t, migration1.ID, migration1Fetched.ID)
 		requireEqualTime(t, migration1.CreatedAt, migration1Fetched.CreatedAt)
 		require.Equal(t, "alternate", migration1Fetched.Line)
 		require.Equal(t, migration1.Version, migration1Fetched.Version)

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -385,11 +385,6 @@ type LeaderResignParams struct {
 //
 // API is not stable. DO NOT USE.
 type Migration struct {
-	// ID is an automatically generated primary key for the migration.
-	//
-	// API is not stable. DO NOT USE.
-	ID int
-
 	// CreatedAt is when the migration was initially created.
 	//
 	// API is not stable. DO NOT USE.

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
@@ -85,10 +85,9 @@ type RiverLeader struct {
 }
 
 type RiverMigration struct {
-	ID        int64
-	CreatedAt time.Time
 	Line      string
 	Version   int64
+	CreatedAt time.Time
 }
 
 type RiverQueue struct {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_migration.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_migration.sql.go
@@ -36,13 +36,11 @@ const riverMigrationDeleteAssumingMainMany = `-- name: RiverMigrationDeleteAssum
 DELETE FROM river_migration
 WHERE version = any($1::bigint[])
 RETURNING
-    id,
     created_at,
     version
 `
 
 type RiverMigrationDeleteAssumingMainManyRow struct {
-	ID        int64
 	CreatedAt time.Time
 	Version   int64
 }
@@ -56,7 +54,7 @@ func (q *Queries) RiverMigrationDeleteAssumingMainMany(ctx context.Context, db D
 	var items []*RiverMigrationDeleteAssumingMainManyRow
 	for rows.Next() {
 		var i RiverMigrationDeleteAssumingMainManyRow
-		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.Version); err != nil {
+		if err := rows.Scan(&i.CreatedAt, &i.Version); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -74,7 +72,7 @@ const riverMigrationDeleteByLineAndVersionMany = `-- name: RiverMigrationDeleteB
 DELETE FROM river_migration
 WHERE line = $1
     AND version = any($2::bigint[])
-RETURNING id, created_at, line, version
+RETURNING line, version, created_at
 `
 
 type RiverMigrationDeleteByLineAndVersionManyParams struct {
@@ -91,12 +89,7 @@ func (q *Queries) RiverMigrationDeleteByLineAndVersionMany(ctx context.Context, 
 	var items []*RiverMigration
 	for rows.Next() {
 		var i RiverMigration
-		if err := rows.Scan(
-			&i.ID,
-			&i.CreatedAt,
-			&i.Line,
-			&i.Version,
-		); err != nil {
+		if err := rows.Scan(&i.Line, &i.Version, &i.CreatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -112,7 +105,6 @@ func (q *Queries) RiverMigrationDeleteByLineAndVersionMany(ctx context.Context, 
 
 const riverMigrationGetAllAssumingMain = `-- name: RiverMigrationGetAllAssumingMain :many
 SELECT
-    id,
     created_at,
     version
 FROM river_migration
@@ -120,7 +112,6 @@ ORDER BY version
 `
 
 type RiverMigrationGetAllAssumingMainRow struct {
-	ID        int64
 	CreatedAt time.Time
 	Version   int64
 }
@@ -139,7 +130,7 @@ func (q *Queries) RiverMigrationGetAllAssumingMain(ctx context.Context, db DBTX)
 	var items []*RiverMigrationGetAllAssumingMainRow
 	for rows.Next() {
 		var i RiverMigrationGetAllAssumingMainRow
-		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.Version); err != nil {
+		if err := rows.Scan(&i.CreatedAt, &i.Version); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -154,7 +145,7 @@ func (q *Queries) RiverMigrationGetAllAssumingMain(ctx context.Context, db DBTX)
 }
 
 const riverMigrationGetByLine = `-- name: RiverMigrationGetByLine :many
-SELECT id, created_at, line, version
+SELECT line, version, created_at
 FROM river_migration
 WHERE line = $1
 ORDER BY version
@@ -169,12 +160,7 @@ func (q *Queries) RiverMigrationGetByLine(ctx context.Context, db DBTX, line str
 	var items []*RiverMigration
 	for rows.Next() {
 		var i RiverMigration
-		if err := rows.Scan(
-			&i.ID,
-			&i.CreatedAt,
-			&i.Line,
-			&i.Version,
-		); err != nil {
+		if err := rows.Scan(&i.Line, &i.Version, &i.CreatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -195,7 +181,7 @@ INSERT INTO river_migration (
 ) VALUES (
     $1,
     $2
-) RETURNING id, created_at, line, version
+) RETURNING line, version, created_at
 `
 
 type RiverMigrationInsertParams struct {
@@ -206,12 +192,7 @@ type RiverMigrationInsertParams struct {
 func (q *Queries) RiverMigrationInsert(ctx context.Context, db DBTX, arg *RiverMigrationInsertParams) (*RiverMigration, error) {
 	row := db.QueryRowContext(ctx, riverMigrationInsert, arg.Line, arg.Version)
 	var i RiverMigration
-	err := row.Scan(
-		&i.ID,
-		&i.CreatedAt,
-		&i.Line,
-		&i.Version,
-	)
+	err := row.Scan(&i.Line, &i.Version, &i.CreatedAt)
 	return &i, err
 }
 
@@ -223,7 +204,7 @@ INSERT INTO river_migration (
 SELECT
     $1,
     unnest($2::bigint[])
-RETURNING id, created_at, line, version
+RETURNING line, version, created_at
 `
 
 type RiverMigrationInsertManyParams struct {
@@ -240,12 +221,7 @@ func (q *Queries) RiverMigrationInsertMany(ctx context.Context, db DBTX, arg *Ri
 	var items []*RiverMigration
 	for rows.Next() {
 		var i RiverMigration
-		if err := rows.Scan(
-			&i.ID,
-			&i.CreatedAt,
-			&i.Line,
-			&i.Version,
-		); err != nil {
+		if err := rows.Scan(&i.Line, &i.Version, &i.CreatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -266,13 +242,11 @@ INSERT INTO river_migration (
 SELECT
     unnest($1::bigint[])
 RETURNING
-    id,
     created_at,
     version
 `
 
 type RiverMigrationInsertManyAssumingMainRow struct {
-	ID        int64
 	CreatedAt time.Time
 	Version   int64
 }
@@ -286,7 +260,7 @@ func (q *Queries) RiverMigrationInsertManyAssumingMain(ctx context.Context, db D
 	var items []*RiverMigrationInsertManyAssumingMainRow
 	for rows.Next() {
 		var i RiverMigrationInsertManyAssumingMainRow
-		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.Version); err != nil {
+		if err := rows.Scan(&i.CreatedAt, &i.Version); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/riverdriver/riverdatabasesql/migration/main/005_river_migration_add_line.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/005_river_migration_add_line.down.sql
@@ -1,6 +1,36 @@
-DROP INDEX river_migration_line_version_idx;
-CREATE UNIQUE INDEX river_migration_version_idx ON river_migration USING btree(version);
+--
+-- If any non-main migration are present, 005 is considered irreversible.
+--
+
+DO
+$body$
+BEGIN
+    IF EXISTS (
+        SELECT *
+        FROM river_migration
+        WHERE line <> 'main'
+    ) THEN
+        RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
+    END IF;
+END;
+$body$
+LANGUAGE 'plpgsql'; 
 
 ALTER TABLE river_migration
-    DROP CONSTRAINT line_length,
-    DROP COLUMN line;
+    RENAME TO river_migration_old;
+
+CREATE TABLE river_migration(
+  id bigserial PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  version bigint NOT NULL,
+  CONSTRAINT version CHECK (version >= 1)
+);
+
+CREATE UNIQUE INDEX ON river_migration USING btree(version);
+
+INSERT INTO river_migration
+    (created_at, version)
+SELECT created_at, version
+FROM river_migration_old;
+
+DROP TABLE river_migration_old;

--- a/riverdriver/riverdatabasesql/river_database_sql.go
+++ b/riverdriver/riverdatabasesql/river_database_sql.go
@@ -499,7 +499,6 @@ func (e *Executor) MigrationDeleteAssumingMainMany(ctx context.Context, versions
 	}
 	return sliceutil.Map(migrations, func(internal *dbsqlc.RiverMigrationDeleteAssumingMainManyRow) *riverdriver.Migration {
 		return &riverdriver.Migration{
-			ID:        int(internal.ID),
 			CreatedAt: internal.CreatedAt.UTC(),
 			Line:      riverdriver.MigrationLineMain,
 			Version:   int(internal.Version),
@@ -525,7 +524,6 @@ func (e *Executor) MigrationGetAllAssumingMain(ctx context.Context) ([]*riverdri
 	}
 	return sliceutil.Map(migrations, func(internal *dbsqlc.RiverMigrationGetAllAssumingMainRow) *riverdriver.Migration {
 		return &riverdriver.Migration{
-			ID:        int(internal.ID),
 			CreatedAt: internal.CreatedAt.UTC(),
 			Line:      riverdriver.MigrationLineMain,
 			Version:   int(internal.Version),
@@ -561,7 +559,6 @@ func (e *Executor) MigrationInsertManyAssumingMain(ctx context.Context, versions
 	}
 	return sliceutil.Map(migrations, func(internal *dbsqlc.RiverMigrationInsertManyAssumingMainRow) *riverdriver.Migration {
 		return &riverdriver.Migration{
-			ID:        int(internal.ID),
 			CreatedAt: internal.CreatedAt.UTC(),
 			Line:      riverdriver.MigrationLineMain,
 			Version:   int(internal.Version),
@@ -839,7 +836,6 @@ func mapSliceError[T any, R any](collection []T, mapFunc func(T) (R, error)) ([]
 
 func migrationFromInternal(internal *dbsqlc.RiverMigration) *riverdriver.Migration {
 	return &riverdriver.Migration{
-		ID:        int(internal.ID),
 		CreatedAt: internal.CreatedAt.UTC(),
 		Line:      internal.Line,
 		Version:   int(internal.Version),

--- a/riverdriver/riverpgxv5/internal/dbsqlc/models.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/models.go
@@ -85,10 +85,9 @@ type RiverLeader struct {
 }
 
 type RiverMigration struct {
-	ID        int64
-	CreatedAt time.Time
 	Line      string
 	Version   int64
+	CreatedAt time.Time
 }
 
 type RiverQueue struct {

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
@@ -1,17 +1,16 @@
 CREATE TABLE river_migration(
-    id bigserial PRIMARY KEY,
-    created_at timestamptz NOT NULL DEFAULT NOW(),
     line TEXT NOT NULL,
     version bigint NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
     CONSTRAINT line_length CHECK (char_length(line) > 0 AND char_length(line) < 128),
-    CONSTRAINT version CHECK (version >= 1)
+    CONSTRAINT version_gte_1 CHECK (version >= 1),
+    PRIMARY KEY (line, version)
 );
 
 -- name: RiverMigrationDeleteAssumingMainMany :many
 DELETE FROM river_migration
 WHERE version = any(@version::bigint[])
 RETURNING
-    id,
     created_at,
     version;
 
@@ -29,7 +28,6 @@ RETURNING *;
 --
 -- name: RiverMigrationGetAllAssumingMain :many
 SELECT
-    id,
     created_at,
     version
 FROM river_migration
@@ -67,7 +65,6 @@ INSERT INTO river_migration (
 SELECT
     unnest(@version::bigint[])
 RETURNING
-    id,
     created_at,
     version;
 

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql.go
@@ -34,13 +34,11 @@ const riverMigrationDeleteAssumingMainMany = `-- name: RiverMigrationDeleteAssum
 DELETE FROM river_migration
 WHERE version = any($1::bigint[])
 RETURNING
-    id,
     created_at,
     version
 `
 
 type RiverMigrationDeleteAssumingMainManyRow struct {
-	ID        int64
 	CreatedAt time.Time
 	Version   int64
 }
@@ -54,7 +52,7 @@ func (q *Queries) RiverMigrationDeleteAssumingMainMany(ctx context.Context, db D
 	var items []*RiverMigrationDeleteAssumingMainManyRow
 	for rows.Next() {
 		var i RiverMigrationDeleteAssumingMainManyRow
-		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.Version); err != nil {
+		if err := rows.Scan(&i.CreatedAt, &i.Version); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -69,7 +67,7 @@ const riverMigrationDeleteByLineAndVersionMany = `-- name: RiverMigrationDeleteB
 DELETE FROM river_migration
 WHERE line = $1
     AND version = any($2::bigint[])
-RETURNING id, created_at, line, version
+RETURNING line, version, created_at
 `
 
 type RiverMigrationDeleteByLineAndVersionManyParams struct {
@@ -86,12 +84,7 @@ func (q *Queries) RiverMigrationDeleteByLineAndVersionMany(ctx context.Context, 
 	var items []*RiverMigration
 	for rows.Next() {
 		var i RiverMigration
-		if err := rows.Scan(
-			&i.ID,
-			&i.CreatedAt,
-			&i.Line,
-			&i.Version,
-		); err != nil {
+		if err := rows.Scan(&i.Line, &i.Version, &i.CreatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -104,7 +97,6 @@ func (q *Queries) RiverMigrationDeleteByLineAndVersionMany(ctx context.Context, 
 
 const riverMigrationGetAllAssumingMain = `-- name: RiverMigrationGetAllAssumingMain :many
 SELECT
-    id,
     created_at,
     version
 FROM river_migration
@@ -112,7 +104,6 @@ ORDER BY version
 `
 
 type RiverMigrationGetAllAssumingMainRow struct {
-	ID        int64
 	CreatedAt time.Time
 	Version   int64
 }
@@ -131,7 +122,7 @@ func (q *Queries) RiverMigrationGetAllAssumingMain(ctx context.Context, db DBTX)
 	var items []*RiverMigrationGetAllAssumingMainRow
 	for rows.Next() {
 		var i RiverMigrationGetAllAssumingMainRow
-		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.Version); err != nil {
+		if err := rows.Scan(&i.CreatedAt, &i.Version); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -143,7 +134,7 @@ func (q *Queries) RiverMigrationGetAllAssumingMain(ctx context.Context, db DBTX)
 }
 
 const riverMigrationGetByLine = `-- name: RiverMigrationGetByLine :many
-SELECT id, created_at, line, version
+SELECT line, version, created_at
 FROM river_migration
 WHERE line = $1
 ORDER BY version
@@ -158,12 +149,7 @@ func (q *Queries) RiverMigrationGetByLine(ctx context.Context, db DBTX, line str
 	var items []*RiverMigration
 	for rows.Next() {
 		var i RiverMigration
-		if err := rows.Scan(
-			&i.ID,
-			&i.CreatedAt,
-			&i.Line,
-			&i.Version,
-		); err != nil {
+		if err := rows.Scan(&i.Line, &i.Version, &i.CreatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -181,7 +167,7 @@ INSERT INTO river_migration (
 ) VALUES (
     $1,
     $2
-) RETURNING id, created_at, line, version
+) RETURNING line, version, created_at
 `
 
 type RiverMigrationInsertParams struct {
@@ -192,12 +178,7 @@ type RiverMigrationInsertParams struct {
 func (q *Queries) RiverMigrationInsert(ctx context.Context, db DBTX, arg *RiverMigrationInsertParams) (*RiverMigration, error) {
 	row := db.QueryRow(ctx, riverMigrationInsert, arg.Line, arg.Version)
 	var i RiverMigration
-	err := row.Scan(
-		&i.ID,
-		&i.CreatedAt,
-		&i.Line,
-		&i.Version,
-	)
+	err := row.Scan(&i.Line, &i.Version, &i.CreatedAt)
 	return &i, err
 }
 
@@ -209,7 +190,7 @@ INSERT INTO river_migration (
 SELECT
     $1,
     unnest($2::bigint[])
-RETURNING id, created_at, line, version
+RETURNING line, version, created_at
 `
 
 type RiverMigrationInsertManyParams struct {
@@ -226,12 +207,7 @@ func (q *Queries) RiverMigrationInsertMany(ctx context.Context, db DBTX, arg *Ri
 	var items []*RiverMigration
 	for rows.Next() {
 		var i RiverMigration
-		if err := rows.Scan(
-			&i.ID,
-			&i.CreatedAt,
-			&i.Line,
-			&i.Version,
-		); err != nil {
+		if err := rows.Scan(&i.Line, &i.Version, &i.CreatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -249,13 +225,11 @@ INSERT INTO river_migration (
 SELECT
     unnest($1::bigint[])
 RETURNING
-    id,
     created_at,
     version
 `
 
 type RiverMigrationInsertManyAssumingMainRow struct {
-	ID        int64
 	CreatedAt time.Time
 	Version   int64
 }
@@ -269,7 +243,7 @@ func (q *Queries) RiverMigrationInsertManyAssumingMain(ctx context.Context, db D
 	var items []*RiverMigrationInsertManyAssumingMainRow
 	for rows.Next() {
 		var i RiverMigrationInsertManyAssumingMainRow
-		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.Version); err != nil {
+		if err := rows.Scan(&i.CreatedAt, &i.Version); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/riverdriver/riverpgxv5/migration/main/005_river_migration_add_line.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/005_river_migration_add_line.down.sql
@@ -1,6 +1,36 @@
-DROP INDEX river_migration_line_version_idx;
-CREATE UNIQUE INDEX river_migration_version_idx ON river_migration USING btree(version);
+--
+-- If any non-main migration are present, 005 is considered irreversible.
+--
+
+DO
+$body$
+BEGIN
+    IF EXISTS (
+        SELECT *
+        FROM river_migration
+        WHERE line <> 'main'
+    ) THEN
+        RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
+    END IF;
+END;
+$body$
+LANGUAGE 'plpgsql'; 
 
 ALTER TABLE river_migration
-    DROP CONSTRAINT line_length,
-    DROP COLUMN line;
+    RENAME TO river_migration_old;
+
+CREATE TABLE river_migration(
+  id bigserial PRIMARY KEY,
+  created_at timestamptz NOT NULL DEFAULT NOW(),
+  version bigint NOT NULL,
+  CONSTRAINT version CHECK (version >= 1)
+);
+
+CREATE UNIQUE INDEX ON river_migration USING btree(version);
+
+INSERT INTO river_migration
+    (created_at, version)
+SELECT created_at, version
+FROM river_migration_old;
+
+DROP TABLE river_migration_old;

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -475,7 +475,6 @@ func (e *Executor) MigrationDeleteAssumingMainMany(ctx context.Context, versions
 	}
 	return sliceutil.Map(migrations, func(internal *dbsqlc.RiverMigrationDeleteAssumingMainManyRow) *riverdriver.Migration {
 		return &riverdriver.Migration{
-			ID:        int(internal.ID),
 			CreatedAt: internal.CreatedAt.UTC(),
 			Line:      riverdriver.MigrationLineMain,
 			Version:   int(internal.Version),
@@ -501,7 +500,6 @@ func (e *Executor) MigrationGetAllAssumingMain(ctx context.Context) ([]*riverdri
 	}
 	return sliceutil.Map(migrations, func(internal *dbsqlc.RiverMigrationGetAllAssumingMainRow) *riverdriver.Migration {
 		return &riverdriver.Migration{
-			ID:        int(internal.ID),
 			CreatedAt: internal.CreatedAt.UTC(),
 			Line:      riverdriver.MigrationLineMain,
 			Version:   int(internal.Version),
@@ -537,7 +535,6 @@ func (e *Executor) MigrationInsertManyAssumingMain(ctx context.Context, versions
 	}
 	return sliceutil.Map(migrations, func(internal *dbsqlc.RiverMigrationInsertManyAssumingMainRow) *riverdriver.Migration {
 		return &riverdriver.Migration{
-			ID:        int(internal.ID),
 			CreatedAt: internal.CreatedAt.UTC(),
 			Line:      riverdriver.MigrationLineMain,
 			Version:   int(internal.Version),
@@ -817,7 +814,6 @@ func mapSliceError[T any, R any](collection []T, mapFunc func(T) (R, error)) ([]
 
 func migrationFromInternal(internal *dbsqlc.RiverMigration) *riverdriver.Migration {
 	return &riverdriver.Migration{
-		ID:        int(internal.ID),
 		CreatedAt: internal.CreatedAt.UTC(),
 		Line:      internal.Line,
 		Version:   int(internal.Version),


### PR DESCRIPTION
I'd totally forgotten I'd even created it this way, but going back
through migrations recently I realized that the table's primary key is a
`bigserial`.

This isn't totally bad, and even has some advantages in that rows are
easier to target from a psql session, but in this instance it feels a
little on the sloppy side because it's fairly easy to conflate the
serial with migration `version` -- both are expected to be small
integers that a human could easily mix up.

Since we haven't shipped a new version yet containing the addition of
`line` in #435, here I propose that we modify that a little further to
reshape `river_migration` into a slightly smaller table with a compound
key on `(line, version)`:

    CREATE TABLE river_migration(
        created_at timestamptz NOT NULL DEFAULT NOW(),
        line TEXT NOT NULL,
        version bigint NOT NULL,
        CONSTRAINT line_length CHECK (char_length(line) > 0 AND char_length(line) < 128),
        CONSTRAINT version_gte_1 CHECK (version >= 1),
        PRIMARY KEY (line, version)
    );

This has two tiny side benefits that (1) the table is smaller (drops a
column), and (2) we don't need an extra index on `(line, version)` since
it's already covered by the primary key. Very similar in spirit to what
it was before, but I think a little cleaner in design.