### PR TITLE
Prepare release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2024-08-05
+
 ### Fixed
 
 - `database/sql` driver: fix default value of `scheduled_at` for `InsertManyTx` when it is not specified in `InsertOpts`. [PR #504](https://github.com/riverqueue/river/pull/504).

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,6 +31,7 @@ queries. After changing an sqlc `.sql` file, generate Go with:
     git checkout master && git pull --rebase
     export VERSION=v0.x.y
     go run ./internal/cmd/update-submodule-versions/main.go
+    git checkout -b $USER-$VERSION
     ```
 
 2. Prepare a PR with the changes, updating `CHANGELOG.md` with any necessary additions at the same time. Have it reviewed and merged.

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.0
-	github.com/riverqueue/river/rivershared v0.11.0
-	github.com/riverqueue/river/rivertype v0.11.0
+	github.com/riverqueue/river/riverdriver v0.11.1
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.1
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.1
+	github.com/riverqueue/river/rivershared v0.11.1
+	github.com/riverqueue/river/rivertype v0.11.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21.4
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.11.0
+require github.com/riverqueue/river/rivertype v0.11.1

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -10,9 +10,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.11.0
-	github.com/riverqueue/river/rivershared v0.11.0
-	github.com/riverqueue/river/rivertype v0.11.0
+	github.com/riverqueue/river/riverdriver v0.11.1
+	github.com/riverqueue/river/rivershared v0.11.1
+	github.com/riverqueue/river/rivertype v0.11.1
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -11,9 +11,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.0
-	github.com/riverqueue/river/rivershared v0.11.0
-	github.com/riverqueue/river/rivertype v0.11.0
+	github.com/riverqueue/river/riverdriver v0.11.1
+	github.com/riverqueue/river/rivershared v0.11.1
+	github.com/riverqueue/river/rivertype v0.11.1
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prepare release v0.11.1 containing #504 and #505. This will also require
a CLI release.