### PR TITLE
Upgrade to golangci-lint 1.60.1

### DIFF
--- a/internal/util/hashutil/hash_util.go
+++ b/internal/util/hashutil/hash_util.go
@@ -35,10 +35,12 @@ func NewAdvisoryLockHash(configuredPrefix int32) *AdvisoryLockHash {
 // functions like `pg_advisory_xact_lock`.
 func (h *AdvisoryLockHash) Key() int64 {
 	if h.configuredPrefix == 0 {
-		return int64(h.hash64.Sum64()) // overflow allowed
+		// Overflow is okay and allowed.
+		return int64(h.hash64.Sum64()) //nolint:gosec
 	}
 
-	return int64(uint64(h.configuredPrefix)<<32 | uint64(h.hash32.Sum32())) // overflow allowed
+	// Overflow is okay and allowed.
+	return int64(uint64(h.configuredPrefix)<<32 | uint64(h.hash32.Sum32())) //nolint:gosec
 }
 
 // Write writes bytes to the underlying hash.

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -327,7 +327,7 @@ func (p *JobListParams) First(count int) *JobListParams {
 		panic("count must be <= 10000")
 	}
 	paramsCopy := p.copy()
-	paramsCopy.paginationCount = int32(count)
+	paramsCopy.paginationCount = int32(count) //nolint:gosec
 	return paramsCopy
 }
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -121,7 +121,7 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 			default:
 			}
 			numActiveJobs := producer.numJobsActive.Load()
-			if numActiveJobs > int32(producer.config.MaxWorkers) {
+			if int(numActiveJobs) > producer.config.MaxWorkers {
 				panic(fmt.Sprintf("producer exceeded MaxWorkerCount=%d, actual count=%d", producer.config.MaxWorkers, numActiveJobs))
 			}
 		}

--- a/queue_list_params.go
+++ b/queue_list_params.go
@@ -35,6 +35,6 @@ func (p *QueueListParams) First(count int) *QueueListParams {
 		panic("count must be <= 10000")
 	}
 	result := p.copy()
-	result.paginationCount = int32(count)
+	result.paginationCount = int32(count) //nolint:gosec
 	return result
 }

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -143,7 +143,7 @@ func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobD
 func (e *Executor) JobGetAvailable(ctx context.Context, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
 	jobs, err := dbsqlc.New().JobGetAvailable(ctx, e.dbtx, &dbsqlc.JobGetAvailableParams{
 		AttemptedBy: params.AttemptedBy,
-		Max:         int32(params.Max),
+		Max:         int32(min(params.Max, math.MaxInt32)), //nolint:gosec
 		Queue:       params.Queue,
 	})
 	if err != nil {
@@ -185,7 +185,7 @@ func (e *Executor) JobGetByKindMany(ctx context.Context, kind []string) ([]*rive
 }
 
 func (e *Executor) JobGetStuck(ctx context.Context, params *riverdriver.JobGetStuckParams) ([]*rivertype.JobRow, error) {
-	jobs, err := dbsqlc.New().JobGetStuck(ctx, e.dbtx, &dbsqlc.JobGetStuckParams{Max: int32(params.Max), StuckHorizon: params.StuckHorizon})
+	jobs, err := dbsqlc.New().JobGetStuck(ctx, e.dbtx, &dbsqlc.JobGetStuckParams{Max: int32(min(params.Max, math.MaxInt32)), StuckHorizon: params.StuckHorizon}) //nolint:gosec
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -197,9 +197,9 @@ func (e *Executor) JobInsertFast(ctx context.Context, params *riverdriver.JobIns
 		Args:        params.EncodedArgs,
 		CreatedAt:   params.CreatedAt,
 		Kind:        params.Kind,
-		MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)),
+		MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)), //nolint:gosec
 		Metadata:    params.Metadata,
-		Priority:    int16(min(params.Priority, math.MaxInt16)),
+		Priority:    int16(min(params.Priority, math.MaxInt16)), //nolint:gosec
 		Queue:       params.Queue,
 		ScheduledAt: params.ScheduledAt,
 		State:       dbsqlc.RiverJobState(params.State),
@@ -236,9 +236,9 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 		insertJobsParams[i] = &dbsqlc.JobInsertFastManyCopyFromParams{
 			Args:        params.EncodedArgs,
 			Kind:        params.Kind,
-			MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)),
+			MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)), //nolint:gosec
 			Metadata:    metadata,
-			Priority:    int16(min(params.Priority, math.MaxInt16)),
+			Priority:    int16(min(params.Priority, math.MaxInt16)), //nolint:gosec
 			Queue:       params.Queue,
 			ScheduledAt: scheduledAt,
 			State:       dbsqlc.RiverJobState(params.State),
@@ -256,16 +256,16 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 
 func (e *Executor) JobInsertFull(ctx context.Context, params *riverdriver.JobInsertFullParams) (*rivertype.JobRow, error) {
 	job, err := dbsqlc.New().JobInsertFull(ctx, e.dbtx, &dbsqlc.JobInsertFullParams{
-		Attempt:     int16(params.Attempt),
+		Attempt:     int16(min(params.Attempt, math.MaxInt16)), //nolint:gosec
 		AttemptedAt: params.AttemptedAt,
 		Args:        params.EncodedArgs,
 		CreatedAt:   params.CreatedAt,
 		Errors:      params.Errors,
 		FinalizedAt: params.FinalizedAt,
 		Kind:        params.Kind,
-		MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)),
+		MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)), //nolint:gosec
 		Metadata:    params.Metadata,
-		Priority:    int16(min(params.Priority, math.MaxInt16)),
+		Priority:    int16(min(params.Priority, math.MaxInt16)), //nolint:gosec
 		Queue:       params.Queue,
 		ScheduledAt: params.ScheduledAt,
 		State:       dbsqlc.RiverJobState(params.State),
@@ -283,9 +283,9 @@ func (e *Executor) JobInsertUnique(ctx context.Context, params *riverdriver.JobI
 		Args:        params.EncodedArgs,
 		CreatedAt:   params.CreatedAt,
 		Kind:        params.Kind,
-		MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)),
+		MaxAttempts: int16(min(params.MaxAttempts, math.MaxInt16)), //nolint:gosec
 		Metadata:    params.Metadata,
-		Priority:    int16(min(params.Priority, math.MaxInt16)),
+		Priority:    int16(min(params.Priority, math.MaxInt16)), //nolint:gosec
 		Queue:       params.Queue,
 		ScheduledAt: params.ScheduledAt,
 		State:       dbsqlc.RiverJobState(params.State),
@@ -391,7 +391,7 @@ func (e *Executor) JobSetCompleteIfRunningMany(ctx context.Context, params *rive
 func (e *Executor) JobSetStateIfRunning(ctx context.Context, params *riverdriver.JobSetStateIfRunningParams) (*rivertype.JobRow, error) {
 	var maxAttempts int16
 	if params.MaxAttempts != nil {
-		maxAttempts = int16(*params.MaxAttempts)
+		maxAttempts = int16(min(*params.MaxAttempts, math.MaxInt16)) //nolint:gosec
 	}
 
 	job, err := dbsqlc.New().JobSetStateIfRunning(ctx, e.dbtx, &dbsqlc.JobSetStateIfRunningParams{
@@ -418,7 +418,7 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		AttemptedAtDoUpdate: params.AttemptedAtDoUpdate,
 		AttemptedAt:         params.AttemptedAt,
 		AttemptDoUpdate:     params.AttemptDoUpdate,
-		Attempt:             int16(params.Attempt),
+		Attempt:             int16(min(params.Attempt, math.MaxInt16)), //nolint:gosec
 		ErrorsDoUpdate:      params.ErrorsDoUpdate,
 		Errors:              params.Errors,
 		FinalizedAtDoUpdate: params.FinalizedAtDoUpdate,
@@ -621,7 +621,7 @@ func (e *Executor) QueueGet(ctx context.Context, name string) (*rivertype.Queue,
 }
 
 func (e *Executor) QueueList(ctx context.Context, limit int) ([]*rivertype.Queue, error) {
-	internalQueues, err := dbsqlc.New().QueueList(ctx, e.dbtx, int32(limit))
+	internalQueues, err := dbsqlc.New().QueueList(ctx, e.dbtx, int32(min(limit, math.MaxInt32))) //nolint:gosec
 	if err != nil {
 		return nil, interpretError(err)
 	}


### PR DESCRIPTION
Here, take the project to golangci-lint 1.60.1, which is now widely
available on Homebrew and elsewhere. It comes with a number of breaking
changes, so I figure it's not the worst idea to keep us on latest so
that future upgrades are less painful.

All breakages are related to overflow checking in `gosec` getting more
strict. The strictness is kind of useful in that it reminds us to check
bounds with something like `min(limit, math.MaxInt32)`, but it can't
detect that a bounds check is done with `min(...)`, which is kind of
annoying because it means you need a `nolint` tag on all of these.