### PR TITLE
Report CLI failures to stderr, not stdout

### DIFF
--- a/cmd/river/rivercli/command.go
+++ b/cmd/river/rivercli/command.go
@@ -125,7 +125,7 @@ func RunCommand[TOpts CommandOpts](ctx context.Context, bundle *RunCommandBundle
 
 	ok, err := procureAndRun()
 	if err != nil {
-		fmt.Fprintf(os.Stdout, "failed: %s\n", err)
+		fmt.Fprintf(os.Stderr, "failed: %s\n", err)
 	}
 	if err != nil || !ok {
 		os.Exit(1)


### PR DESCRIPTION
This corrects a problem from #537, wherein I was doing a lot of
refactoring for testing purposes, and accidentally changed a place where
failures were reported from stderr to stdout.