### PR TITLE
Account for schema when checking whether a column exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `database/sql` driver: fix default value of `scheduled_at` for `InsertManyTx` when it is not specified in `InsertOpts`. [PR #504](https://github.com/riverqueue/river/pull/504).
+- Change `ColumnExists` query to respect `search_path`, thereby allowing migrations to be runnable outside of default schema. [PR #505](https://github.com/riverqueue/river/pull/505).
 
 ## [0.11.0] - 2024-08-02
 

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -192,6 +192,26 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 		exists, err = exec.ColumnExists(ctx, "river_job", "does_not_exist")
 		require.NoError(t, err)
 		require.False(t, exists)
+
+		exists, err = exec.ColumnExists(ctx, "does_not_exist", "id")
+		require.NoError(t, err)
+		require.False(t, exists)
+
+		// Will be rolled back by the test transaction.
+		_, err = exec.Exec(ctx, "CREATE SCHEMA another_schema_123")
+		require.NoError(t, err)
+
+		_, err = exec.Exec(ctx, "SET search_path = another_schema_123")
+		require.NoError(t, err)
+
+		// Table with the same name as the main schema, but without the same
+		// columns.
+		_, err = exec.Exec(ctx, "CREATE TABLE river_job (another_id bigint)")
+		require.NoError(t, err)
+
+		exists, err = exec.ColumnExists(ctx, "river_job", "id")
+		require.NoError(t, err)
+		require.False(t, exists)
 	})
 
 	t.Run("Exec", func(t *testing.T) {
@@ -2284,6 +2304,17 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 		require.True(t, exists)
 
 		exists, err = exec.TableExists(ctx, "does_not_exist")
+		require.NoError(t, err)
+		require.False(t, exists)
+
+		// Will be rolled back by the test transaction.
+		_, err = exec.Exec(ctx, "CREATE SCHEMA another_schema_123")
+		require.NoError(t, err)
+
+		_, err = exec.Exec(ctx, "SET search_path = another_schema_123")
+		require.NoError(t, err)
+
+		exists, err = exec.TableExists(ctx, "river_job")
 		require.NoError(t, err)
 		require.False(t, exists)
 	})

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_migration.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_migration.sql.go
@@ -16,13 +16,15 @@ const columnExists = `-- name: ColumnExists :one
 SELECT EXISTS (
     SELECT column_name
     FROM information_schema.columns 
-    WHERE table_name = $1 and column_name = $2
+    WHERE table_name = $1::text
+        AND table_schema = CURRENT_SCHEMA
+        AND column_name = $2::text
 )
 `
 
 type ColumnExistsParams struct {
-	TableName  interface{}
-	ColumnName interface{}
+	TableName  string
+	ColumnName string
 }
 
 func (q *Queries) ColumnExists(ctx context.Context, db DBTX, arg *ColumnExistsParams) (bool, error) {

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
@@ -72,7 +72,9 @@ RETURNING
 SELECT EXISTS (
     SELECT column_name
     FROM information_schema.columns 
-    WHERE table_name = @table_name and column_name = @column_name
+    WHERE table_name = @table_name::text
+        AND table_schema = CURRENT_SCHEMA
+        AND column_name = @column_name::text
 );
 
 -- name: TableExists :one

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql.go
@@ -14,13 +14,15 @@ const columnExists = `-- name: ColumnExists :one
 SELECT EXISTS (
     SELECT column_name
     FROM information_schema.columns 
-    WHERE table_name = $1 and column_name = $2
+    WHERE table_name = $1::text
+        AND table_schema = CURRENT_SCHEMA
+        AND column_name = $2::text
 )
 `
 
 type ColumnExistsParams struct {
-	TableName  interface{}
-	ColumnName interface{}
+	TableName  string
+	ColumnName string
 }
 
 func (q *Queries) ColumnExists(ctx context.Context, db DBTX, arg *ColumnExistsParams) (bool, error) {


### PR DESCRIPTION
This one's aimed at addressing #503, in which migrations won't run when
using an alternate schema with `search_path` because the `ColumnExists`
query isn't accounting for schema in any way.

Here, modify `ColumnExists` so that it looks up within `CURRENT_SCHEMA`,
which will respect search path. Add test assertions to verify that this
works as expected, and similar ones in `TableExists` to avoid any
regressions there (it already does respect search path as written, but a
future change could potentially break that).

Fixes #503.