### PR TITLE
Prepare release v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.11.2] - 2024-08-08
+
 - Derive all internal contexts from user-provided `Client` context. This includes the job fetch context, notifier unlisten, and completer. [PR #514](https://github.com/riverqueue/river/pull/514).
 - Lowered the `go` directives in `go.mod` to Go 1.21, which River aims to support. A more modern version of Go is specified with the `toolchain` directive. This should provide more flexibility on the minimum required Go version for programs importing River. [PR #522](https://github.com/riverqueue/river/pull/522).
 

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -20,9 +20,9 @@ require (
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/lmittmann/tint v1.0.4
 	github.com/riverqueue/river v0.11.1
-	github.com/riverqueue/river/riverdriver v0.11.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.1
-	github.com/riverqueue/river/rivertype v0.11.1
+	github.com/riverqueue/river/riverdriver v0.11.2
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.2
+	github.com/riverqueue/river/rivertype v0.11.2
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 )
@@ -34,7 +34,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/rivershared v0.11.1 // indirect
+	github.com/riverqueue/river/rivershared v0.11.2 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,11 +18,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.1
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.1
-	github.com/riverqueue/river/rivershared v0.11.1
-	github.com/riverqueue/river/rivertype v0.11.1
+	github.com/riverqueue/river/riverdriver v0.11.2
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.2
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.2
+	github.com/riverqueue/river/rivershared v0.11.2
+	github.com/riverqueue/river/rivertype v0.11.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -6,4 +6,4 @@ toolchain go1.22.5
 
 replace github.com/riverqueue/river/rivertype => ../rivertype
 
-require github.com/riverqueue/river/rivertype v0.11.1
+require github.com/riverqueue/river/rivertype v0.11.2

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -12,9 +12,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.11.1
-	github.com/riverqueue/river/rivershared v0.11.1
-	github.com/riverqueue/river/rivertype v0.11.1
+	github.com/riverqueue/river/riverdriver v0.11.2
+	github.com/riverqueue/river/rivershared v0.11.2
+	github.com/riverqueue/river/rivertype v0.11.2
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -13,9 +13,9 @@ replace github.com/riverqueue/river/rivertype => ../../rivertype
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.1
-	github.com/riverqueue/river/rivershared v0.11.1
-	github.com/riverqueue/river/rivertype v0.11.1
+	github.com/riverqueue/river/riverdriver v0.11.2
+	github.com/riverqueue/river/rivershared v0.11.2
+	github.com/riverqueue/river/rivertype v0.11.2
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prepare release v0.11.2, containing #504 and #505. This will also
require a separate CLI release because of some minimum Go version
changes in all the project's `go.mod` files.