### PR TITLE
Do not insert a new job if PeriodicJobConstructor returns nil

### DIFF
--- a/periodic_job.go
+++ b/periodic_job.go
@@ -183,6 +183,9 @@ func (b *PeriodicJobBundle) toInternal(periodicJob *PeriodicJob) *maintenance.Pe
 	return &maintenance.PeriodicJob{
 		ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
 			args, options := periodicJob.constructorFunc()
+			if args == nil {
+				return nil, nil, maintenance.ErrNoJobToInsert
+			}
 			return insertParamsFromConfigArgsAndOptions(&b.periodicJobEnqueuer.Archetype, b.clientConfig, args, options)
 		},
 		RunOnStart:   opts.RunOnStart,

--- a/periodic_job_test.go
+++ b/periodic_job_test.go
@@ -65,10 +65,6 @@ func TestPeriodicJobBundle(t *testing.T) {
 
 		periodicJobBundle, _ := setup(t)
 
-		type TestJobArgs struct {
-			JobArgsReflectKind[TestJobArgs]
-		}
-
 		periodicJob := NewPeriodicJob(
 			PeriodicInterval(15*time.Minute),
 			func() (JobArgs, *InsertOpts) {


### PR DESCRIPTION
This commit fixes an issue with the PerioridJobConstructor ignoring the return value. According to the [docs](https://github.com/riverqueue/river/blob/65fd8158aa6c4dd51558bb62cc4b3ce0f74de47a/periodic_job.go#L25-L26), we should ignore the job is nil is returned.

Before:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1089c1d1]

goroutine 470 [running]:
github.com/riverqueue/river.insertParamsFromConfigArgsAndOptions(0xc0007e2270, 0xc0003a3500, {0x0, 0x0}, 0x0)
        /Users/semanser/Programming/river/client.go:1218 +0x531
github.com/riverqueue/river.(*PeriodicJobBundle).toInternal-fm.(*PeriodicJobBundle).toInternal.func1()
        /Users/semanser/Programming/river/periodic_job.go:186 +0x4e
github.com/riverqueue/river/internal/maintenance.(*PeriodicJobEnqueuer).insertParamsFromConstructor(0xc0007e2270, {0x11a6dc58, 0xc000a3a550}, 0xc000392438, {0xc1ab4192dd537df8, 0xbb93aaf1, 0x12a4f360})
        /Users/semanser/Programming/river/internal/maintenance/periodic_job_enqueuer.go:413 +0xb2
github.com/riverqueue/river/internal/maintenance.(*PeriodicJobEnqueuer).Start.func1.2(0xc0007e2270, {0xc18a41c1?, 0x12a4f360?, 0x12a4f360?}, {0x11a6dc58, 0xc000a3a550}, 0xc000a27ee8, 0xc000a27f00)
        /Users/semanser/Programming/river/internal/maintenance/periodic_job_enqueuer.go:307 +0x1eb
github.com/riverqueue/river/internal/maintenance.(*PeriodicJobEnqueuer).Start.func1()
        /Users/semanser/Programming/river/internal/maintenance/periodic_job_enqueuer.go:321 +0x3d5
created by github.com/riverqueue/river/internal/maintenance.(*PeriodicJobEnqueuer).Start in goroutine 120
        /Users/semanser/Programming/river/internal/maintenance/periodic_job_enqueuer.go:212 +0xd6
```

After:
```
2024-08-26T16:19:33.510+0200    INFO    PeriodicJobEnqueuer: nil returned from periodic job constructor, skipping
```