### PR TITLE
Prepare version v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2024-07-19
+
 ⚠️ Version 0.10.0 contains a new database migration, version 5. See [documentation on running River migrations](https://riverqueue.com/docs/migrations). If migrating with the CLI, make sure to update it to its latest version:
 
 ```shell

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.9.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.9.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.9.0
-	github.com/riverqueue/river/rivershared v0.0.0-20240707210043-f9063791ecb1
-	github.com/riverqueue/river/rivertype v0.9.0
+	github.com/riverqueue/river/riverdriver v0.10.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.10.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.10.0
+	github.com/riverqueue/river/rivershared v0.10.0
+	github.com/riverqueue/river/rivertype v0.10.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.9.0
+require github.com/riverqueue/river/rivertype v0.10.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -10,9 +10,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.9.0
-	github.com/riverqueue/river/rivershared v0.0.0-20240707210043-f9063791ecb1
-	github.com/riverqueue/river/rivertype v0.9.0
+	github.com/riverqueue/river/riverdriver v0.10.0
+	github.com/riverqueue/river/rivershared v0.10.0
+	github.com/riverqueue/river/rivertype v0.10.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -11,9 +11,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.9.0
-	github.com/riverqueue/river/rivershared v0.0.0-20240707210043-f9063791ecb1
-	github.com/riverqueue/river/rivertype v0.9.0
+	github.com/riverqueue/river/riverdriver v0.10.0
+	github.com/riverqueue/river/rivershared v0.10.0
+	github.com/riverqueue/river/rivertype v0.10.0
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prepare version v0.10.0 which contains a broad bucket of changes
including a new migration. See the changelog for details.

Notably, this release will require a separate CLI release step, which
will follow this one.