### PR TITLE
Add River Python link from README + `doc.go`

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -151,6 +151,13 @@ See the [`InsertAndWork` example] for complete code.
 
   - [Work functions] for simplified worker implementation.
 
+## Cross language enqueueing
+
+River supports inserting jobs in some non-Go languages which are then worked by Go implementations. This may be desirable in performance sensitive cases so that jobs can take advantage of Go's fast runtime.
+
+  - [Inserting jobs from Python].
+  - [Inserting jobs from Ruby].
+
 # Development
 
 See [developing River].
@@ -163,6 +170,8 @@ See [developing River].
 [Batch job insertion]: https://riverqueue.com/docs/batch-job-insertion
 [Cancelling jobs]: https://riverqueue.com/docs/cancelling-jobs
 [Error and panic handling]: https://riverqueue.com/docs/error-handling
+[Inserting jobs from Python]: https://riverqueue.com/docs/python
+[Inserting jobs from Ruby]: https://riverqueue.com/docs/ruby
 [Multiple queues]: https://riverqueue.com/docs/multiple-queues
 [Periodic and cron jobs]: https://riverqueue.com/docs/periodic-jobs
 [River UI]: https://github.com/riverqueue/riverui

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,8 +165,9 @@ See the [`InsertAndWork` example] for complete code.
 
 ## Cross language enqueueing
 
-River supports inserting jobs in some non-Go languages which are then be worked by Go implementations. This may be desirable in performance sensitive cases so that jobs can take advantage of Go's fast runtime.
+River supports inserting jobs in some non-Go languages which are then worked by Go implementations. This may be desirable in performance sensitive cases so that jobs can take advantage of Go's fast runtime.
 
+  - [Inserting jobs from Python](https://riverqueue.com/docs/python).
   - [Inserting jobs from Ruby](https://riverqueue.com/docs/ruby).
 
 ## Development


### PR DESCRIPTION
The README links out to River Ruby already. Here, add a link to Stripe
Python as well. Also, add this section to `doc.go` (where it'd
previously been forgotten) to keep these two docs in sync.