### PR TITLE
Expose executor via InternalExecutorBundle on Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1657,6 +1657,12 @@ func (c *Client[TTx]) JobListTx(ctx context.Context, tx TTx, params *JobListPara
 // client, and can be used to add new ones or remove existing ones.
 func (c *Client[TTx]) PeriodicJobs() *PeriodicJobBundle { return c.periodicJobs }
 
+// InternalExecutorBundle is an accessor for the internal executors of the client.
+// It is not stable for external use and no compatibility guarantees are made.
+func (c *Client[TTx]) InternalExecutorBundle() riverdriver.InternalExecutorBundle[TTx] {
+	return &internalExecutorBundle[TTx]{driver: c.driver}
+}
+
 // Queues returns the currently configured set of queues for the client, and can
 // be used to add new ones.
 func (c *Client[TTx]) Queues() *QueueBundle { return c.queues }
@@ -1842,6 +1848,18 @@ func (c *Client[TTx]) QueueResumeTx(ctx context.Context, tx TTx, name string, op
 	}
 
 	return nil
+}
+
+type internalExecutorBundle[TTx any] struct {
+	driver riverdriver.Driver[TTx]
+}
+
+func (i *internalExecutorBundle[TTx]) Executor() riverdriver.Executor {
+	return i.driver.GetExecutor()
+}
+
+func (i *internalExecutorBundle[TTx]) ExecutorTx(tx TTx) riverdriver.Executor {
+	return i.driver.UnwrapExecutor(tx)
 }
 
 // QueueBundle is a bundle for adding additional queues. It's made accessible

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -162,6 +162,11 @@ type Executor interface {
 	NotifyMany(ctx context.Context, params *NotifyManyParams) error
 	PGAdvisoryXactLock(ctx context.Context, key int64) (*struct{}, error)
 
+	// Query executes raw SQL.
+	Query(ctx context.Context, sql string, args ...any) (Rows, error)
+	// QueryRow executes raw SQL.
+	QueryRow(ctx context.Context, sql string, args ...any) Row
+
 	QueueCreateOrSetUpdatedAt(ctx context.Context, params *QueueCreateOrSetUpdatedAtParams) (*rivertype.Queue, error)
 	QueueDeleteExpired(ctx context.Context, params *QueueDeleteExpiredParams) ([]string, error)
 	QueueGet(ctx context.Context, name string) (*rivertype.Queue, error)
@@ -176,6 +181,42 @@ type Executor interface {
 
 type ExecResult interface {
 	RowsAffected() int64
+}
+
+type Row interface {
+	// Scan works the same as Rows.Scan with the following exceptions. If no rows
+	// were found it returns rivertype.ErrNotFound. If multiple rows were found it
+	// ignores all but the first.
+	Scan(dest ...any) error
+}
+
+type Rows interface {
+	// Close closes the rows, making the connection ready for use again. It is safe
+	// to call Close after rows is already closed.
+	Close() error
+
+	// Err returns any error that occurred while reading. Err must only be called after the Rows is closed (either by
+	// calling Close or by Next returning false). If it is called early it may return nil even if there was an error
+	// executing the query.
+	Err() error
+
+	// Next prepares the next row for reading. It returns true if there is another
+	// row and false if no more rows are available or a fatal error has occurred.
+	// It automatically closes rows when all rows are read.
+	//
+	// Callers should check rows.Err() after rows.Next() returns false to detect
+	// whether result-set reading ended prematurely due to an error. See
+	// Conn.Query for details.
+	//
+	// For simpler error handling, consider using the higher-level pgx v5
+	// CollectRows() and ForEachRow() helpers instead.
+	Next() bool
+
+	// Scan reads the values from the current row into dest values positionally.
+	// dest can include pointers to core types, values implementing the Scanner
+	// interface, and nil. nil will skip the value entirely. It is an error to
+	// call Scan without first calling Next() and checking that it returned true.
+	Scan(dest ...any) error
 }
 
 // ExecutorTx is an executor which is a transaction. In addition to standard

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -82,6 +82,8 @@ type Driver[TTx any] interface {
 	// API is not stable. DO NOT USE.
 	SupportsListener() bool
 
+	RowsToJobs(rows Rows) ([]*rivertype.JobRow, error)
+
 	// UnwrapExecutor gets an executor from a driver transaction.
 	//
 	// API is not stable. DO NOT USE.

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -102,8 +102,8 @@ type Executor interface {
 	// the schema in the current search schema.
 	ColumnExists(ctx context.Context, tableName, columnName string) (bool, error)
 
-	// Exec executes raw SQL. Used for migrations.
-	Exec(ctx context.Context, sql string) (struct{}, error)
+	// Exec executes raw SQL.
+	Exec(ctx context.Context, sql string, args ...any) (ExecResult, error)
 
 	JobCancel(ctx context.Context, params *JobCancelParams) (*rivertype.JobRow, error)
 	JobCountByState(ctx context.Context, state rivertype.JobState) (int, error)
@@ -172,6 +172,10 @@ type Executor interface {
 	// TableExists checks whether a table exists for the schema in the current
 	// search schema.
 	TableExists(ctx context.Context, tableName string) (bool, error)
+}
+
+type ExecResult interface {
+	RowsAffected() int64
 }
 
 // ExecutorTx is an executor which is a transaction. In addition to standard

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -93,6 +93,8 @@ type Driver[TTx any] interface {
 //
 // API is not stable. DO NOT IMPLEMENT.
 type Executor interface {
+	// High level DB operations:
+
 	// Begin begins a new subtransaction. ErrSubTxNotSupported may be returned
 	// if the executor is a transaction and the driver doesn't support
 	// subtransactions (like riverdriver/riverdatabasesql for database/sql).
@@ -104,6 +106,12 @@ type Executor interface {
 
 	// Exec executes raw SQL.
 	Exec(ctx context.Context, sql string, args ...any) (ExecResult, error)
+	// Query executes raw SQL.
+	Query(ctx context.Context, sql string, args ...any) (Rows, error)
+	// QueryRow executes raw SQL.
+	QueryRow(ctx context.Context, sql string, args ...any) Row
+
+	// Specific queries:
 
 	JobCancel(ctx context.Context, params *JobCancelParams) (*rivertype.JobRow, error)
 	JobCountByState(ctx context.Context, state rivertype.JobState) (int, error)
@@ -161,11 +169,6 @@ type Executor interface {
 
 	NotifyMany(ctx context.Context, params *NotifyManyParams) error
 	PGAdvisoryXactLock(ctx context.Context, key int64) (*struct{}, error)
-
-	// Query executes raw SQL.
-	Query(ctx context.Context, sql string, args ...any) (Rows, error)
-	// QueryRow executes raw SQL.
-	QueryRow(ctx context.Context, sql string, args ...any) Row
 
 	QueueCreateOrSetUpdatedAt(ctx context.Context, params *QueueCreateOrSetUpdatedAtParams) (*rivertype.Queue, error)
 	QueueDeleteExpired(ctx context.Context, params *QueueDeleteExpiredParams) ([]string, error)
@@ -235,6 +238,14 @@ type ExecutorTx interface {
 	//
 	// API is not stable. DO NOT USE.
 	Rollback(ctx context.Context) error
+}
+
+// InternalExecutorBundle is a bundle of an executor and a transaction executor.
+//
+// API is not stable. DO NOT USE.
+type InternalExecutorBundle[TTx any] interface {
+	Executor() Executor
+	ExecutorTx(tx TTx) Executor
 }
 
 // Listener listens for notifications. In Postgres, this is a database

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -709,6 +709,21 @@ func (e *Executor) PGAdvisoryXactLock(ctx context.Context, key int64) (*struct{}
 	return &struct{}{}, interpretError(err)
 }
 
+// Query executes raw SQL.
+func (e *Executor) Query(ctx context.Context, sql string, args ...any) (riverdriver.Rows, error) {
+	if len(args) == 0 {
+		args = nil
+	}
+	return e.dbtx.QueryContext(ctx, sql, args...)
+}
+
+func (e *Executor) QueryRow(ctx context.Context, sql string, args ...any) riverdriver.Row {
+	if len(args) == 0 {
+		args = nil
+	}
+	return &rowWrapper{e.dbtx.QueryRowContext(ctx, sql, args...)}
+}
+
 func (e *Executor) QueueCreateOrSetUpdatedAt(ctx context.Context, params *riverdriver.QueueCreateOrSetUpdatedAtParams) (*rivertype.Queue, error) {
 	queue, err := dbsqlc.New().QueueCreateOrSetUpdatedAt(ctx, e.dbtx, &dbsqlc.QueueCreateOrSetUpdatedAtParams{
 		Metadata:  valutil.ValOrDefault(string(params.Metadata), "{}"),
@@ -863,6 +878,14 @@ func (t *ExecutorSubTx) Rollback(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+type rowWrapper struct {
+	*sql.Row
+}
+
+func (r *rowWrapper) Scan(dest ...any) error {
+	return interpretError(r.Row.Scan(dest...))
 }
 
 func interpretError(err error) error {

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -63,6 +63,18 @@ func (d *Driver) UnwrapExecutor(tx *sql.Tx) riverdriver.ExecutorTx {
 	return &ExecutorTx{Executor: Executor{nil, tx}, tx: tx}
 }
 
+type execResultWrapper struct {
+	sql.Result
+}
+
+func (e *execResultWrapper) RowsAffected() int64 {
+	count, err := e.Result.RowsAffected()
+	if err != nil {
+		return 0
+	}
+	return count
+}
+
 type Executor struct {
 	dbPool *sql.DB
 	dbtx   dbsqlc.DBTX
@@ -84,9 +96,12 @@ func (e *Executor) ColumnExists(ctx context.Context, tableName, columnName strin
 	return exists, interpretError(err)
 }
 
-func (e *Executor) Exec(ctx context.Context, sql string) (struct{}, error) {
-	_, err := e.dbtx.ExecContext(ctx, sql)
-	return struct{}{}, interpretError(err)
+func (e *Executor) Exec(ctx context.Context, sql string, args ...any) (riverdriver.ExecResult, error) {
+	res, err := e.dbtx.ExecContext(ctx, sql, args...)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return &execResultWrapper{res}, interpretError(err)
 }
 
 func (e *Executor) JobCancel(ctx context.Context, params *riverdriver.JobCancelParams) (*rivertype.JobRow, error) {

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -714,7 +714,15 @@ func (e *Executor) Query(ctx context.Context, sql string, args ...any) (riverdri
 	if len(args) == 0 {
 		args = nil
 	}
-	return e.dbtx.QueryContext(ctx, sql, args...)
+	rows, err := e.dbtx.QueryContext(ctx, sql, args...)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return rows, nil
 }
 
 func (e *Executor) QueryRow(ctx context.Context, sql string, args ...any) riverdriver.Row {

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -62,6 +62,53 @@ func (d *Driver) GetMigrationLines() []string { return []string{riverdriver.Migr
 func (d *Driver) HasPool() bool               { return d.dbPool != nil }
 func (d *Driver) SupportsListener() bool      { return true }
 
+// RowsToJobs converts a riverdriver.Rows to a slice of *rivertype.JobRow, using
+// this driver's internal type as an intermediate for safe deserialization.
+//
+// This approach would allow us to use the higher level executor query methods
+// with raw SQL to query the database, and then safely scan the rows with
+// driver-specific details abstracted away.
+func (d *Driver) RowsToJobs(rows riverdriver.Rows) ([]*rivertype.JobRow, error) {
+	var items []*dbsqlc.RiverJob
+	for rows.Next() {
+		var i dbsqlc.RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			&i.AttemptedBy,
+			&i.CreatedAt,
+			&i.Errors,
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			&i.Tags,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	jobs := make([]*rivertype.JobRow, len(items))
+	var err error
+	for i, item := range items {
+		jobs[i], err = jobRowFromInternal(item)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return jobs, nil
+}
+
 func (d *Driver) UnwrapExecutor(tx pgx.Tx) riverdriver.ExecutorTx {
 	return &ExecutorTx{Executor: Executor{tx}, tx: tx}
 }

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -89,9 +89,11 @@ func (e *Executor) ColumnExists(ctx context.Context, tableName, columnName strin
 	return exists, interpretError(err)
 }
 
-func (e *Executor) Exec(ctx context.Context, sql string) (struct{}, error) {
-	_, err := e.dbtx.Exec(ctx, sql)
-	return struct{}{}, interpretError(err)
+func (e *Executor) Exec(ctx context.Context, sql string, args ...any) (riverdriver.ExecResult, error) {
+	if len(args) == 0 {
+		args = nil
+	}
+	return e.dbtx.Exec(ctx, sql, args...)
 }
 
 func (e *Executor) JobCancel(ctx context.Context, params *riverdriver.JobCancelParams) (*rivertype.JobRow, error) {


### PR DESCRIPTION
This adds an `InternalExecutorBundle()` method to `Client` which returns a new `driver.InternalExecutorBundle[TTx]` interface type. The interface exposes the driver's internal executors via `Executor()` and `ExecutorTx(tx)` methods. This can enable external modules to run queries against River's underlying drivers, including arbitrary SQL.

Compatibility interfaces for `ExecResult`, `Rows`, and `Row` are able to paper over the basic differences between `database/sql` and `pgx` in order to expose just enough functionality for basic arbitrary SQL queries.

For now, this allows us to run simple SQL queries against River's drivers from external libraries. In the future, it could be a path toward extracting most of the duplicate queries in drivers into a shared query module that isn't driver-specific. Drivers would become a simpler interface focused on `Exec`/`Query`/`QueryRow` and row scanning details, rather than each needing to implement every query under the sun.

A final commit [ef5dff2](https://github.com/riverqueue/river/pull/494/commits/ef5dff2594898e9646124ea328a879ad3e7fb0e5) demonstrates a possible extension of this pattern to expand the driver interface so that it can abstract all details of deserializing `river_job` rows, allowing driver-specific details like `[]byte` vs `string` for json to be tucked away in a single implementation, even if external packages are able to run arbitrary queries for jobs. This commit can be omitted from merge but I wanted to at least illustrate the potential here.