### PR TITLE
Add CLI version subcommand and flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,10 @@ jobs:
         run: river validate --database-url $DATABASE_URL
         shell: bash
 
+      - name: river version
+        run: river version
+        shell: bash
+
       - name: river bench
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
@@ -214,7 +218,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v1.60
+      GOLANGCI_LINT_VERSION: v1.60.1
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- A new `river migrate-list` command is available which lists available migrations and which version a target database is migrated to. [PR #534](https://github.com/riverqueue/river/pull/534).
+- `river version` or `river --version` now prints River version information. [PR #537](https://github.com/riverqueue/river/pull/537).
+
 ## [0.11.4] - 2024-08-20
 
 ### Fixed

--- a/cmd/river/main.go
+++ b/cmd/river/main.go
@@ -18,7 +18,10 @@ func (p *DriverProcurer) ProcurePgxV5(pool *pgxpool.Pool) riverdriver.Driver[pgx
 }
 
 func main() {
-	cli := rivercli.NewCLI(&DriverProcurer{})
+	cli := rivercli.NewCLI(&rivercli.Config{
+		DriverProcurer: &DriverProcurer{},
+		Name:           "River",
+	})
 
 	if err := cli.BaseCommandSet().Execute(); err != nil {
 		// Cobra will already print an error on problems like an unknown command

--- a/cmd/river/rivercli/command.go
+++ b/cmd/river/rivercli/command.go
@@ -73,6 +73,7 @@ type RunCommandBundle struct {
 	DatabaseURL    *string
 	DriverProcurer DriverProcurer
 	Logger         *slog.Logger
+	OutStd         io.Writer
 }
 
 // RunCommand bootstraps and runs a River CLI subcommand.
@@ -85,7 +86,7 @@ func RunCommand[TOpts CommandOpts](ctx context.Context, bundle *RunCommandBundle
 		commandBase := &CommandBase{
 			DriverProcurer: bundle.DriverProcurer,
 			Logger:         bundle.Logger,
-			Out:            os.Stdout,
+			Out:            bundle.OutStd,
 		}
 
 		switch {
@@ -124,7 +125,7 @@ func RunCommand[TOpts CommandOpts](ctx context.Context, bundle *RunCommandBundle
 
 	ok, err := procureAndRun()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed: %s\n", err)
+		fmt.Fprintf(os.Stdout, "failed: %s\n", err)
 	}
 	if err != nil || !ok {
 		os.Exit(1)


### PR DESCRIPTION
I was trying to help which River CLI I had installed and realized
there's no easy way to know this currently because it can't currently
reveal its version information in any built-in way.

Here, add a `river version` subcommand that prints the version of the Go
module it's distributed as, along with the version of Go used to build
it, making accessing version information easy.

I also added support for a `river --version` flag. There's no common
standard on whether version should be revealed by subcommand or flag,
and since `--version`'s (unlike `-v`) never going to be used for
anything else, we may as well be permissable in what we accept.

I also add a basic framework for a CLI "integration" test suite that
allows CLI commands to be tested from the level of the Cobra command,
which is useful for checking flags and such. It has the downside in that
there's no way to inject a test transaction into it, so it's not always
appropriate for use right now.