### PR TITLE
rivertest.RequireNotInsertedTx: fix incorrect description

### DIFF
--- a/rivertest/rivertest.go
+++ b/rivertest/rivertest.go
@@ -205,9 +205,8 @@ func requireNotInserted[TDriver riverdriver.Driver[TTx], TTx any, TArgs river.Jo
 	}
 }
 
-// RequireInsertedTx is a test helper that verifies that a job of the given kind
-// was inserted for work, failing the test if it wasn't. If found, the inserted
-// job is returned so that further assertions can be made against it.
+// RequireNotInsertedTx is a test helper that verifies that a job of the given
+// kind was not inserted for work, failing the test if one was.
 //
 //	job := RequireInsertedTx[*riverpgxv5.Driver](ctx, t, tx, &Job1Args{}, nil)
 //


### PR DESCRIPTION
Noticed this description was wrong from some copy pasta 🍝  https://pkg.go.dev/github.com/riverqueue/river/rivertest#RequireNotInsertedTx

Set to auto-merge, make edits before approving if you want to please 🙏 