### PR TITLE
Show names in migration output + trim duration precision

### DIFF
--- a/cmd/river/rivercli/river_cli_test.go
+++ b/cmd/river/rivercli/river_cli_test.go
@@ -2,6 +2,7 @@ package rivercli
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -13,4 +14,23 @@ func TestMigrationComment(t *testing.T) {
 
 	require.Equal(t, "-- River migration 001 [down]", migrationComment(1, rivermigrate.DirectionDown))
 	require.Equal(t, "-- River migration 002 [up]", migrationComment(2, rivermigrate.DirectionUp))
+}
+
+func TestRoundDuration(t *testing.T) {
+	t.Parallel()
+
+	mustParseDuration := func(s string) time.Duration {
+		d, err := time.ParseDuration(s)
+		require.NoError(t, err)
+		return d
+	}
+
+	require.Equal(t, "1.33µs", roundDuration(mustParseDuration("1.332µs")).String())
+	require.Equal(t, "765.62µs", roundDuration(mustParseDuration("765.625µs")).String())
+	require.Equal(t, "4.42ms", roundDuration(mustParseDuration("4.422125ms")).String())
+	require.Equal(t, "13.28ms", roundDuration(mustParseDuration("13.280834ms")).String())
+	require.Equal(t, "234.91ms", roundDuration(mustParseDuration("234.91075ms")).String())
+	require.Equal(t, "3.93s", roundDuration(mustParseDuration("3.937042s")).String())
+	require.Equal(t, "34.04s", roundDuration(mustParseDuration("34.042234s")).String())
+	require.Equal(t, "2m34.04s", roundDuration(mustParseDuration("2m34.042234s")).String())
 }

--- a/rivermigrate/river_migrate_test.go
+++ b/rivermigrate/river_migrate_test.go
@@ -154,6 +154,9 @@ func TestMigrator(t *testing.T) {
 			require.Equal(t, DirectionDown, res.Direction)
 			require.Equal(t, []int{migrateVersionIncludingRiverJob}, sliceutil.Map(res.Versions, migrateVersionToInt))
 
+			version := res.Versions[0]
+			require.Equal(t, "initial schema", version.Name)
+
 			err = dbExecError(ctx, bundle.driver.UnwrapExecutor(bundle.tx), "SELECT * FROM river_job")
 			require.Error(t, err)
 		}
@@ -616,6 +619,11 @@ func TestMigrationsFromFS(t *testing.T) {
 		migrations, err := migrationsFromFS(migrationFS, "main")
 		require.NoError(t, err)
 		require.Equal(t, []int{1, 2}, sliceutil.Map(migrations, migrationToInt))
+
+		migration := migrations[0]
+		require.Equal(t, "first", migration.Name)
+		require.Equal(t, "SELECT 1;\n", migration.SQLDown)
+		require.Equal(t, "SELECT 1;\n", migration.SQLUp)
 	})
 
 	t.Run("Alternate", func(t *testing.T) {
@@ -624,6 +632,11 @@ func TestMigrationsFromFS(t *testing.T) {
 		migrations, err := migrationsFromFS(migrationFS, migrationLineAlternate)
 		require.NoError(t, err)
 		require.Equal(t, seqOneTo(migrationLineAlternateMaxVersion), sliceutil.Map(migrations, migrationToInt))
+
+		migration := migrations[0]
+		require.Equal(t, "premier", migration.Name)
+		require.Equal(t, "SELECT 1;\n", migration.SQLDown)
+		require.Equal(t, "SELECT 1;\n", migration.SQLUp)
 	})
 
 	t.Run("DoesNotExist", func(t *testing.T) {


### PR DESCRIPTION
Currently, running a migration via the CLI produces output like this:

    applied migration 001 [up] [7.855584ms]
    applied migration 002 [up] [28.0565ms]
    applied migration 003 [up] [9.860208ms]
    applied migration 004 [up] [10.549625ms]
    applied migration 005 [up] [10.458333ms]

It's not the worst, but notice a few things:

* Only a migration's version number is included, not the human-friendly
  name from its filename.

* We use Go's default `time.Duration` output, so all the durations look
  ugly and have way more significant digits than is necessary.

Here, we make a few tweaks to fix those problems. New output looks like:

    applied migration 001 [up] create river migration   [4.74ms]
    applied migration 002 [up] initial schema           [18.61ms]
    applied migration 003 [up] river job tags non null  [522.12µs]
    applied migration 004 [up] pending and more         [3.45ms]
    applied migration 005 [up] river migration add line [1.43ms]