### PR TITLE
Makefile `make db/reset` target + rename everything to use `river_test` convention

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ env:
   DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/river_dev?sslmode=disable
 
   # Test database.
-  TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/river_testdb?sslmode=disable
+  TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/river_test?sslmode=disable
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,21 @@ generate:
 generate: generate/migrations
 generate: generate/sqlc
 
+.PHONY: db/reset
+db/reset: ## drop, create, and migrate dev and test databases
+db/reset: db/reset/dev
+db/reset: db/reset/test
+
+.PHONY: db/reset/dev
+db/reset/dev: ## drop, create, and migrate dev database
+	dropdb river_dev --force --if-exists
+	createdb river_dev
+	cd cmd/river && go run . migrate-up --database-url "postgres://localhost/river_dev"
+
+.PHONY: db/reset/test
+db/reset/test: ## drop, create, and migrate test databases
+	go run ./internal/cmd/testdbman reset
+
 .PHONY: generate/migrations
 generate/migrations: ## sync changes of pgxv5 migrations to database/sql
 	rsync -au --delete "riverdriver/riverpgxv5/migration/" "riverdriver/riverdatabasesql/migration/"

--- a/example_batch_insert_test.go
+++ b/example_batch_insert_test.go
@@ -33,7 +33,7 @@ func (w *BatchInsertWorker) Work(ctx context.Context, job *river.Job[BatchInsert
 func Example_batchInsert() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_complete_job_within_tx_test.go
+++ b/example_complete_job_within_tx_test.go
@@ -58,7 +58,7 @@ func (w *TransactionalWorker) Work(ctx context.Context, job *river.Job[Transacti
 func Example_completeJobWithinTx() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_cron_job_test.go
+++ b/example_cron_job_test.go
@@ -35,7 +35,7 @@ func (w *CronJobWorker) Work(ctx context.Context, job *river.Job[CronJobArgs]) e
 func Example_cronJob() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_custom_insert_opts_test.go
+++ b/example_custom_insert_opts_test.go
@@ -56,7 +56,7 @@ func (w *SometimesHighPriorityWorker) Work(ctx context.Context, job *river.Job[S
 func Example_customInsertOpts() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_error_handler_test.go
+++ b/example_error_handler_test.go
@@ -61,7 +61,7 @@ func (w *ErroringWorker) Work(ctx context.Context, job *river.Job[ErroringArgs])
 func Example_errorHandler() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -51,7 +51,7 @@ func (w *WaitsForCancelOnlyWorker) Work(ctx context.Context, job *river.Job[Wait
 func Example_gracefulShutdown() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_insert_and_work_test.go
+++ b/example_insert_and_work_test.go
@@ -36,7 +36,7 @@ func (w *SortWorker) Work(ctx context.Context, job *river.Job[SortArgs]) error {
 func Example_insertAndWork() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_job_cancel_from_client_test.go
+++ b/example_job_cancel_from_client_test.go
@@ -38,7 +38,7 @@ func (w *SleepingWorker) Work(ctx context.Context, job *river.Job[CancellingArgs
 func Example_jobCancelFromClient() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_job_cancel_test.go
+++ b/example_job_cancel_test.go
@@ -37,7 +37,7 @@ func (w *CancellingWorker) Work(ctx context.Context, job *river.Job[CancellingAr
 func Example_jobCancel() { //nolint:dupl
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_job_snooze_test.go
+++ b/example_job_snooze_test.go
@@ -39,7 +39,7 @@ func (w *SnoozingWorker) Work(ctx context.Context, job *river.Job[SnoozingArgs])
 func Example_jobSnooze() { //nolint:dupl
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_periodic_job_test.go
+++ b/example_periodic_job_test.go
@@ -33,7 +33,7 @@ func (w *PeriodicJobWorker) Work(ctx context.Context, job *river.Job[PeriodicJob
 func Example_periodicJob() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_queue_pause_test.go
+++ b/example_queue_pause_test.go
@@ -37,7 +37,7 @@ func (w *ReportingWorker) Work(ctx context.Context, job *river.Job[ReportingArgs
 func Example_queuePause() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_scheduled_job_test.go
+++ b/example_scheduled_job_test.go
@@ -34,7 +34,7 @@ func (w *ScheduledWorker) Work(ctx context.Context, job *river.Job[ScheduledArgs
 func Example_scheduledJob() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_subscription_test.go
+++ b/example_subscription_test.go
@@ -42,7 +42,7 @@ func (w *SubscriptionWorker) Work(ctx context.Context, job *river.Job[Subscripti
 func Example_subscription() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_unique_job_test.go
+++ b/example_unique_job_test.go
@@ -64,7 +64,7 @@ func (w *ReconcileAccountWorker) Work(ctx context.Context, job *river.Job[Reconc
 func Example_uniqueJob() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/example_work_func_test.go
+++ b/example_work_func_test.go
@@ -25,7 +25,7 @@ func (WorkFuncArgs) Kind() string { return "work_func" }
 func Example_workFunc() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/cmd/producersample/main.go
+++ b/internal/cmd/producersample/main.go
@@ -193,7 +193,7 @@ func getDatabaseURL() string {
 	if envURL := os.Getenv("DATABASE_URL"); envURL != "" {
 		return envURL
 	}
-	return "postgres:///river_testdb_example?sslmode=disable"
+	return "postgres:///river_test_example?sslmode=disable"
 }
 
 type MyJobArgs struct {

--- a/internal/cmd/testdbman/main.go
+++ b/internal/cmd/testdbman/main.go
@@ -45,8 +45,8 @@ test run.
 Creates the test databases used by parallel tests and the sample applications.
 Each is migrated with River's current schema.
 
-The sample application DB is named river_testdb, while the DBs for parallel
-tests are named river_testdb_0, river_testdb_1, etc. up to the larger of 4 or
+The sample application DB is named river_test, while the DBs for parallel
+tests are named river_test_0, river_test_1, etc. up to the larger of 4 or
 runtime.NumCPU() (a choice that comes from pgx's default connection pool size).
 `,
 			createTestDatabases,
@@ -60,8 +60,8 @@ runtime.NumCPU() (a choice that comes from pgx's default connection pool size).
 			"Drop test databases",
 			`
 Drops all test databases. Any test database matching the base name
-(river_testdb) or the base name with an underscore followed by any other token
-(river_testdb_example, river_testdb_0, river_testdb_1, etc.) will be dropped.
+(river_test) or the base name with an underscore followed by any other token
+(river_test_example, river_test_0, river_test_1, etc.) will be dropped.
 `,
 			dropTestDatabases,
 		)
@@ -152,12 +152,12 @@ func createTestDatabases(ctx context.Context, out io.Writer) error {
 
 func generateTestDBNames(numDBs int) []string {
 	dbNames := []string{
-		"river_testdb",
-		"river_testdb_example",
+		"river_test",
+		"river_test_example",
 	}
 
 	for i := 0; i < numDBs; i++ {
-		dbNames = append(dbNames, fmt.Sprintf("river_testdb_%d", i))
+		dbNames = append(dbNames, fmt.Sprintf("river_test_%d", i))
 	}
 
 	return dbNames
@@ -188,7 +188,7 @@ func dropTestDatabases(ctx context.Context, out io.Writer) error {
 	rows.Close()
 
 	for _, dbName := range allDBNames {
-		if strings.HasPrefix(dbName, "river_testdb") {
+		if strings.HasPrefix(dbName, "river_test") {
 			if _, err := mgmtConn.Exec(ctx, "DROP DATABASE "+dbName); err != nil {
 				return fmt.Errorf("error dropping database %q: %w", dbName, err)
 			}

--- a/internal/cmd/testdbman/main_test.go
+++ b/internal/cmd/testdbman/main_test.go
@@ -16,12 +16,12 @@ func TestGenerateTestDBNames(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, []string{
-		"river_testdb",
-		"river_testdb_example",
-		"river_testdb_0",
-		"river_testdb_1",
-		"river_testdb_2",
-		"river_testdb_3",
+		"river_test",
+		"river_test_example",
+		"river_test_0",
+		"river_test_1",
+		"river_test_2",
+		"river_test_3",
 	}, generateTestDBNames(4))
 }
 

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -60,7 +60,7 @@ func DatabaseConfig(databaseName string) *pgxpool.Config {
 }
 
 // DatabaseURL gets a test database URL from TEST_DATABASE_URL or falls back on
-// a default pointing to `river_testdb`. If databaseName is set, it replaces the
+// a default pointing to `river_test`. If databaseName is set, it replaces the
 // database in the URL, although the host and other parameters are preserved.
 //
 // Most of the time DatabaseConfig should be used instead of this function, but
@@ -69,7 +69,7 @@ func DatabaseConfig(databaseName string) *pgxpool.Config {
 func DatabaseURL(databaseName string) string {
 	parsedURL, err := url.Parse(valutil.ValOrDefault(
 		os.Getenv("TEST_DATABASE_URL"),
-		"postgres://localhost/river_testdb?sslmode=disable"),
+		"postgres://localhost/river_test?sslmode=disable"),
 	)
 	if err != nil {
 		panic(err)
@@ -215,7 +215,7 @@ func TestTx(ctx context.Context, tb testing.TB) pgx.Tx {
 		}
 
 		var err error
-		dbPool, err = pgxpool.NewWithConfig(ctx, DatabaseConfig("river_testdb"))
+		dbPool, err = pgxpool.NewWithConfig(ctx, DatabaseConfig("river_test"))
 		require.NoError(tb, err)
 
 		return dbPool
@@ -283,7 +283,7 @@ func TruncateRiverTables(ctx context.Context, pool *pgxpool.Pool) error {
 // and checks for no goroutine leaks on teardown.
 func WrapTestMain(m *testing.M) {
 	var err error
-	dbManager, err = testdb.NewManager(DatabaseConfig("river_testdb"), dbPoolMaxConns, nil, TruncateRiverTables)
+	dbManager, err = testdb.NewManager(DatabaseConfig("river_test"), dbPoolMaxConns, nil, TruncateRiverTables)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/testdb/manager_test.go
+++ b/internal/testdb/manager_test.go
@@ -16,7 +16,7 @@ func getTestDatabaseURL() string {
 	if envURL := os.Getenv("TEST_DATABASE_URL"); envURL != "" {
 		return envURL
 	}
-	return "postgres:///river_testdb?sslmode=disable"
+	return "postgres:///river_test?sslmode=disable"
 }
 
 func testConfig(t *testing.T) *pgxpool.Config {
@@ -47,7 +47,7 @@ func TestManager_AcquireMultiple(t *testing.T) {
 	}
 	defer pool0.Release()
 
-	checkDBNameForPool(ctx, t, pool0, "river_testdb_")
+	checkDBNameForPool(ctx, t, pool0, "river_test_")
 
 	pool1, err := manager.Acquire(ctx)
 	if err != nil {
@@ -55,7 +55,7 @@ func TestManager_AcquireMultiple(t *testing.T) {
 	}
 	defer pool1.Release()
 
-	checkDBNameForPool(ctx, t, pool1, "river_testdb_")
+	checkDBNameForPool(ctx, t, pool1, "river_test_")
 	pool0.Release()
 
 	//  ensure we get db 0 back on subsequent acquire since it was released to the pool:
@@ -65,7 +65,7 @@ func TestManager_AcquireMultiple(t *testing.T) {
 	}
 	defer pool0Again.Release()
 
-	checkDBNameForPool(ctx, t, pool0Again, "river_testdb_")
+	checkDBNameForPool(ctx, t, pool0Again, "river_test_")
 	pool0Again.Release()
 	pool1.Release()
 

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver_test.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver_test.go
@@ -118,7 +118,7 @@ func (c *connStub) Close() error {
 }
 
 func testPoolConfig() *pgxpool.Config {
-	databaseURL := "postgres://localhost/river_testdb?sslmode=disable"
+	databaseURL := "postgres://localhost/river_test?sslmode=disable"
 	if url := os.Getenv("TEST_DATABASE_URL"); url != "" {
 		databaseURL = url
 	}

--- a/rivermigrate/example_migrate_database_sql_test.go
+++ b/rivermigrate/example_migrate_database_sql_test.go
@@ -18,7 +18,7 @@ import (
 func Example_migrateDatabaseSQL() {
 	ctx := context.Background()
 
-	dbPool, err := sql.Open("pgx", riverinternaltest.DatabaseURL("river_testdb_example"))
+	dbPool, err := sql.Open("pgx", riverinternaltest.DatabaseURL("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/rivermigrate/example_migrate_test.go
+++ b/rivermigrate/example_migrate_test.go
@@ -17,7 +17,7 @@ import (
 func Example_migrate() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/rivertest/example_require_inserted_test.go
+++ b/rivertest/example_require_inserted_test.go
@@ -32,7 +32,7 @@ func (w *RequiredWorker) Work(ctx context.Context, job *river.Job[RequiredArgs])
 func Example_requireInserted() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}

--- a/rivertest/example_require_many_inserted_test.go
+++ b/rivertest/example_require_many_inserted_test.go
@@ -49,7 +49,7 @@ func (w *SecondRequiredWorker) Work(ctx context.Context, job *river.Job[SecondRe
 func Example_requireManyInserted() {
 	ctx := context.Background()
 
-	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_testdb_example"))
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
A couple small ones:

* I often find myself wanting to reset my dev database from scratch, and
  it's quite inconvenient to do because you want to use the current code
  (rather than installed River CLI), and doing so requires cding into
  the `./cmd/river` directory because `go run` won't let you run a
  directory that's not in the current project. Here, add a `make
  db/reset` that'll easily reset the dev database, test databases, or
  both, all at once.

* While we're at it, change over to the naming convention of
  `river_test` established in the River Ruby and River Python projects.