### PR TITLE
Preinitialize `workCancel` function in case `StopAndCancel` called before start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new `river migrate-list` command is available which lists available migrations and which version a target database is migrated to. [PR #534](https://github.com/riverqueue/river/pull/534).
 - `river version` or `river --version` now prints River version information. [PR #537](https://github.com/riverqueue/river/pull/537).
 
+## Fixed
+
+- Fixed a panic that'd occur if `StopAndCancel` was invoked before a client was started. [PR #557](https://github.com/riverqueue/river/pull/557).
+
 ## [0.11.4] - 2024-08-20
 
 ### Fixed

--- a/client.go
+++ b/client.go
@@ -491,6 +491,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		uniqueInserter: baseservice.Init(archetype, &dbunique.UniqueInserter{
 			AdvisoryLockPrefix: config.AdvisoryLockPrefix,
 		}),
+		workCancel: func(cause error) {}, // replaced on start, but here in case StopAndCancel is called before start up
 	}
 	client.queues = &QueueBundle{addProducer: client.addProducer}
 


### PR DESCRIPTION
This one's related to #549. Although the most proximate problem in that
repro code is that there was no error check when calling `Start`, it did
reveal a legitimate problem in that the River client will panic in case
`StopAndCancel` is called before `Start` because `workCancel` was never
set.

Here, initialize `workCancel` in the client's constructor. During normal
operation this will be overwritten almost immediately on `Start` as the
client starts up, but in case `Start` was never called or didn't run
successfully, it provides a function for `StopAndCancel` to call so that
it doesn't panic.

Fixes #549.