### PR TITLE
Derive all internal contexts from Client context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Derive all internal contexts from user-provided `Client` context. This includes the job fetch context, notifier unlisten, and completer. [PR #514](https://github.com/riverqueue/river/pull/514).
+
 ## [0.11.1] - 2024-08-05
 
 ### Fixed

--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -506,7 +506,7 @@ func (c *BatchCompleter) waitOrInitBacklogChannel(ctx context.Context) {
 const numRetries = 3
 
 func withRetries[T any](logCtx context.Context, baseService *baseservice.BaseService, disableSleep bool, retryFunc func(ctx context.Context) (T, error)) (T, error) {
-	uncancelledCtx := context.Background()
+	uncancelledCtx := context.WithoutCancel(logCtx)
 
 	var (
 		defaultVal T

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -35,8 +35,8 @@ type Subscription struct {
 
 func (s *Subscription) Unlisten(ctx context.Context) {
 	s.unlistenOnce.Do(func() {
-		// Unlisten uses background context in case of cancellation.
-		if err := s.notifier.unlisten(context.Background(), s); err != nil { //nolint:contextcheck
+		// Unlisten strips cancellation from the parent context to ensure it runs:
+		if err := s.notifier.unlisten(context.WithoutCancel(ctx), s); err != nil { //nolint:contextcheck
 			s.notifier.Logger.ErrorContext(ctx, s.notifier.Name+": Error unlistening on topic", "err", err, "topic", s.topic)
 		}
 	})


### PR DESCRIPTION
We were previously using `context.Background()` in some situations to avoid cancellation of things that really shouldn't be cancelled by the user context cancellation. However, we can now do that with `context.WithoutCancel` instead in order to preserve context values without any cancellation or deadline.

Fixes #512.