### PR TITLE
Add Go 1.23 to build matrix + update toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
         go-version:
           - "1.21"
           - "1.22"
+          - "1.23"
         postgres-version: [14, 15, 16]
       fail-fast: false
     timeout-minutes: 5

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/river/cmd/river
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require (
 	github.com/jackc/pgx/v5 v5.6.0

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,3 +104,11 @@ If updates to River dependencies _are_ required, then a second phase of the rele
     ```
 
     The main `$VERSION` tag and `cmd/river/$VERSION` will point to different commits, and although a little odd, is tolerable.
+
+### Updating Go or toolchain versions in all `go.mod` files
+
+Modify `go.work` so it contains the new desired version in `go` and/or `toolchain` directives, then run `make update-mod-go` to have it reflect the new version(s) into all the workspace's `go.mod` files:
+
+```shell
+make update-mod-go
+```

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/river
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 use (
 	.

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -2,6 +2,6 @@ module github.com/riverqueue/river/riverdriver
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require github.com/riverqueue/river/rivertype v0.11.2

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/river/riverdriver/riverdatabasesql
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require (
 	github.com/lib/pq v1.10.9

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/river/riverdriver/riverpgxv5
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require (
 	github.com/jackc/pgx/v5 v5.5.0

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/river/rivershared
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/rivertype/go.mod
+++ b/rivertype/go.mod
@@ -2,7 +2,7 @@ module github.com/riverqueue/river/rivertype
 
 go 1.21
 
-toolchain go1.22.5
+toolchain go1.23.0
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
Add Go 1.23 to the build matrix and update toolchain in `go.work` and
all `go.mod` files. Add development instructions for how to use the new
`make update-mod-go` to do so in an automated way.

I didn't drop Go 1.21 support yet because I figure there isn't a hurry
in jettisoning it immediately, although, we'll have to see how the build
stability is with the expanded matrix.