### PR TITLE
database/sql: default to current time if scheduled_at unspecified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `database/sql` driver: fix default value of `scheduled_at` for `InsertManyTx` when it is not specified in `InsertOpts`. [PR #504](https://github.com/riverqueue/river/pull/504).
+
 ## [0.11.0] - 2024-08-02
 
 ### Added

--- a/client.go
+++ b/client.go
@@ -1169,9 +1169,8 @@ func insertParamsFromConfigArgsAndOptions(archetype *baseservice.Archetype, conf
 	}
 
 	// If the time is stubbed (in a test), use that for `created_at`. Otherwise,
-	// leave an empty value which will use the database's `now()` value, which
-	// keeps the timestamps of jobs inserted across many different computers
-	// more consistent (i.e. in case of minor time drifts).
+	// leave an empty value which will either use the database's `now()` or be defaulted
+	// by drivers as necessary.
 	createdAt := archetype.Time.NowUTCOrNil()
 
 	maxAttempts := valutil.FirstNonZero(insertOpts.MaxAttempts, jobInsertOpts.MaxAttempts, config.MaxAttempts)

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -228,11 +228,12 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 		State:       make([]dbsqlc.RiverJobState, len(params)),
 		Tags:        make([]string, len(params)),
 	}
+	now := time.Now()
 
 	for i := 0; i < len(params); i++ {
 		params := params[i]
 
-		var scheduledAt time.Time
+		scheduledAt := now
 		if params.ScheduledAt != nil {
 			scheduledAt = *params.ScheduledAt
 		}


### PR DESCRIPTION
The database/sql driver had a slightly different behavior than the pgx driver in that it was setting the `scheduled_at` time to `null`, rather than setting the current timestamp if one was not specified.

Additionally, the driver test suite did not cover this case at all.

Fix both of these issues. Fixes https://github.com/riverqueue/river/issues/502.