### PR TITLE
Add `pending` job state to default unique job states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ river migrate-up --database-url "$DATABASE_URL"
 
 - Tags are now limited to 255 characters in length, and should match the regex `\A[\w][\w\-]+[\w]\z` (importantly, they can't contain commas). [PR #351](https://github.com/riverqueue/river/pull/351).
 - Many info logging statements have been demoted to debug level. [PR #452](https://github.com/riverqueue/river/pull/452).
+- `pending` is now part of the default set of unique job states. [PR #461](https://github.com/riverqueue/river/pull/461).
 
 ## [0.9.0] - 2024-07-04
 

--- a/internal/dbunique/db_unique.go
+++ b/internal/dbunique/db_unique.go
@@ -24,6 +24,7 @@ import (
 var defaultUniqueStates = []rivertype.JobState{ //nolint:gochecknoglobals
 	rivertype.JobStateAvailable,
 	rivertype.JobStateCompleted,
+	rivertype.JobStatePending,
 	rivertype.JobStateRetryable,
 	rivertype.JobStateRunning,
 	rivertype.JobStateScheduled,

--- a/internal/dbunique/db_unique_test.go
+++ b/internal/dbunique/db_unique_test.go
@@ -398,6 +398,7 @@ func TestUniqueInserter_JobInsert(t *testing.T) {
 		// already been done above.
 		for _, defaultState := range []rivertype.JobState{
 			rivertype.JobStateCompleted,
+			rivertype.JobStatePending,
 			rivertype.JobStateRunning,
 			rivertype.JobStateRetryable,
 			rivertype.JobStateScheduled,


### PR DESCRIPTION
Here, add the `pending` job state to the set of default unique states.
`pending` was a relatively recent addition in #301 and probably should 
always have been in the default unique states, but `pending` isn't used yet
so no one noticed one way or the other.