### PR TITLE
Update indirect dependencies from `update-mod-version` script

### DIFF
--- a/rivershared/cmd/update-mod-version/main.go
+++ b/rivershared/cmd/update-mod-version/main.go
@@ -75,7 +75,7 @@ func parseAndUpdateGoModFile(filename, version string) (bool, error) {
 	fmt.Printf("%s\n", filename)
 
 	for _, require := range modFile.Require {
-		if require.Indirect || !strings.HasPrefix(require.Mod.Path, "github.com/riverqueue/river") {
+		if !strings.HasPrefix(require.Mod.Path, "github.com/riverqueue/river") {
 			continue
 		}
 

--- a/rivershared/cmd/update-mod-version/main_test.go
+++ b/rivershared/cmd/update-mod-version/main_test.go
@@ -20,6 +20,10 @@ require (
 	github.com/riverqueue/river/riverdriver v0.0.0-00010101000000-000000000000
 	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.0.0-00010101000000-000000000000
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.0.12
+)
+
+require (
+	github.com/riverqueue/river/rivershared v0.0.12 // indirect
 )`
 
 func TestParseAndUpdateGoModFile(t *testing.T) {
@@ -60,7 +64,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 
 		versions := make([]module.Version, 0, len(modFile.Require))
 		for _, require := range modFile.Require {
-			if require.Indirect || !strings.HasPrefix(require.Mod.Path, "github.com/riverqueue/river") {
+			if !strings.HasPrefix(require.Mod.Path, "github.com/riverqueue/river") {
 				continue
 			}
 
@@ -71,6 +75,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 			{Path: "github.com/riverqueue/river/riverdriver", Version: "v0.0.13"},
 			{Path: "github.com/riverqueue/river/riverdriver/riverdatabasesql", Version: "v0.0.13"},
 			{Path: "github.com/riverqueue/river/riverdriver/riverpgxv5", Version: "v0.0.13"},
+			{Path: "github.com/riverqueue/river/rivershared", Version: "v0.0.13"},
 		}, versions)
 
 		// Running again is allowed and should be idempontent. This time it'll


### PR DESCRIPTION
This is driven by [1] and the same bug we'd noticed in another project
previously too. Until now, `update-mod-version` hadn't been updating
versions on indirect dependencies, and `rivershared` in the CLI had been
indirect, thereby causing it to try and resolve v0.11.2 instead of
v0.11.3.

Here, update the script so that indirect dependencies are updated as
well.

[1] https://github.com/riverqueue/river/issues/538