### PR TITLE
Upgrade to golangci-lint 1.60 + linting fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,7 +212,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.59
+      GOLANGCI_LINT_VERSION: v1.60
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.

--- a/internal/cmd/testdbman/main.go
+++ b/internal/cmd/testdbman/main.go
@@ -84,7 +84,7 @@ followed by "create".
 	ctx := context.Background()
 
 	if err := commandBundle.Exec(ctx, os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "failed: "+err.Error()+"\n")
+		fmt.Fprintf(os.Stderr, "failed: %s\n", err)
 		os.Exit(1)
 	}
 }
@@ -311,7 +311,7 @@ func (b *CommandBundle) Exec(ctx context.Context, args []string) error {
 	}
 
 	if commandUse == "" || commandUse == helpUse && len(args) < 1 {
-		fmt.Fprintf(b.out, b.printUsage(&flagSet)+"\n")
+		fmt.Fprintf(b.out, "%s\n", b.usage(&flagSet))
 		return nil
 	}
 
@@ -326,14 +326,14 @@ func (b *CommandBundle) Exec(ctx context.Context, args []string) error {
 	}
 
 	if help {
-		fmt.Fprintf(b.out, command.printUsage(b.use, &flagSet)+"\n")
+		fmt.Fprintf(b.out, "%s\n", command.printUsage(b.use, &flagSet))
 		return nil
 	}
 
 	return command.execFunc(ctx, b.out)
 }
 
-func (b *CommandBundle) printUsage(flagSet *flag.FlagSet) string {
+func (b *CommandBundle) usage(flagSet *flag.FlagSet) string {
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf(`

--- a/internal/dbunique/db_unique_test.go
+++ b/internal/dbunique/db_unique_test.go
@@ -98,7 +98,7 @@ func TestUniqueInserter_JobInsert(t *testing.T) {
 		// Sanity check, following assertion depends on this:
 		require.Nil(t, insertParams.ScheduledAt)
 
-		require.Greater(t, res.Job.ID, int64(0), "expected job ID to be set, got %d", res.Job.ID)
+		require.Positive(t, res.Job.ID, "expected job ID to be set, got %d", res.Job.ID)
 		require.JSONEq(t, string(insertParams.EncodedArgs), string(res.Job.EncodedArgs))
 		require.Equal(t, 0, res.Job.Attempt)
 		require.Nil(t, res.Job.AttemptedAt)

--- a/internal/leadership/elector_test.go
+++ b/internal/leadership/elector_test.go
@@ -138,7 +138,7 @@ func testElector[TElectorBundle any](
 
 	startElector := func(ctx context.Context, t *testing.T, elector *Elector) {
 		t.Helper()
-		t.Logf("Starting " + elector.config.ClientID)
+		t.Logf("Starting %s", elector.config.ClientID)
 		require.NoError(t, elector.Start(ctx))
 		t.Cleanup(elector.Stop)
 	}
@@ -226,7 +226,7 @@ func testElector[TElectorBundle any](
 
 		elector.testSignals.GainedLeadership.WaitOrTimeout()
 
-		t.Logf("Force resigning " + elector.config.ClientID)
+		t.Logf("Force resigning %s", elector.config.ClientID)
 
 		// Artificially force resign the elector and add a new leader record
 		// so that it can't be elected again.
@@ -279,7 +279,7 @@ func testElector[TElectorBundle any](
 
 			elector2.testSignals.DeniedLeadership.WaitOrTimeout()
 
-			t.Logf("Stopping " + elector1.config.ClientID)
+			t.Logf("Stopping %s", elector1.config.ClientID)
 			elector1.Stop()
 			elector1.testSignals.ResignedLeadership.WaitOrTimeout()
 
@@ -292,7 +292,7 @@ func testElector[TElectorBundle any](
 			t.Logf("Waiting for %s to gain leadership", elector2.config.ClientID)
 			elector2.testSignals.GainedLeadership.WaitOrTimeout()
 
-			t.Logf("Stopping " + elector2.config.ClientID)
+			t.Logf("Stopping %s", elector2.config.ClientID)
 			elector2.Stop()
 			elector2.testSignals.ResignedLeadership.WaitOrTimeout()
 		}

--- a/producer_test.go
+++ b/producer_test.go
@@ -356,7 +356,7 @@ func testProducer(t *testing.T, makeProducer func(ctx context.Context, t *testin
 		// written somewhat strangely.
 		findJob := func(kind string) *rivertype.JobRow {
 			index := slices.IndexFunc(updates, func(u jobcompleter.CompleterJobUpdated) bool { return u.Job.Kind == kind })
-			require.NotEqualf(t, -1, index, "Job update not found", "Job update not found for kind: %s", kind)
+			require.NotEqualf(t, -1, index, "Job update not found for kind: %s", kind)
 			return updates[index].Job
 		}
 

--- a/rivermigrate/river_migrate_test.go
+++ b/rivermigrate/river_migrate_test.go
@@ -739,21 +739,21 @@ func dbExecError(ctx context.Context, exec riverdriver.Executor, sql string) err
 func driverMigrationToInt(r *riverdriver.Migration) int { return r.Version }
 func migrationToInt(migration Migration) int            { return migration.Version }
 
-// Produces a sequence down to one. Max is included.
-func seqOneTo(max int) []int {
-	seq := make([]int, 0, max)
+// Produces a sequence down to one. UpperLimit is included.
+func seqOneTo(upperLimit int) []int {
+	seq := make([]int, 0, upperLimit)
 
-	for i := 1; i <= max; i++ {
+	for i := 1; i <= upperLimit; i++ {
 		seq = append(seq, i)
 	}
 
 	return seq
 }
 
-func seqDownTo(max, min int) []int {
-	seq := make([]int, 0, max-min+1)
+func seqDownTo(upperLimit, lowerLimit int) []int {
+	seq := make([]int, 0, upperLimit-lowerLimit+1)
 
-	for i := min; i <= max; i++ {
+	for i := lowerLimit; i <= upperLimit; i++ {
 		seq = append(seq, i)
 	}
 

--- a/rivershared/util/randutil/rand_util.go
+++ b/rivershared/util/randutil/rand_util.go
@@ -19,9 +19,9 @@ func NewCryptoSeededConcurrentSafeRand() *mathrand.Rand {
 	return mathrand.New(newCryptoSeededConcurrentSafeSource())
 }
 
-// IntBetween generates a random number in the range of [min, max).
-func IntBetween(rand *mathrand.Rand, min, max int) int {
-	return rand.Intn(max-min) + min
+// IntBetween generates a random number in the range of [lowerLimit, upperLimit).
+func IntBetween(rand *mathrand.Rand, lowerLimit, upperLimit int) int {
+	return rand.Intn(upperLimit-lowerLimit) + lowerLimit
 }
 
 func newCryptoSeededConcurrentSafeSource() mathrand.Source {

--- a/rivershared/util/randutil/rand_util_test.go
+++ b/rivershared/util/randutil/rand_util_test.go
@@ -34,16 +34,16 @@ func TestNewCryptoSeededConcurrentSafeRand(t *testing.T) {
 func TestIntBetween(t *testing.T) {
 	t.Parallel()
 
-	const min, max = 5, 8
+	const lowerLimit, upperLimit = 5, 8
 	rand := NewCryptoSeededConcurrentSafeRand()
 
 	// Not exactly a super exhaustive test, but choose a relatively small range,
 	// generate numbers and check they're within bounds, and run enough times
 	// that we'd expect an offender to be generated if one was likely to be.
-	for i := 0; i < int(max-min)*2; i++ {
-		n := IntBetween(rand, min, max)
-		require.GreaterOrEqual(t, n, min)
-		require.Less(t, n, max)
+	for i := 0; i < int(upperLimit-lowerLimit)*2; i++ {
+		n := IntBetween(rand, lowerLimit, upperLimit)
+		require.GreaterOrEqual(t, n, lowerLimit)
+		require.Less(t, n, upperLimit)
 	}
 }
 
@@ -68,8 +68,8 @@ func BenchmarkConcurrentSafeSource(b *testing.B) {
 }
 
 func BenchmarkCryptoSource(b *testing.B) {
-	intN := func(max int64) int64 {
-		nBig, err := cryptorand.Int(cryptorand.Reader, big.NewInt(max))
+	intN := func(upperLimit int64) int64 {
+		nBig, err := cryptorand.Int(cryptorand.Reader, big.NewInt(upperLimit))
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This is in preparation for an eventual upgrade to Go 1.23. Golangci-lint
1.60+ is required for 1.23 support, so here upgrade to 1.23 and fix some
new linting problems that fell out of the process.