### PR TITLE
Break `BaseService` functions into `serviceutil`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,9 +59,6 @@ jobs:
       - name: Display Go version
         run: go version
 
-      - name: Install dependencies
-        run: go get -t ./...
-
       - name: Set up test DBs
         run: go run ./internal/cmd/testdbman create
         env:

--- a/client_test.go
+++ b/client_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -838,7 +840,7 @@ func Test_Client_Stop(t *testing.T) {
 					require.NoError(t, err)
 
 					// Sleep a brief time between inserts.
-					client.baseService.CancellableSleepRandomBetween(ctx, 1*time.Microsecond, 10*time.Millisecond)
+					serviceutil.CancellableSleep(ctx, randutil.DurationBetween(client.baseService.Rand, 1*time.Microsecond, 10*time.Millisecond))
 				}
 			}()
 		}

--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -534,11 +535,11 @@ func withRetries[T any](logCtx context.Context, baseService *baseservice.BaseSer
 			}
 
 			lastErr = err
-			sleepDuration := baseService.ExponentialBackoff(attempt, baseservice.MaxAttemptsBeforeResetDefault)
+			sleepDuration := serviceutil.ExponentialBackoff(baseService.Rand, attempt, serviceutil.MaxAttemptsBeforeResetDefault)
 			baseService.Logger.ErrorContext(logCtx, baseService.Name+": Completer error (will retry after sleep)",
 				"attempt", attempt, "err", err, "sleep_duration", sleepDuration, "timeout", timeout)
 			if !disableSleep {
-				baseService.CancellableSleep(logCtx, sleepDuration)
+				serviceutil.CancellableSleep(logCtx, sleepDuration)
 			}
 			continue
 		}

--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -14,6 +14,8 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
 
@@ -200,9 +202,9 @@ func (e *Elector) attemptGainLeadershipLoop(ctx context.Context) error {
 			}
 
 			numErrors++
-			sleepDuration := e.ExponentialBackoff(numErrors, baseservice.MaxAttemptsBeforeResetDefault)
+			sleepDuration := serviceutil.ExponentialBackoff(e.Rand, numErrors, serviceutil.MaxAttemptsBeforeResetDefault)
 			e.Logger.ErrorContext(ctx, e.Name+": Error attempting to elect", "client_id", e.config.ClientID, "err", err, "num_errors", numErrors, "sleep_duration", sleepDuration)
-			e.CancellableSleep(ctx, sleepDuration)
+			serviceutil.CancellableSleep(ctx, sleepDuration)
 			continue
 		}
 		if elected {
@@ -219,7 +221,7 @@ func (e *Elector) attemptGainLeadershipLoop(ctx context.Context) error {
 		// of resignations. May want to make this reusable & cancel it when retrying?
 		// We may also want to consider a specialized ticker utility that can tick
 		// within a random range.
-		case <-e.CancellableSleepRandomBetweenC(ctx, e.config.ElectInterval, e.config.ElectInterval+e.config.ElectIntervalJitter):
+		case <-serviceutil.CancellableSleepC(ctx, randutil.DurationBetween(e.Rand, e.config.ElectInterval, e.config.ElectInterval+e.config.ElectIntervalJitter)):
 			if ctx.Err() != nil { // context done
 				return ctx.Err()
 			}
@@ -227,7 +229,7 @@ func (e *Elector) attemptGainLeadershipLoop(ctx context.Context) error {
 		case <-e.leadershipNotificationChan:
 			// Somebody just resigned, try to win the next election after a very
 			// short random interval (to prevent all clients from bidding at once).
-			e.CancellableSleepRandomBetween(ctx, 0, 50*time.Millisecond)
+			serviceutil.CancellableSleep(ctx, randutil.DurationBetween(e.Rand, 0, 50*time.Millisecond))
 		}
 	}
 }
@@ -340,10 +342,10 @@ func (e *Elector) keepLeadershipLoop(ctx context.Context) error {
 				return err
 			}
 
-			sleepDuration := e.ExponentialBackoff(numErrors, baseservice.MaxAttemptsBeforeResetDefault)
+			sleepDuration := serviceutil.ExponentialBackoff(e.Rand, numErrors, serviceutil.MaxAttemptsBeforeResetDefault)
 			e.Logger.Error(e.Name+": Error attempting reelection",
 				"client_id", e.config.ClientID, "err", err, "sleep_duration", sleepDuration)
-			e.CancellableSleep(ctx, sleepDuration)
+			serviceutil.CancellableSleep(ctx, sleepDuration)
 			continue
 		}
 		if !reelected {
@@ -381,10 +383,10 @@ func (e *Elector) attemptResignLoop(ctx context.Context) {
 		if err := e.attemptResign(ctx, attempt); err != nil {
 			e.Logger.ErrorContext(ctx, e.Name+": Error attempting to resign", "attempt", attempt, "client_id", e.config.ClientID, "err", err)
 
-			sleepDuration := e.ExponentialBackoff(attempt, baseservice.MaxAttemptsBeforeResetDefault)
+			sleepDuration := serviceutil.ExponentialBackoff(e.Rand, attempt, serviceutil.MaxAttemptsBeforeResetDefault)
 			e.Logger.ErrorContext(ctx, e.Name+": Error attempting to resign",
 				"client_id", e.config.ClientID, "err", err, "num_errors", attempt, "sleep_duration", sleepDuration)
-			e.CancellableSleep(ctx, sleepDuration)
+			serviceutil.CancellableSleep(ctx, sleepDuration)
 
 			continue
 		}

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -11,6 +11,8 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -176,7 +178,7 @@ func (s *JobCleaner) runOnce(ctx context.Context) (*jobCleanerRunOnceResult, err
 			slog.Int("num_jobs_deleted", numDeleted),
 		)
 
-		s.CancellableSleepRandomBetween(ctx, BatchBackoffMin, BatchBackoffMax)
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -14,6 +14,8 @@ import (
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 	"github.com/riverqueue/river/rivertype"
@@ -234,7 +236,7 @@ func (s *JobRescuer) runOnce(ctx context.Context) (*rescuerRunOnceResult, error)
 			break
 		}
 
-		s.CancellableSleepRandomBetween(ctx, BatchBackoffMin, BatchBackoffMax)
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -194,7 +196,7 @@ func (s *JobScheduler) runOnce(ctx context.Context) (*schedulerRunOnceResult, er
 			break
 		}
 
-		s.CancellableSleepRandomBetween(ctx, BatchBackoffMin, BatchBackoffMax)
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/queue_cleaner.go
+++ b/internal/maintenance/queue_cleaner.go
@@ -12,6 +12,8 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -152,7 +154,7 @@ func (s *QueueCleaner) runOnce(ctx context.Context) (*queueCleanerRunOnceResult,
 			break
 		}
 
-		s.CancellableSleepRandomBetween(ctx, BatchBackoffMin, BatchBackoffMax)
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/queue_maintainer.go
+++ b/internal/maintenance/queue_maintainer.go
@@ -8,6 +8,8 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/util/maputil"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 )
 
 const (
@@ -116,7 +118,7 @@ func (s *queueMaintainerServiceBase) StaggerStart(ctx context.Context) {
 		return
 	}
 
-	s.CancellableSleepRandomBetween(ctx, 0*time.Second, 1*time.Second)
+	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, 0*time.Second, 1*time.Second))
 }
 
 // StaggerStartupDisable sets whether the short staggered sleep on start up

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -13,6 +13,7 @@ import (
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/maputil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 )
 
@@ -126,12 +127,12 @@ func (n *Notifier) Start(ctx context.Context) error {
 					break
 				}
 
-				sleepDuration := n.ExponentialBackoff(attempt, baseservice.MaxAttemptsBeforeResetDefault)
+				sleepDuration := serviceutil.ExponentialBackoff(n.Rand, attempt, serviceutil.MaxAttemptsBeforeResetDefault)
 				n.Logger.ErrorContext(ctx, n.Name+": Error running listener (will attempt reconnect after backoff)",
 					"attempt", attempt, "err", err, "sleep_duration", sleepDuration)
 				n.testSignals.BackoffError.Signal(err)
 				if !n.disableSleep {
-					n.CancellableSleep(ctx, sleepDuration)
+					serviceutil.CancellableSleep(ctx, sleepDuration)
 				}
 			}
 		}

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/util/maputil"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 )
 
 func TestNotifier(t *testing.T) {
@@ -437,7 +439,7 @@ func TestNotifier(t *testing.T) {
 					require.NoError(t, err)
 
 					// Pause a random brief amount of time.
-					notifier.BaseService.CancellableSleepRandomBetween(ctx, 15*time.Millisecond, 50*time.Millisecond)
+					serviceutil.CancellableSleep(ctx, randutil.DurationBetween(notifier.Rand, 15*time.Millisecond, 50*time.Millisecond))
 
 					sub.Unlisten(ctx)
 				}

--- a/producer.go
+++ b/producer.go
@@ -18,6 +18,8 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -647,7 +649,7 @@ func (p *producer) fetchQueueSettings(ctx context.Context) (*rivertype.Queue, er
 }
 
 func (p *producer) reportQueueStatusLoop(ctx context.Context) {
-	p.CancellableSleepRandomBetween(ctx, 0, time.Second)
+	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(p.Rand, 0, time.Second))
 	reportTicker := time.NewTicker(p.config.QueueReportInterval)
 	for {
 		select {

--- a/rivershared/baseservice/base_service_test.go
+++ b/rivershared/baseservice/base_service_test.go
@@ -1,7 +1,6 @@
 package baseservice
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -21,120 +20,6 @@ func TestInit(t *testing.T) {
 	require.NotNil(t, myService.Logger)
 	require.Equal(t, "MyService", myService.Name)
 	require.WithinDuration(t, time.Now().UTC(), myService.Time.NowUTC(), 2*time.Second)
-}
-
-func TestBaseService_CancellableSleep(t *testing.T) {
-	t.Parallel()
-
-	testCancellableSleep := func(t *testing.T, startSleepFunc func(ctx context.Context, myService *MyService) <-chan struct{}) {
-		t.Helper()
-
-		ctx := context.Background()
-
-		archetype := archetype()
-		myService := Init(archetype, &MyService{})
-
-		ctx, cancel := context.WithCancel(ctx)
-		t.Cleanup(cancel)
-
-		sleepDone := startSleepFunc(ctx, myService)
-
-		// Wait a very nominal amount of time just to make sure that some sleep is
-		// actually happening.
-		select {
-		case <-sleepDone:
-			require.FailNow(t, "Sleep returned sooner than expected")
-		case <-time.After(50 * time.Millisecond):
-		}
-
-		cancel()
-
-		select {
-		case <-sleepDone:
-		case <-time.After(50 * time.Millisecond):
-			require.FailNow(t, "Timed out waiting for sleep to finish after cancel")
-		}
-	}
-
-	// Starts sleep for sleep functions that don't return a channel, returning a
-	// channel that's closed when sleep finishes.
-	startSleep := func(sleepFunc func()) <-chan struct{} {
-		sleepDone := make(chan struct{})
-		go func() {
-			defer close(sleepDone)
-			sleepFunc()
-		}()
-		return sleepDone
-	}
-
-	t.Run("CancellableSleep", func(t *testing.T) {
-		t.Parallel()
-
-		testCancellableSleep(t, func(ctx context.Context, myService *MyService) <-chan struct{} {
-			return startSleep(func() {
-				myService.CancellableSleep(ctx, 5*time.Second)
-			})
-		})
-	})
-
-	t.Run("CancellableSleepC", func(t *testing.T) {
-		t.Parallel()
-
-		testCancellableSleep(t, func(ctx context.Context, myService *MyService) <-chan struct{} {
-			return myService.CancellableSleepC(ctx, 5*time.Second)
-		})
-	})
-
-	t.Run("CancellableSleepRandomBetween", func(t *testing.T) {
-		t.Parallel()
-
-		testCancellableSleep(t, func(ctx context.Context, myService *MyService) <-chan struct{} {
-			return startSleep(func() {
-				myService.CancellableSleepRandomBetween(ctx, 5*time.Second, 10*time.Second)
-			})
-		})
-	})
-
-	t.Run("CancellableSleepRandomBetweenC", func(t *testing.T) {
-		t.Parallel()
-
-		testCancellableSleep(t, func(ctx context.Context, myService *MyService) <-chan struct{} {
-			return myService.CancellableSleepRandomBetweenC(ctx, 5*time.Second, 10*time.Second)
-		})
-	})
-}
-
-func TestBaseService_ExponentialBackoff(t *testing.T) {
-	t.Parallel()
-
-	archetype := archetype()
-	myService := Init(archetype, &MyService{})
-
-	require.InDelta(t, 1.0, myService.ExponentialBackoff(1, MaxAttemptsBeforeResetDefault).Seconds(), 1.0*0.1)
-	require.InDelta(t, 2.0, myService.ExponentialBackoff(2, MaxAttemptsBeforeResetDefault).Seconds(), 2.0*0.1)
-	require.InDelta(t, 4.0, myService.ExponentialBackoff(3, MaxAttemptsBeforeResetDefault).Seconds(), 4.0*0.1)
-	require.InDelta(t, 8.0, myService.ExponentialBackoff(4, MaxAttemptsBeforeResetDefault).Seconds(), 8.0*0.1)
-	require.InDelta(t, 16.0, myService.ExponentialBackoff(5, MaxAttemptsBeforeResetDefault).Seconds(), 16.0*0.1)
-	require.InDelta(t, 32.0, myService.ExponentialBackoff(6, MaxAttemptsBeforeResetDefault).Seconds(), 32.0*0.1)
-}
-
-func TestBaseService_exponentialBackoffSecondsWithoutJitter(t *testing.T) {
-	t.Parallel()
-
-	archetype := archetype()
-	myService := Init(archetype, &MyService{})
-
-	require.Equal(t, 1, int(myService.exponentialBackoffSecondsWithoutJitter(1, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 2, int(myService.exponentialBackoffSecondsWithoutJitter(2, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 4, int(myService.exponentialBackoffSecondsWithoutJitter(3, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 8, int(myService.exponentialBackoffSecondsWithoutJitter(4, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 16, int(myService.exponentialBackoffSecondsWithoutJitter(5, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 32, int(myService.exponentialBackoffSecondsWithoutJitter(6, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 64, int(myService.exponentialBackoffSecondsWithoutJitter(7, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 128, int(myService.exponentialBackoffSecondsWithoutJitter(8, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 256, int(myService.exponentialBackoffSecondsWithoutJitter(9, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 512, int(myService.exponentialBackoffSecondsWithoutJitter(10, MaxAttemptsBeforeResetDefault)))
-	require.Equal(t, 1, int(myService.exponentialBackoffSecondsWithoutJitter(11, MaxAttemptsBeforeResetDefault))) // resets
 }
 
 type MyService struct {

--- a/rivershared/util/randutil/rand_util.go
+++ b/rivershared/util/randutil/rand_util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	mathrand "math/rand"
 	"sync"
+	"time"
 )
 
 // NewCryptoSeededConcurrentSafeSource generates a new pseudo-random source
@@ -19,7 +20,18 @@ func NewCryptoSeededConcurrentSafeRand() *mathrand.Rand {
 	return mathrand.New(newCryptoSeededConcurrentSafeSource())
 }
 
+// DurationBetween generates a random duraiton in the range of [lowerLimit, upperLimit).
+//
+// TODO: When we drop Go 1.21 support, switch to `math/rand/v2` and kill the
+// `rand.Rand` argument.
+func DurationBetween(rand *mathrand.Rand, lowerLimit, upperLimit time.Duration) time.Duration {
+	return time.Duration(IntBetween(rand, int(lowerLimit), int(upperLimit)))
+}
+
 // IntBetween generates a random number in the range of [lowerLimit, upperLimit).
+//
+// TODO: When we drop Go 1.21 support, switch to `math/rand/v2` and kill the
+// `rand.Rand` argument.
 func IntBetween(rand *mathrand.Rand, lowerLimit, upperLimit int) int {
 	return rand.Intn(upperLimit-lowerLimit) + lowerLimit
 }

--- a/rivershared/util/randutil/rand_util_test.go
+++ b/rivershared/util/randutil/rand_util_test.go
@@ -6,6 +6,7 @@ import (
 	mathrand "math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +30,22 @@ func TestNewCryptoSeededConcurrentSafeRand(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestDurationBetween(t *testing.T) {
+	t.Parallel()
+
+	const lowerLimit, upperLimit = 5 * time.Second, 8 * time.Second
+	rand := NewCryptoSeededConcurrentSafeRand()
+
+	// Not exactly a super exhaustive test, but choose a relatively small range,
+	// generate numbers and check they're within bounds, and run enough times
+	// that we'd expect an offender to be generated if one was likely to be.
+	for i := 0; i < int(upperLimit/time.Second-lowerLimit/time.Second)*2; i++ {
+		n := DurationBetween(rand, lowerLimit, upperLimit)
+		require.GreaterOrEqual(t, n, lowerLimit)
+		require.Less(t, n, upperLimit)
+	}
 }
 
 func TestIntBetween(t *testing.T) {

--- a/rivershared/util/serviceutil/service_util.go
+++ b/rivershared/util/serviceutil/service_util.go
@@ -1,0 +1,78 @@
+package serviceutil
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/riverqueue/river/rivershared/util/timeutil"
+)
+
+// CancellableSleep sleeps for the given duration, but returns early if context
+// has been cancelled.
+func CancellableSleep(ctx context.Context, sleepDuration time.Duration) {
+	timer := time.NewTimer(sleepDuration)
+
+	select {
+	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
+	case <-timer.C:
+	}
+}
+
+// CancellableSleep sleeps for the given duration, but returns early if context
+// has been cancelled.
+//
+// This variant returns a channel that should be waited on and which wll be
+// closed when either the sleep or context is done.
+func CancellableSleepC(ctx context.Context, sleepDuration time.Duration) <-chan struct{} {
+	doneChan := make(chan struct{})
+
+	go func() {
+		defer close(doneChan)
+		CancellableSleep(ctx, sleepDuration)
+	}()
+
+	return doneChan
+}
+
+// MaxAttemptsBeforeResetDefault is the number of attempts during exponential
+// backoff after which attempts is reset so that sleep durations aren't flung
+// into a ridiculously distant future. This constant is typically injected into
+// the CancellableSleepExponentialBackoff function. It could technically take
+// another value instead, but shouldn't unless there's a good reason to do so.
+const MaxAttemptsBeforeResetDefault = 10
+
+// ExponentialBackoff returns a duration for a reasonable exponential backoff
+// interval for a service based on the given attempt number, which can then be
+// fed into CancellableSleep to perform the sleep. Uses a 2**N second algorithm,
+// +/- 10% random jitter. Sleep is cancelled if the given context is cancelled.
+//
+// Attempt should start at one for the first backoff/failure.
+//
+// TODO: When we drop Go 1.21 support, switch to `math/rand/v2` and kill the
+// `rand.Rand` argument.
+func ExponentialBackoff(rand *rand.Rand, attempt, maxAttemptsBeforeReset int) time.Duration {
+	retrySeconds := exponentialBackoffSecondsWithoutJitter(attempt, maxAttemptsBeforeReset)
+
+	// Jitter number of seconds +/- 10%.
+	retrySeconds += retrySeconds * (rand.Float64()*0.2 - 0.1)
+
+	return timeutil.SecondsAsDuration(retrySeconds)
+}
+
+func exponentialBackoffSecondsWithoutJitter(attempt, maxAttemptsBeforeReset int) float64 {
+	// It's easier for callers and more intuitive if attempt starts at one, but
+	// subtract one before sending it the exponent so we start at only one
+	// second of sleep instead of two.
+	attempt--
+
+	// We use a different exponential backoff algorithm here compared to the
+	// default retry policy (2**N versus N**4) because it results in more
+	// retries sooner. When it comes to exponential backoffs in services we
+	// never want to sleep for hours/days, unlike with failed jobs.
+	return math.Pow(2, float64(attempt%maxAttemptsBeforeReset))
+}

--- a/rivershared/util/serviceutil/service_util_test.go
+++ b/rivershared/util/serviceutil/service_util_test.go
@@ -1,0 +1,100 @@
+package serviceutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/rivershared/util/randutil"
+)
+
+func TestCancellableSleep(t *testing.T) {
+	t.Parallel()
+
+	testCancellableSleep := func(t *testing.T, startSleepFunc func(ctx context.Context) <-chan struct{}) {
+		t.Helper()
+
+		ctx := context.Background()
+
+		ctx, cancel := context.WithCancel(ctx)
+		t.Cleanup(cancel)
+
+		sleepDone := startSleepFunc(ctx)
+
+		// Wait a very nominal amount of time just to make sure that some sleep is
+		// actually happening.
+		select {
+		case <-sleepDone:
+			require.FailNow(t, "Sleep returned sooner than expected")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		cancel()
+
+		select {
+		case <-sleepDone:
+		case <-time.After(50 * time.Millisecond):
+			require.FailNow(t, "Timed out waiting for sleep to finish after cancel")
+		}
+	}
+
+	// Starts sleep for sleep functions that don't return a channel, returning a
+	// channel that's closed when sleep finishes.
+	startSleep := func(sleepFunc func()) <-chan struct{} {
+		sleepDone := make(chan struct{})
+		go func() {
+			defer close(sleepDone)
+			sleepFunc()
+		}()
+		return sleepDone
+	}
+
+	t.Run("CancellableSleep", func(t *testing.T) {
+		t.Parallel()
+
+		testCancellableSleep(t, func(ctx context.Context) <-chan struct{} {
+			return startSleep(func() {
+				CancellableSleep(ctx, 5*time.Second)
+			})
+		})
+	})
+
+	t.Run("CancellableSleepC", func(t *testing.T) {
+		t.Parallel()
+
+		testCancellableSleep(t, func(ctx context.Context) <-chan struct{} {
+			return CancellableSleepC(ctx, 5*time.Second)
+		})
+	})
+}
+
+func TestExponentialBackoff(t *testing.T) {
+	t.Parallel()
+
+	rand := randutil.NewCryptoSeededConcurrentSafeRand()
+
+	require.InDelta(t, 1.0, ExponentialBackoff(rand, 1, MaxAttemptsBeforeResetDefault).Seconds(), 1.0*0.1)
+	require.InDelta(t, 2.0, ExponentialBackoff(rand, 2, MaxAttemptsBeforeResetDefault).Seconds(), 2.0*0.1)
+	require.InDelta(t, 4.0, ExponentialBackoff(rand, 3, MaxAttemptsBeforeResetDefault).Seconds(), 4.0*0.1)
+	require.InDelta(t, 8.0, ExponentialBackoff(rand, 4, MaxAttemptsBeforeResetDefault).Seconds(), 8.0*0.1)
+	require.InDelta(t, 16.0, ExponentialBackoff(rand, 5, MaxAttemptsBeforeResetDefault).Seconds(), 16.0*0.1)
+	require.InDelta(t, 32.0, ExponentialBackoff(rand, 6, MaxAttemptsBeforeResetDefault).Seconds(), 32.0*0.1)
+}
+
+func TestExponentialBackoffSecondsWithoutJitter(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 1, int(exponentialBackoffSecondsWithoutJitter(1, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 2, int(exponentialBackoffSecondsWithoutJitter(2, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 4, int(exponentialBackoffSecondsWithoutJitter(3, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 8, int(exponentialBackoffSecondsWithoutJitter(4, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 16, int(exponentialBackoffSecondsWithoutJitter(5, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 32, int(exponentialBackoffSecondsWithoutJitter(6, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 64, int(exponentialBackoffSecondsWithoutJitter(7, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 128, int(exponentialBackoffSecondsWithoutJitter(8, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 256, int(exponentialBackoffSecondsWithoutJitter(9, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 512, int(exponentialBackoffSecondsWithoutJitter(10, MaxAttemptsBeforeResetDefault)))
+	require.Equal(t, 1, int(exponentialBackoffSecondsWithoutJitter(11, MaxAttemptsBeforeResetDefault))) // resets
+}


### PR DESCRIPTION
I was going through trying to refactor the demo project to use
`rivershared`, and while doing so, noticed that it'd broken out some
of the `BaseService` functions like `CancellableSleep` into a new
package so that they could be used without an available `BaseService`.

Looking over this API again, there's no good reason for functions like
`CancellableSleep` and `ExponentialBackoff` to be tied so tight to
`BaseService`. The reason they are is that `BaseService` provides a
random source that both can conveniently use, but that can be moved to a
function argument instead.

The reason that `BaseService` has a random source is to avoid the old
`math/rand` seeding problem. A single random source is initialized and
seeding securely once, then placed onto an archetype that's inherited
by all `BaseService` instances.

Soon, even that can go away. One of the biggest things fixed by Go
1.22's `math/rand/v2` is that it's no longer necessary to seed the top
level functions. Once we drop support for Go 1.21, we'll be able to
simplify this code dramatically by dropping `BaseService.Rand` and the
random source arguments from functions like `ExponentialBackoff` in
favor of just using top level `math/rand/v2` functions.

I also drop the variant `CancellableSleepBetween` in favor of having
callers use `CancellableSleep` combined with `randutil.DurationBetween`,
a new random helper similar to `IntBetween`.

With all this in, we'll be able to fully jettison all utilities from the
demo project in favor of going all in with `rivershared`'s equivalents.