### PR TITLE
Modify migration 005 to tolerate the absence of `river_migration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Migration version 005 has been altered so that it can run even if the `river_migration` table isn't present, making it more friendly for projects that aren't using River's internal migration system. [PR #465](https://github.com/riverqueue/river/pull/465).
+
 ## [0.10.0] - 2024-07-19
 
 ⚠️ Version 0.10.0 contains a new database migration, version 5. See [documentation on running River migrations](https://riverqueue.com/docs/migrations). If migrating with the CLI, make sure to update it to its latest version:
@@ -14,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ```shell
 go install github.com/riverqueue/river/cmd/river@latest
 river migrate-up --database-url "$DATABASE_URL"
+```
+
+If not using River's internal migration system, the raw SQL can alternatively be dumped with:
+
+```shell
+go install github.com/riverqueue/river/cmd/river@latest
+river migrate-get --version 5 --up > river5.up.sql
+river migrate-get --version 5 --down > river5.down.sql
 ```
 
 The migration **includes a new index**. Users with a very large job table may want to consider raising the index separately using `CONCURRENTLY` (which must be run outside of a transaction), then run `river migrate-up` to finalize the process (it will tolerate an index that already exists):

--- a/riverdriver/riverdatabasesql/migration/main/005_migration_unique_client.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/005_migration_unique_client.down.sql
@@ -7,35 +7,40 @@
 DO
 $body$
 BEGIN
-    IF EXISTS (
-        SELECT *
-        FROM river_migration
-        WHERE line <> 'main'
-    ) THEN
-        RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
+    -- Tolerate users who may be using their own migration system rather than
+    -- River's. If they are, they will have skipped version 001 containing
+    -- `CREATE TABLE river_migration`, so this table won't exist.
+    IF (SELECT to_regclass('river_migration') IS NOT NULL) THEN
+        IF EXISTS (
+            SELECT *
+            FROM river_migration
+            WHERE line <> 'main'
+        ) THEN
+            RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
+        END IF;
+
+        ALTER TABLE river_migration
+            RENAME TO river_migration_old;
+
+        CREATE TABLE river_migration(
+            id bigserial PRIMARY KEY,
+            created_at timestamptz NOT NULL DEFAULT NOW(),
+            version bigint NOT NULL,
+            CONSTRAINT version CHECK (version >= 1)
+        );
+
+        CREATE UNIQUE INDEX ON river_migration USING btree(version);
+
+        INSERT INTO river_migration
+            (created_at, version)
+        SELECT created_at, version
+        FROM river_migration_old;
+
+        DROP TABLE river_migration_old;
     END IF;
 END;
 $body$
 LANGUAGE 'plpgsql'; 
-
-ALTER TABLE river_migration
-    RENAME TO river_migration_old;
-
-CREATE TABLE river_migration(
-  id bigserial PRIMARY KEY,
-  created_at timestamptz NOT NULL DEFAULT NOW(),
-  version bigint NOT NULL,
-  CONSTRAINT version CHECK (version >= 1)
-);
-
-CREATE UNIQUE INDEX ON river_migration USING btree(version);
-
-INSERT INTO river_migration
-    (created_at, version)
-SELECT created_at, version
-FROM river_migration_old;
-
-DROP TABLE river_migration_old;
 
 --
 -- Drop `river_job.unique_key`.

--- a/riverdriver/riverpgxv5/migration/main/005_migration_unique_client.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/005_migration_unique_client.down.sql
@@ -7,35 +7,40 @@
 DO
 $body$
 BEGIN
-    IF EXISTS (
-        SELECT *
-        FROM river_migration
-        WHERE line <> 'main'
-    ) THEN
-        RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
+    -- Tolerate users who may be using their own migration system rather than
+    -- River's. If they are, they will have skipped version 001 containing
+    -- `CREATE TABLE river_migration`, so this table won't exist.
+    IF (SELECT to_regclass('river_migration') IS NOT NULL) THEN
+        IF EXISTS (
+            SELECT *
+            FROM river_migration
+            WHERE line <> 'main'
+        ) THEN
+            RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
+        END IF;
+
+        ALTER TABLE river_migration
+            RENAME TO river_migration_old;
+
+        CREATE TABLE river_migration(
+            id bigserial PRIMARY KEY,
+            created_at timestamptz NOT NULL DEFAULT NOW(),
+            version bigint NOT NULL,
+            CONSTRAINT version CHECK (version >= 1)
+        );
+
+        CREATE UNIQUE INDEX ON river_migration USING btree(version);
+
+        INSERT INTO river_migration
+            (created_at, version)
+        SELECT created_at, version
+        FROM river_migration_old;
+
+        DROP TABLE river_migration_old;
     END IF;
 END;
 $body$
 LANGUAGE 'plpgsql'; 
-
-ALTER TABLE river_migration
-    RENAME TO river_migration_old;
-
-CREATE TABLE river_migration(
-  id bigserial PRIMARY KEY,
-  created_at timestamptz NOT NULL DEFAULT NOW(),
-  version bigint NOT NULL,
-  CONSTRAINT version CHECK (version >= 1)
-);
-
-CREATE UNIQUE INDEX ON river_migration USING btree(version);
-
-INSERT INTO river_migration
-    (created_at, version)
-SELECT created_at, version
-FROM river_migration_old;
-
-DROP TABLE river_migration_old;
 
 --
 -- Drop `river_job.unique_key`.


### PR DESCRIPTION
Version 0.10.0's migration (005) brought in a number of changes
including one that adds a new `line` field to the migration table.

It works, but could present a problem for River installations that are
purposely not using River's migration system, which is a path that even
if not explicitly recommended, we've been trying to support.

Here, add some conditionals to 005 so that the migration-related changes
only run if `river_migration` exists. A test verifies that even if 001
(which brings in `river_migration`) had never run, the up and own
migrations still work.