### PR TITLE
Prepare release v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [0.11.4] - 2024-08-20
 
-- A new `river migrate-list` command is available which lists available migrations and which version a target database is migrated to. [PR #534](https://github.com/riverqueue/river/pull/534).
+### Fixed
+
+- Fixed release script that caused CLI to become uninstallable because its reference to `rivershared` wasn't updated. [PR #541](https://github.com/riverqueue/river/pull/541).
 
 ## [0.11.3] - 2024-08-19
 

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/lmittmann/tint v1.0.4
-	github.com/riverqueue/river v0.11.3
-	github.com/riverqueue/river/riverdriver v0.11.3
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.3
-	github.com/riverqueue/river/rivertype v0.11.3
+	github.com/riverqueue/river v0.11.4
+	github.com/riverqueue/river/riverdriver v0.11.4
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.4
+	github.com/riverqueue/river/rivertype v0.11.4
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 )
@@ -22,7 +22,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/rivershared v0.11.3 // indirect
+	github.com/riverqueue/river/rivershared v0.11.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.3
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.3
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.3
-	github.com/riverqueue/river/rivershared v0.11.3
-	github.com/riverqueue/river/rivertype v0.11.3
+	github.com/riverqueue/river/riverdriver v0.11.4
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.11.4
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.11.4
+	github.com/riverqueue/river/rivershared v0.11.4
+	github.com/riverqueue/river/rivertype v0.11.4
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21
 
 toolchain go1.23.0
 
-require github.com/riverqueue/river/rivertype v0.11.3
+require github.com/riverqueue/river/rivertype v0.11.4

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -6,9 +6,9 @@ toolchain go1.23.0
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.11.3
-	github.com/riverqueue/river/rivershared v0.11.3
-	github.com/riverqueue/river/rivertype v0.11.3
+	github.com/riverqueue/river/riverdriver v0.11.4
+	github.com/riverqueue/river/rivershared v0.11.4
+	github.com/riverqueue/river/rivertype v0.11.4
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,9 +7,9 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.11.3
-	github.com/riverqueue/river/rivershared v0.11.3
-	github.com/riverqueue/river/rivertype v0.11.3
+	github.com/riverqueue/river/riverdriver v0.11.4
+	github.com/riverqueue/river/rivershared v0.11.4
+	github.com/riverqueue/river/rivertype v0.11.4
 	github.com/stretchr/testify v1.9.0
 )
 


### PR DESCRIPTION
Prepare release v0.11.4 to fix the bad release in v0.11.3 that was
causing the CLI to become uninstalled as described in #538. The release
script has now been updated in #534 so that the `rivershared` dependency
also gets properly bumped.

I'm also going to try to the `[skip ci]` tag during this release to
hopefully prevent bad caching in the Go proxy and make the release
available sooner.

Fixes #538.

[skip ci]