### PR TITLE
Add `startstop.StartAll` helper to start a series of services

### DIFF
--- a/rivershared/baseservice/base_service.go
+++ b/rivershared/baseservice/base_service.go
@@ -43,6 +43,16 @@ type Archetype struct {
 	Time TimeGenerator
 }
 
+// NewArchetype returns a new archetype. This function is most suitable for
+// non-test usage wherein nothing should be stubbed.
+func NewArchetype(logger *slog.Logger) *Archetype {
+	return &Archetype{
+		Logger: logger,
+		Rand:   randutil.NewCryptoSeededConcurrentSafeRand(),
+		Time:   &UnStubbableTimeGenerator{},
+	}
+}
+
 // BaseService is a struct that's meant to be embedded on "service-like" objects
 // (e.g. client, producer, queue maintainer) and which provides a number of
 // convenient properties that are widely needed so that they don't have to be


### PR DESCRIPTION
Add a `StartAll` helper that starts a number of services at once, also
taking care that in the event of a problem, any services that had
started are once stopped. I found the use of something like this
convenient while trying some service code in River UI.

I also make a couple tweaks so that the `Stopped` channel becomes a
little safer to use. Like `Started`, it will preallocate itself if
called before a service is started. It's still not safe to call while
stopping or after a stop, but its ergonomics still measurably improve.

Lastly, I pull a somewhat unrelated change to add a `NewArchetype`
function in for easily creating an archetype in non-test environments.
Also found this useful when bringing use of archetypes into River UI.