### PR TITLE
Clean up extraneous SQL annotations

### DIFF
--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -38,8 +38,8 @@ updated_job AS (
     SET
         -- If the job is actively running, we want to let its current client and
         -- producer handle the cancellation. Otherwise, immediately cancel it.
-        state = CASE WHEN state = 'running'::river_job_state THEN state ELSE 'cancelled'::river_job_state END,
-        finalized_at = CASE WHEN state = 'running'::river_job_state THEN finalized_at ELSE now() END,
+        state = CASE WHEN state = 'running' THEN state ELSE 'cancelled' END,
+        finalized_at = CASE WHEN state = 'running' THEN finalized_at ELSE now() END,
         -- Mark the job as cancelled by query so that the rescuer knows not to
         -- rescue it, even if it gets stuck in the running state:
         metadata = jsonb_set(metadata, '{cancel_attempted_at}'::text[], $3::jsonb, true)
@@ -112,7 +112,7 @@ deleted_job AS (
     USING job_to_delete
     WHERE river_job.id = job_to_delete.id
         -- Do not touch running jobs:
-        AND river_job.state != 'running'::river_job_state
+        AND river_job.state != 'running'
     RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags
 )
 SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
@@ -193,7 +193,7 @@ WITH locked_jobs AS (
     FROM
         river_job
     WHERE
-        state = 'available'::river_job_state
+        state = 'available'
         AND queue = $2::text
         AND scheduled_at <= now()
     ORDER BY
@@ -207,7 +207,7 @@ WITH locked_jobs AS (
 UPDATE
     river_job
 SET
-    state = 'running'::river_job_state,
+    state = 'running',
     attempt = river_job.attempt + 1,
     attempted_at = now(),
     attempted_by = array_append(river_job.attempted_by, $1::text)
@@ -451,7 +451,7 @@ func (q *Queries) JobGetByKindMany(ctx context.Context, db DBTX, kind []string) 
 const jobGetStuck = `-- name: JobGetStuck :many
 SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
 FROM river_job
-WHERE state = 'running'::river_job_state
+WHERE state = 'running'
     AND attempted_at < $1::timestamptz
 ORDER BY id
 LIMIT $2
@@ -516,16 +516,16 @@ INSERT INTO river_job(
     state,
     tags
 ) VALUES (
-    $1::jsonb,
+    $1,
     coalesce($2::timestamptz, now()),
     $3,
-    $4::text,
-    $5::smallint,
+    $4,
+    $5,
     coalesce($6::jsonb, '{}'),
-    $7::smallint,
-    $8::text,
+    $7,
+    $8,
     coalesce($9::timestamptz, now()),
-    $10::river_job_state,
+    $10,
     coalesce($11::varchar(255)[], '{}')
 ) RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
 `
@@ -659,15 +659,15 @@ INSERT INTO river_job(
     coalesce($2::smallint, 0),
     $3,
     coalesce($4::timestamptz, now()),
-    $5::jsonb[],
+    $5,
     $6,
-    $7::text,
+    $7,
     $8::smallint,
     coalesce($9::jsonb, '{}'),
-    $10::smallint,
-    $11::text,
+    $10,
+    $11,
     coalesce($12::timestamptz, now()),
-    $13::river_job_state,
+    $13,
     coalesce($14::varchar(255)[], '{}')
 ) RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
 `
@@ -776,16 +776,16 @@ WITH job_to_update AS (
 updated_job AS (
     UPDATE river_job
     SET
-        state = 'available'::river_job_state,
+        state = 'available',
         scheduled_at = now(),
         max_attempts = CASE WHEN attempt = max_attempts THEN max_attempts + 1 ELSE max_attempts END,
         finalized_at = NULL
     FROM job_to_update
     WHERE river_job.id = job_to_update.id
         -- Do not touch running jobs:
-        AND river_job.state != 'running'::river_job_state
+        AND river_job.state != 'running'
         -- If the job is already available with a prior scheduled_at, leave it alone.
-        AND NOT (river_job.state = 'available'::river_job_state AND river_job.scheduled_at < now())
+        AND NOT (river_job.state = 'available' AND river_job.scheduled_at < now())
     RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags
 )
 SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags
@@ -839,7 +839,7 @@ WITH jobs_to_schedule AS (
 ),
 river_job_scheduled AS (
     UPDATE river_job
-    SET state = 'available'::river_job_state
+    SET state = 'available'
     FROM jobs_to_schedule
     WHERE river_job.id = jobs_to_schedule.id
     RETURNING river_job.id
@@ -904,7 +904,7 @@ job_to_update AS (
     SELECT river_job.id, job_to_finalized_at.finalized_at
     FROM river_job, job_to_finalized_at
     WHERE river_job.id = job_to_finalized_at.id
-        AND river_job.state = 'running'::river_job_state
+        AND river_job.state = 'running'
     FOR UPDATE
 ),
 updated_job AS (
@@ -973,7 +973,7 @@ const jobSetStateIfRunning = `-- name: JobSetStateIfRunning :one
 WITH job_to_update AS (
     SELECT
         id,
-        $1::river_job_state IN ('retryable'::river_job_state, 'scheduled'::river_job_state) AND metadata ? 'cancel_attempted_at' AS should_cancel
+        $1::river_job_state IN ('retryable', 'scheduled') AND metadata ? 'cancel_attempted_at' AS should_cancel
     FROM river_job
     WHERE id = $2::bigint
     FOR UPDATE
@@ -994,7 +994,7 @@ updated_job AS (
                             ELSE scheduled_at END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id
-        AND river_job.state = 'running'::river_job_state
+        AND river_job.state = 'running'
     RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags
 )
 SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
@@ -12,7 +12,7 @@ import (
 
 const leaderAttemptElect = `-- name: LeaderAttemptElect :execrows
 INSERT INTO river_leader(leader_id, elected_at, expires_at)
-    VALUES ($1::text, now(), now() + $2::interval)
+    VALUES ($1, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO NOTHING
 `
@@ -32,12 +32,12 @@ func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAt
 
 const leaderAttemptReelect = `-- name: LeaderAttemptReelect :execrows
 INSERT INTO river_leader(leader_id, elected_at, expires_at)
-    VALUES ($1::text, now(), now() + $2::interval)
+    VALUES ($1, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO UPDATE SET
-        expires_at = now() + $2::interval
+        expires_at = now() + $2
     WHERE
-        river_leader.leader_id = $1::text
+        river_leader.leader_id = $1
 `
 
 type LeaderAttemptReelectParams struct {

--- a/riverdriver/riverdatabasesql/migration/main/002_initial_schema.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/002_initial_schema.up.sql
@@ -18,7 +18,7 @@ CREATE TABLE river_job(
   -- looking at jobs with `SELECT *` it'll appear first after ID. The other two
   -- fields aren't as important but are kept adjacent to `state` for alignment
   -- to get an 8-byte block.
-  state river_job_state NOT NULL DEFAULT 'available' ::river_job_state,
+  state river_job_state NOT NULL DEFAULT 'available',
   attempt smallint NOT NULL DEFAULT 0,
   max_attempts smallint NOT NULL,
 
@@ -36,8 +36,8 @@ CREATE TABLE river_job(
   attempted_by text[],
   errors jsonb[],
   kind text NOT NULL,
-  metadata jsonb NOT NULL DEFAULT '{}' ::jsonb,
-  queue text NOT NULL DEFAULT 'default' ::text,
+  metadata jsonb NOT NULL DEFAULT '{}',
+  queue text NOT NULL DEFAULT 'default',
   tags varchar(255)[],
 
   CONSTRAINT finalized_or_finalized_at_null CHECK ((state IN ('cancelled', 'completed', 'discarded') AND finalized_at IS NOT NULL) OR finalized_at IS NULL),

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql
@@ -9,18 +9,18 @@ CREATE UNLOGGED TABLE river_leader(
 
 -- name: LeaderAttemptElect :execrows
 INSERT INTO river_leader(leader_id, elected_at, expires_at)
-    VALUES (@leader_id::text, now(), now() + @ttl::interval)
+    VALUES (@leader_id, now(), now() + @ttl::interval)
 ON CONFLICT (name)
     DO NOTHING;
 
 -- name: LeaderAttemptReelect :execrows
 INSERT INTO river_leader(leader_id, elected_at, expires_at)
-    VALUES (@leader_id::text, now(), now() + @ttl::interval)
+    VALUES (@leader_id, now(), now() + @ttl::interval)
 ON CONFLICT (name)
     DO UPDATE SET
-        expires_at = now() + @ttl::interval
+        expires_at = now() + @ttl
     WHERE
-        river_leader.leader_id = @leader_id::text;
+        river_leader.leader_id = @leader_id;
 
 -- name: LeaderDeleteExpired :execrows
 DELETE FROM river_leader

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
@@ -12,7 +12,7 @@ import (
 
 const leaderAttemptElect = `-- name: LeaderAttemptElect :execrows
 INSERT INTO river_leader(leader_id, elected_at, expires_at)
-    VALUES ($1::text, now(), now() + $2::interval)
+    VALUES ($1, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO NOTHING
 `
@@ -32,12 +32,12 @@ func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAt
 
 const leaderAttemptReelect = `-- name: LeaderAttemptReelect :execrows
 INSERT INTO river_leader(leader_id, elected_at, expires_at)
-    VALUES ($1::text, now(), now() + $2::interval)
+    VALUES ($1, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO UPDATE SET
-        expires_at = now() + $2::interval
+        expires_at = now() + $2
     WHERE
-        river_leader.leader_id = $1::text
+        river_leader.leader_id = $1
 `
 
 type LeaderAttemptReelectParams struct {

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
@@ -26,6 +26,7 @@ RETURNING *;
 -- only select non-line properties so the query doesn't error on older schemas.
 -- (Even if we use `SELECT *` below, sqlc materializes it to a list of column
 -- names in the generated query.)
+--
 -- name: RiverMigrationGetAllAssumingMain :many
 SELECT
     id,

--- a/riverdriver/riverpgxv5/migration/main/002_initial_schema.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/002_initial_schema.up.sql
@@ -18,7 +18,7 @@ CREATE TABLE river_job(
   -- looking at jobs with `SELECT *` it'll appear first after ID. The other two
   -- fields aren't as important but are kept adjacent to `state` for alignment
   -- to get an 8-byte block.
-  state river_job_state NOT NULL DEFAULT 'available' ::river_job_state,
+  state river_job_state NOT NULL DEFAULT 'available',
   attempt smallint NOT NULL DEFAULT 0,
   max_attempts smallint NOT NULL,
 
@@ -36,8 +36,8 @@ CREATE TABLE river_job(
   attempted_by text[],
   errors jsonb[],
   kind text NOT NULL,
-  metadata jsonb NOT NULL DEFAULT '{}' ::jsonb,
-  queue text NOT NULL DEFAULT 'default' ::text,
+  metadata jsonb NOT NULL DEFAULT '{}',
+  queue text NOT NULL DEFAULT 'default',
   tags varchar(255)[],
 
   CONSTRAINT finalized_or_finalized_at_null CHECK ((state IN ('cancelled', 'completed', 'discarded') AND finalized_at IS NOT NULL) OR finalized_at IS NULL),


### PR DESCRIPTION
A small change that goes through and cleans up SQL a bit by removing
some unnecessary annotations, mostly typecasting that's already implied
by the type of the column where the values are going.