### PR TITLE
Simplify names of base service types involving generics for logging

### DIFF
--- a/rivershared/baseservice/base_service_test.go
+++ b/rivershared/baseservice/base_service_test.go
@@ -148,3 +148,22 @@ func archetype() *Archetype {
 		Time:   &UnStubbableTimeGenerator{},
 	}
 }
+
+func TestSimplifyLogName(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "NotGeneric", simplifyLogName("NotGeneric"))
+
+	// Simplified for use during debugging. Real generics will tend to have
+	// fully qualified paths and not look like this.
+	require.Equal(t, "Simple[int]", simplifyLogName("Simple[int]"))
+	require.Equal(t, "Simple[*int]", simplifyLogName("Simple[*int]"))
+	require.Equal(t, "Simple[[]int]", simplifyLogName("Simple[[]int]"))
+	require.Equal(t, "Simple[[]*int]", simplifyLogName("Simple[[]*int]"))
+
+	// More realistic examples.
+	require.Equal(t, "QueryCacher[dbsqlc.JobCountByStateRow]", simplifyLogName("QueryCacher[github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
+	require.Equal(t, "QueryCacher[*dbsqlc.JobCountByStateRow]", simplifyLogName("QueryCacher[*github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
+	require.Equal(t, "QueryCacher[[]dbsqlc.JobCountByStateRow]", simplifyLogName("QueryCacher[[]github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
+	require.Equal(t, "QueryCacher[[]*dbsqlc.JobCountByStateRow]", simplifyLogName("QueryCacher[[]*github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]"))
+}


### PR DESCRIPTION
A small improvement to base service so that when it's using reflect to
get a name of the service's type for logging purposes, it strips a long
path out of a generic type for a more succinct result.

So this long, unsightly blemish:

    QueryCacher[[]*github.com/riverqueue/riverui/internal/dbsqlc.JobCountByStateRow]

Would become this, which is quite a bit more tolerable:

    QueryCacher[[]*dbsqlc.JobCountByStateRow]