### PR TITLE
Fix set state if running query bug

### DIFF
--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -1094,18 +1094,18 @@ WITH job_to_update AS (
 updated_job AS (
     UPDATE river_job
     SET
-        state        = CASE WHEN should_cancel                                          THEN 'cancelled'::river_job_state
+        state        = CASE WHEN should_cancel                                           THEN 'cancelled'::river_job_state
                             ELSE $1::river_job_state END,
-        finalized_at = CASE WHEN should_cancel                                          THEN now()
-                            WHEN $3::boolean                       THEN $4
+        finalized_at = CASE WHEN should_cancel                                           THEN now()
+                            WHEN $3::boolean                        THEN $4
                             ELSE finalized_at END,
-        errors       = CASE WHEN $5::boolean                              THEN array_append(errors, $6::jsonb)
+        errors       = CASE WHEN $5::boolean                               THEN array_append(errors, $6::jsonb)
                             ELSE errors       END,
-        max_attempts = CASE WHEN NOT should_cancel AND $7::boolean    THEN $8
+        max_attempts = CASE WHEN NOT should_cancel AND $7::boolean     THEN $8
                             ELSE max_attempts END,
-        scheduled_at = CASE WHEN NOT should_cancel AND $9::boolean THEN $10::timestamptz
+        scheduled_at = CASE WHEN NOT should_cancel AND $9::boolean  THEN $10::timestamptz
                             ELSE scheduled_at END,
-        unique_key   = CASE WHEN $1 IN ('cancelled', 'discarded')                   THEN NULL
+        unique_key   = CASE WHEN ($1 IN ('cancelled', 'discarded') OR should_cancel) THEN NULL
                             ELSE unique_key END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -1074,18 +1074,18 @@ WITH job_to_update AS (
 updated_job AS (
     UPDATE river_job
     SET
-        state        = CASE WHEN should_cancel                                          THEN 'cancelled'::river_job_state
+        state        = CASE WHEN should_cancel                                           THEN 'cancelled'::river_job_state
                             ELSE $1::river_job_state END,
-        finalized_at = CASE WHEN should_cancel                                          THEN now()
-                            WHEN $3::boolean                       THEN $4
+        finalized_at = CASE WHEN should_cancel                                           THEN now()
+                            WHEN $3::boolean                        THEN $4
                             ELSE finalized_at END,
-        errors       = CASE WHEN $5::boolean                              THEN array_append(errors, $6::jsonb)
+        errors       = CASE WHEN $5::boolean                               THEN array_append(errors, $6::jsonb)
                             ELSE errors       END,
-        max_attempts = CASE WHEN NOT should_cancel AND $7::boolean    THEN $8
+        max_attempts = CASE WHEN NOT should_cancel AND $7::boolean     THEN $8
                             ELSE max_attempts END,
-        scheduled_at = CASE WHEN NOT should_cancel AND $9::boolean THEN $10::timestamptz
+        scheduled_at = CASE WHEN NOT should_cancel AND $9::boolean  THEN $10::timestamptz
                             ELSE scheduled_at END,
-        unique_key   = CASE WHEN $1 IN ('cancelled', 'discarded')                   THEN NULL
+        unique_key   = CASE WHEN ($1 IN ('cancelled', 'discarded') OR should_cancel) THEN NULL
                             ELSE unique_key END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id


### PR DESCRIPTION
While doing some work on a related query, I noticed that the `unique_key` is being cleared here specifically if the new state is explicitly `cancelled`, but _not_ if the state is being set to cancel because of a cancellation attempt that didn't get picked up before the job completed.

I didn't yet add test coverage for this but wanted to at least commit it before I forgot. Probably worth it given that this is super nuanced and could easily break in the future?

I also took the occasion to upgrade to sqlc v1.27 in this PR because I picked it up from Homebrew, but I'm opening a separate PR for that too.