### PR TITLE
include pending state by default in JobListParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include `pending` state in `JobListParams` by default so pending jobs are included in `JobList` / `JobListTx` results.
+
 ## [0.10.1] - 2024-07-23
 
 ### Fixed
@@ -69,13 +73,13 @@ river migrate-up --database-url "$DATABASE_URL"
 
 - **Breaking change:** Add stack trace to `ErrorHandler.HandlePanicFunc`. Fixing code only requires adding a new `trace string` argument to `HandlePanicFunc`. [PR #423](https://github.com/riverqueue/river/pull/423).
 
-    ``` go
-    # before
-    HandlePanic(ctx context.Context, job *rivertype.JobRow, panicVal any) *ErrorHandlerResult
+  ```go
+  # before
+  HandlePanic(ctx context.Context, job *rivertype.JobRow, panicVal any) *ErrorHandlerResult
 
-    # after
-    HandlePanic(ctx context.Context, job *rivertype.JobRow, panicVal any, trace string) *ErrorHandlerResult
-    ```
+  # after
+  HandlePanic(ctx context.Context, job *rivertype.JobRow, panicVal any, trace string) *ErrorHandlerResult
+  ```
 
 ### Fixed
 

--- a/client.go
+++ b/client.go
@@ -1590,7 +1590,7 @@ type JobListResult struct {
 // provided context is used for the underlying Postgres query and can be used to
 // cancel the operation or apply a timeout.
 //
-//	params := river.NewJobListParams().WithLimit(10).State(rivertype.JobStateCompleted)
+//	params := river.NewJobListParams().First(10).State(rivertype.JobStateCompleted)
 //	jobRows, err := client.JobList(ctx, params)
 //	if err != nil {
 //		// handle error
@@ -1623,7 +1623,7 @@ func (c *Client[TTx]) JobList(ctx context.Context, params *JobListParams) (*JobL
 // provided context is used for the underlying Postgres query and can be used to
 // cancel the operation or apply a timeout.
 //
-//	params := river.NewJobListParams().First(10).State(river.JobStateCompleted)
+//	params := river.NewJobListParams().First(10).States(river.JobStateCompleted)
 //	jobRows, err := client.JobListTx(ctx, tx, params)
 //	if err != nil {
 //		// handle error

--- a/client_test.go
+++ b/client_test.go
@@ -2021,6 +2021,7 @@ func Test_Client_JobList(t *testing.T) {
 		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
 		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
 		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStatePending)})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().States(rivertype.JobStateAvailable))
 		require.NoError(t, err)
@@ -2030,6 +2031,11 @@ func Test_Client_JobList(t *testing.T) {
 		listRes, err = client.JobList(ctx, NewJobListParams().States(rivertype.JobStateRunning))
 		require.NoError(t, err)
 		require.Equal(t, []int64{job3.ID}, sliceutil.Map(listRes.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
+
+		// All by default:
+		listRes, err = client.JobList(ctx, NewJobListParams())
+		require.NoError(t, err)
+		require.Equal(t, []int64{job1.ID, job2.ID, job3.ID, job4.ID}, sliceutil.Map(listRes.Jobs, func(job *rivertype.JobRow) int64 { return job.ID }))
 	})
 
 	t.Run("DefaultsToOrderingByID", func(t *testing.T) {

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -188,6 +188,7 @@ func NewJobListParams() *JobListParams {
 			rivertype.JobStateCancelled,
 			rivertype.JobStateCompleted,
 			rivertype.JobStateDiscarded,
+			rivertype.JobStatePending,
 			rivertype.JobStateRetryable,
 			rivertype.JobStateRunning,
 			rivertype.JobStateScheduled,


### PR DESCRIPTION
When the pending state was added, we did not add it to the default list of job states used by `JobList`. The filters are supposed to included _all_ states by default, so `pending` needs to be added here.

I also fixed two bits of outdated documentation around these APIs.