### PR TITLE
Bump `rivershared` to v0.11.3 in the CLI

### DIFF
--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/rivershared v0.11.2 // indirect
+	github.com/riverqueue/river/rivershared v0.11.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect


### PR DESCRIPTION
Related to #538, bump `rivershared` to v0.11.3 in the CLI. Instead of
cutting a brand new release here, I think what we can probably do is
swap the CLI's release timestamp with a new one with the `rivershared`
dependency fixed.

There is a chance that that doesn't work because the Go sum database
will prevent a change in checksum. If that's the case, we'll have to
roll forward to v0.11.4 instead.