### PR TITLE
Prepare v0.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2024-07-31
+
 ### Fixed
 
 - Include `pending` state in `JobListParams` by default so pending jobs are included in `JobList` / `JobListTx` results. [PR #477](https://github.com/riverqueue/river/pull/477).
 - Quote strings when using `Client.JobList` functions with the `database/sql` driver. [PR #481](https://github.com/riverqueue/river/pull/481).
-- Remove use of filepath for interacting with embedded migration files, fixing the migration CLI for Windows. [PR #485](https://github.com/riverqueue/river/pull/485).
+- Remove use of `filepath` for interacting with embedded migration files, fixing the migration CLI for Windows. [PR #485](https://github.com/riverqueue/river/pull/485).
 - Respect `ScheduledAt` if set to a non-zero value by `JobArgsWithInsertOpts`. This allows for job arg definitions to utilize custom logic at the args level for determining when the job should be scheduled. [PR #487](https://github.com/riverqueue/river/pull/487).
 
 ## [0.10.1] - 2024-07-23

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.10.1
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.10.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.10.1
-	github.com/riverqueue/river/rivershared v0.10.1
-	github.com/riverqueue/river/rivertype v0.10.1
+	github.com/riverqueue/river/riverdriver v0.10.2
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.10.2
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.10.2
+	github.com/riverqueue/river/rivershared v0.10.2
+	github.com/riverqueue/river/rivertype v0.10.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.10.1
+require github.com/riverqueue/river/rivertype v0.10.2

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -10,9 +10,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.10.1
-	github.com/riverqueue/river/rivershared v0.10.1
-	github.com/riverqueue/river/rivertype v0.10.1
+	github.com/riverqueue/river/riverdriver v0.10.2
+	github.com/riverqueue/river/rivershared v0.10.2
+	github.com/riverqueue/river/rivertype v0.10.2
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -11,9 +11,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.10.1
-	github.com/riverqueue/river/rivershared v0.10.1
-	github.com/riverqueue/river/rivertype v0.10.1
+	github.com/riverqueue/river/riverdriver v0.10.2
+	github.com/riverqueue/river/rivershared v0.10.2
+	github.com/riverqueue/river/rivertype v0.10.2
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
We have a variety of bug fixes that should go out, so here, prepare a
v0.10.2 release that bundles them up.

We have migration changes, so we'll also need to do a separate phase two
release of the CLI for this version.