### PR TITLE
Prepare version 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2024-07-23
+
 ### Fixed
 
 - Migration version 005 has been altered so that it can run even if the `river_migration` table isn't present, making it more friendly for projects that aren't using River's internal migration system. [PR #465](https://github.com/riverqueue/river/pull/465).

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.10.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.10.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.10.0
-	github.com/riverqueue/river/rivershared v0.10.0
-	github.com/riverqueue/river/rivertype v0.10.0
+	github.com/riverqueue/river/riverdriver v0.10.1
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.10.1
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.10.1
+	github.com/riverqueue/river/rivershared v0.10.1
+	github.com/riverqueue/river/rivertype v0.10.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.10.0
+require github.com/riverqueue/river/rivertype v0.10.1

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -10,9 +10,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.10.0
-	github.com/riverqueue/river/rivershared v0.10.0
-	github.com/riverqueue/river/rivertype v0.10.0
+	github.com/riverqueue/river/riverdriver v0.10.1
+	github.com/riverqueue/river/rivershared v0.10.1
+	github.com/riverqueue/river/rivertype v0.10.1
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -11,9 +11,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.10.0
-	github.com/riverqueue/river/rivershared v0.10.0
-	github.com/riverqueue/river/rivertype v0.10.0
+	github.com/riverqueue/river/riverdriver v0.10.1
+	github.com/riverqueue/river/rivershared v0.10.1
+	github.com/riverqueue/river/rivertype v0.10.1
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
A small patch release containing #465 which will allow 0.10.0's
migrations to be run more easily for users not using River's internal
migration framework.

This will also require a separate CLI release which I'll follow up with.