### PR TITLE
Prepare release v0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] - 2024-08-19
+
+### Changed
+
+- Producer's logs are quieter unless jobs are actively being worked. [PR #529](https://github.com/riverqueue/river/pull/529).
+
+### Fixed
+
+- River CLI now accepts `postgresql://` URL schemes in addition to `postgres://`. [PR #532](https://github.com/riverqueue/river/pull/532).
+
 ## [0.11.2] - 2024-08-08
 
 ### Fixed

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/lmittmann/tint v1.0.4
-	github.com/riverqueue/river v0.11.2
-	github.com/riverqueue/river/riverdriver v0.11.2
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.2
-	github.com/riverqueue/river/rivertype v0.11.2
+	github.com/riverqueue/river v0.11.3
+	github.com/riverqueue/river/riverdriver v0.11.3
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.3
+	github.com/riverqueue/river/rivertype v0.11.3
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.2
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.2
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.2
-	github.com/riverqueue/river/rivershared v0.11.2
-	github.com/riverqueue/river/rivertype v0.11.2
+	github.com/riverqueue/river/riverdriver v0.11.3
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.3
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.3
+	github.com/riverqueue/river/rivershared v0.11.3
+	github.com/riverqueue/river/rivertype v0.11.3
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21
 
 toolchain go1.23.0
 
-require github.com/riverqueue/river/rivertype v0.11.2
+require github.com/riverqueue/river/rivertype v0.11.3

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -6,9 +6,9 @@ toolchain go1.23.0
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.11.2
-	github.com/riverqueue/river/rivershared v0.11.2
-	github.com/riverqueue/river/rivertype v0.11.2
+	github.com/riverqueue/river/riverdriver v0.11.3
+	github.com/riverqueue/river/rivershared v0.11.3
+	github.com/riverqueue/river/rivertype v0.11.3
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,9 +7,9 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.2
-	github.com/riverqueue/river/rivershared v0.11.2
-	github.com/riverqueue/river/rivertype v0.11.2
+	github.com/riverqueue/river/riverdriver v0.11.3
+	github.com/riverqueue/river/rivershared v0.11.3
+	github.com/riverqueue/river/rivertype v0.11.3
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prepare release v0.11.3, which includes largely #532, which is a
legitimate bug in the CLI.

This will be the first time I try for a release under workspaces (#528),
so it includes a simultaneous release of the CLI and the rest of the
project, although I'm expecting the build to fail due to lack of
`replace` statements.