### PR TITLE
Move `TestSignal` into `rivershared` for use outside of main project

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/maputil"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
@@ -348,7 +349,7 @@ type Client[TTx any] struct {
 
 // Test-only signals.
 type clientTestSignals struct {
-	electedLeader rivercommon.TestSignal[struct{}] // notifies when elected leader
+	electedLeader testsignal.TestSignal[struct{}] // notifies when elected leader
 
 	jobCleaner          *maintenance.JobCleanerTestSignals
 	jobRescuer          *maintenance.JobRescuerTestSignals

--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/riverqueue/river/internal/notifier"
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/util/dbutil"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
 
@@ -53,11 +53,11 @@ func (s *Subscription) Unlisten() {
 
 // Test-only properties.
 type electorTestSignals struct {
-	DeniedLeadership     rivercommon.TestSignal[struct{}] // notifies when elector fails to gain leadership
-	GainedLeadership     rivercommon.TestSignal[struct{}] // notifies when elector gains leadership
-	LostLeadership       rivercommon.TestSignal[struct{}] // notifies when an elected leader loses leadership
-	MaintainedLeadership rivercommon.TestSignal[struct{}] // notifies when elector maintains leadership
-	ResignedLeadership   rivercommon.TestSignal[struct{}] // notifies when elector resigns leadership
+	DeniedLeadership     testsignal.TestSignal[struct{}] // notifies when elector fails to gain leadership
+	GainedLeadership     testsignal.TestSignal[struct{}] // notifies when elector gains leadership
+	LostLeadership       testsignal.TestSignal[struct{}] // notifies when an elected leader loses leadership
+	MaintainedLeadership testsignal.TestSignal[struct{}] // notifies when elector maintains leadership
+	ResignedLeadership   testsignal.TestSignal[struct{}] // notifies when elector resigns leadership
 }
 
 func (ts *electorTestSignals) Init() {

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -24,7 +24,7 @@ const (
 
 // Test-only properties.
 type JobCleanerTestSignals struct {
-	DeletedBatch rivercommon.TestSignal[struct{}] // notifies when runOnce finishes a pass
+	DeletedBatch testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
 func (ts *JobCleanerTestSignals) Init() {

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -8,11 +8,11 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/workunit"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
@@ -30,8 +30,8 @@ type ClientRetryPolicy interface {
 
 // Test-only properties.
 type JobRescuerTestSignals struct {
-	FetchedBatch rivercommon.TestSignal[struct{}] // notifies when runOnce has fetched a batch of jobs
-	UpdatedBatch rivercommon.TestSignal[struct{}] // notifies when runOnce has updated rescued jobs from a batch
+	FetchedBatch testsignal.TestSignal[struct{}] // notifies when runOnce has fetched a batch of jobs
+	UpdatedBatch testsignal.TestSignal[struct{}] // notifies when runOnce has updated rescued jobs from a batch
 }
 
 func (ts *JobRescuerTestSignals) Init() {

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -22,8 +22,8 @@ const (
 
 // Test-only properties.
 type JobSchedulerTestSignals struct {
-	NotifiedQueues rivercommon.TestSignal[[]string] // notifies when queues are sent an insert notification
-	ScheduledBatch rivercommon.TestSignal[struct{}] // notifies when runOnce finishes a pass
+	NotifiedQueues testsignal.TestSignal[[]string] // notifies when queues are sent an insert notification
+	ScheduledBatch testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
 func (ts *JobSchedulerTestSignals) Init() {

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"github.com/riverqueue/river/internal/dbunique"
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/maputil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -22,10 +22,10 @@ var ErrNoJobToInsert = errors.New("a nil job was returned, nothing to insert")
 
 // Test-only properties.
 type PeriodicJobEnqueuerTestSignals struct {
-	EnteredLoop    rivercommon.TestSignal[struct{}] // notifies when the enqueuer finishes start up and enters its initial run loop
-	InsertedJobs   rivercommon.TestSignal[struct{}] // notifies when a batch of jobs is inserted
-	NotifiedQueues rivercommon.TestSignal[[]string] // notifies when queues are sent an insert notification
-	SkippedJob     rivercommon.TestSignal[struct{}] // notifies when a job is skipped because of nil JobInsertParams
+	EnteredLoop    testsignal.TestSignal[struct{}] // notifies when the enqueuer finishes start up and enters its initial run loop
+	InsertedJobs   testsignal.TestSignal[struct{}] // notifies when a batch of jobs is inserted
+	NotifiedQueues testsignal.TestSignal[[]string] // notifies when queues are sent an insert notification
+	SkippedJob     testsignal.TestSignal[struct{}] // notifies when a job is skipped because of nil JobInsertParams
 }
 
 func (ts *PeriodicJobEnqueuerTestSignals) Init() {

--- a/internal/maintenance/queue_cleaner.go
+++ b/internal/maintenance/queue_cleaner.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -23,7 +23,7 @@ const (
 
 // Test-only properties.
 type QueueCleanerTestSignals struct {
-	DeletedBatch rivercommon.TestSignal[struct{}] // notifies when runOnce finishes a pass
+	DeletedBatch testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
 func (ts *QueueCleanerTestSignals) Init() {

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/internal/dbunique"
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/riverinternaltest/sharedtx"
 	"github.com/riverqueue/river/riverdriver"
@@ -18,6 +17,7 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/startstoptest"
+	"github.com/riverqueue/river/rivershared/testsignal"
 )
 
 type testService struct {
@@ -55,8 +55,8 @@ func (s *testService) Start(ctx context.Context) error {
 }
 
 type testServiceTestSignals struct {
-	returning rivercommon.TestSignal[struct{}]
-	started   rivercommon.TestSignal[struct{}]
+	returning testsignal.TestSignal[struct{}]
+	started   testsignal.TestSignal[struct{}]
 }
 
 func (ts *testServiceTestSignals) Init() {

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -6,10 +6,10 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
 
@@ -22,7 +22,7 @@ var defaultIndexNames = []string{} //nolint:gochecknoglobals
 
 // Test-only properties.
 type ReindexerTestSignals struct {
-	Reindexed rivercommon.TestSignal[struct{}] // notifies when a run finishes executing reindexes for all indexes
+	Reindexed testsignal.TestSignal[struct{}] // notifies when a run finishes executing reindexes for all indexes
 }
 
 func (ts *ReindexerTestSignals) Init() {

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/maputil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 )
@@ -44,9 +44,9 @@ func (s *Subscription) Unlisten(ctx context.Context) {
 
 // Test-only properties.
 type notifierTestSignals struct {
-	BackoffError   rivercommon.TestSignal[error]    // non-cancellation error received by main run loop
-	ListeningBegin rivercommon.TestSignal[struct{}] // notifier has entered a listen loop
-	ListeningEnd   rivercommon.TestSignal[struct{}] // notifier has left a listen loop
+	BackoffError   testsignal.TestSignal[error]    // non-cancellation error received by main run loop
+	ListeningBegin testsignal.TestSignal[struct{}] // notifier has entered a listen loop
+	ListeningEnd   testsignal.TestSignal[struct{}] // notifier has left a listen loop
 }
 
 func (ts *notifierTestSignals) Init() {

--- a/producer.go
+++ b/producer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -27,12 +28,12 @@ const (
 
 // Test-only properties.
 type producerTestSignals struct {
-	DeletedExpiredQueueRecords rivercommon.TestSignal[struct{}] // notifies when the producer deletes expired queue records
-	Paused                     rivercommon.TestSignal[struct{}] // notifies when the producer is paused
-	PolledQueueConfig          rivercommon.TestSignal[struct{}] // notifies when the producer polls for queue settings
-	ReportedQueueStatus        rivercommon.TestSignal[struct{}] // notifies when the producer reports queue status
-	Resumed                    rivercommon.TestSignal[struct{}] // notifies when the producer is resumed
-	StartedExecutors           rivercommon.TestSignal[struct{}] // notifies when runOnce finishes a pass
+	DeletedExpiredQueueRecords testsignal.TestSignal[struct{}] // notifies when the producer deletes expired queue records
+	Paused                     testsignal.TestSignal[struct{}] // notifies when the producer is paused
+	PolledQueueConfig          testsignal.TestSignal[struct{}] // notifies when the producer polls for queue settings
+	ReportedQueueStatus        testsignal.TestSignal[struct{}] // notifies when the producer reports queue status
+	Resumed                    testsignal.TestSignal[struct{}] // notifies when the producer is resumed
+	StartedExecutors           testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
 func (ts *producerTestSignals) Init() {

--- a/rivershared/testsignal/test_signal.go
+++ b/rivershared/testsignal/test_signal.go
@@ -1,4 +1,4 @@
-package rivercommon
+package testsignal
 
 import (
 	"fmt"

--- a/rivershared/testsignal/test_signal_test.go
+++ b/rivershared/testsignal/test_signal_test.go
@@ -1,4 +1,4 @@
-package rivercommon
+package testsignal
 
 import (
 	"testing"


### PR DESCRIPTION
The `TestSignal` paradigm might not be perfect, but as I was writing a
test yesterday that had to involve a bespoke test channel involving many
lines of unsightly and somewhat brittle test-only code, I was reminded
that it's better than the alternative.

Here, move `TestSignal` into `rivershared` so that it can be used
outside of the main River project.