### PR TITLE
Add middleware system for jobs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -2438,7 +2438,7 @@ func Test_Client_ErrorHandler(t *testing.T) {
 		// unknown job.
 		insertParams, _, err := insertParamsFromConfigArgsAndOptions(&client.baseService.Archetype, config, unregisteredJobArgs{}, nil)
 		require.NoError(t, err)
-		_, err = client.driver.GetExecutor().JobInsertFast(ctx, insertParams)
+		_, err = client.driver.GetExecutor().JobInsertFast(ctx, (*riverdriver.JobInsertFastParams)(insertParams))
 		require.NoError(t, err)
 
 		riversharedtest.WaitOrTimeout(t, bundle.SubscribeChan)
@@ -4026,7 +4026,7 @@ func Test_Client_UnknownJobKindErrorsTheJob(t *testing.T) {
 
 	insertParams, _, err := insertParamsFromConfigArgsAndOptions(&client.baseService.Archetype, config, unregisteredJobArgs{}, nil)
 	require.NoError(err)
-	insertedJob, err := client.driver.GetExecutor().JobInsertFast(ctx, insertParams)
+	insertedJob, err := client.driver.GetExecutor().JobInsertFast(ctx, (*riverdriver.JobInsertFastParams)(insertParams))
 	require.NoError(err)
 
 	event := riversharedtest.WaitOrTimeout(t, subscribeChan)

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -39,7 +39,7 @@ func (ts *PeriodicJobEnqueuerTestSignals) Init() {
 // river.PeriodicJobArgs, but needs a separate type because the enqueuer is in a
 // subpackage.
 type PeriodicJob struct {
-	ConstructorFunc func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error)
+	ConstructorFunc func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error)
 	RunOnStart      bool
 	ScheduleFunc    func(time.Time) time.Time
 
@@ -409,7 +409,7 @@ func (s *PeriodicJobEnqueuer) insertBatch(ctx context.Context, insertParamsMany 
 	s.TestSignals.InsertedJobs.Signal(struct{}{})
 }
 
-func (s *PeriodicJobEnqueuer) insertParamsFromConstructor(ctx context.Context, constructorFunc func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error), scheduledAt time.Time) (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, bool) {
+func (s *PeriodicJobEnqueuer) insertParamsFromConstructor(ctx context.Context, constructorFunc func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error), scheduledAt time.Time) (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, bool) {
 	insertParams, uniqueOpts, err := constructorFunc()
 	if err != nil {
 		if errors.Is(err, ErrNoJobToInsert) {
@@ -425,7 +425,7 @@ func (s *PeriodicJobEnqueuer) insertParamsFromConstructor(ctx context.Context, c
 		insertParams.ScheduledAt = &scheduledAt
 	}
 
-	return insertParams, uniqueOpts, true
+	return (*riverdriver.JobInsertFastParams)(insertParams), uniqueOpts, true
 }
 
 const periodicJobEnqueuerVeryLongDuration = 24 * time.Hour

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -33,9 +33,9 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		waitChan             chan (struct{})
 	}
 
-	jobConstructorWithQueueFunc := func(name string, unique bool, queue string) func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
-		return func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
-			return &riverdriver.JobInsertFastParams{
+	jobConstructorWithQueueFunc := func(name string, unique bool, queue string) func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error) {
+		return func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error) {
+			return &rivertype.JobInsertParams{
 				EncodedArgs: []byte("{}"),
 				Kind:        name,
 				MaxAttempts: rivercommon.MaxAttemptsDefault,
@@ -46,7 +46,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		}
 	}
 
-	jobConstructorFunc := func(name string, unique bool) func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
+	jobConstructorFunc := func(name string, unique bool) func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error) {
 		return jobConstructorWithQueueFunc(name, unique, rivercommon.QueueDefault)
 	}
 
@@ -236,7 +236,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc.AddMany([]*PeriodicJob{
 			// skip this insert when it returns nil:
-			{ScheduleFunc: periodicIntervalSchedule(time.Second), ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
+			{ScheduleFunc: periodicIntervalSchedule(time.Second), ConstructorFunc: func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error) {
 				return nil, nil, ErrNoJobToInsert
 			}, RunOnStart: true},
 		})

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/riverinternaltest/sharedtx"
-	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivertype"
 )
 
 type testService struct {
@@ -108,7 +108,7 @@ func TestQueueMaintainer(t *testing.T) {
 			NewPeriodicJobEnqueuer(archetype, &PeriodicJobEnqueuerConfig{
 				PeriodicJobs: []*PeriodicJob{
 					{
-						ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
+						ConstructorFunc: func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error) {
 							return nil, nil, ErrNoJobToInsert
 						},
 						ScheduleFunc: cron.Every(15 * time.Minute).Next,

--- a/middleware_defaults.go
+++ b/middleware_defaults.go
@@ -1,0 +1,47 @@
+package river
+
+import (
+	"context"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+// JobMiddlewareDefaults is an embeddable struct that provides default
+// implementations for the rivertype.JobMiddleware. Use of this struct is
+// recommended in case rivertype.JobMiddleware is expanded in the future so that
+// existing code isn't unexpectedly broken during an upgrade.
+type JobMiddlewareDefaults struct{}
+
+func (l *JobMiddlewareDefaults) Insert(ctx context.Context, params *rivertype.JobInsertParams, doInner func(ctx context.Context) (*rivertype.JobInsertResult, error)) (*rivertype.JobInsertResult, error) {
+	return doInner(ctx)
+}
+
+func (l *JobMiddlewareDefaults) InsertMany(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) (int, error)) (int, error) {
+	return doInner(ctx)
+}
+
+func (l *JobMiddlewareDefaults) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+	return doInner(ctx)
+}
+
+// func (l *JobLifecycleDefaults) InsertBegin(ctx context.Context, params *rivertype.JobLifecycleInsertParams) (context.Context, error) {
+// 	return ctx, nil
+// }
+
+// func (l *JobLifecycleDefaults) InsertEnd(ctx context.Context, res *rivertype.JobInsertResult) error {
+// 	return nil
+// }
+
+// func (l *JobLifecycleDefaults) InsertManyBegin(ctx context.Context, manyParams []*rivertype.JobLifecycleInsertParams) (context.Context, error) {
+// 	return ctx, nil
+// }
+
+// func (l *JobLifecycleDefaults) InsertManyEnd(ctx context.Context, manyParams []*rivertype.JobLifecycleInsertParams) error {
+// 	return nil
+// }
+
+// func (l *JobLifecycleDefaults) WorkBegin(ctx context.Context, job *rivertype.JobRow) (context.Context, error) {
+// 	return ctx, nil
+// }
+
+// func (l *JobLifecycleDefaults) WorkEnd(ctx context.Context, job *rivertype.JobRow) error { return nil }

--- a/middleware_defaults_test.go
+++ b/middleware_defaults_test.go
@@ -1,0 +1,5 @@
+package river
+
+import "github.com/riverqueue/river/rivertype"
+
+var _ rivertype.JobMiddleware = &JobMiddlewareDefaults{}

--- a/periodic_job.go
+++ b/periodic_job.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/internal/maintenance"
-	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -181,7 +180,7 @@ func (b *PeriodicJobBundle) toInternal(periodicJob *PeriodicJob) *maintenance.Pe
 		opts = periodicJob.opts
 	}
 	return &maintenance.PeriodicJob{
-		ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
+		ConstructorFunc: func() (*rivertype.JobInsertParams, *dbunique.UniqueOpts, error) {
 			args, options := periodicJob.constructorFunc()
 			if args == nil {
 				return nil, nil, maintenance.ErrNoJobToInsert

--- a/producer.go
+++ b/producer.go
@@ -63,8 +63,9 @@ type producerConfig struct {
 	// LISTEN/NOTIFY, but this provides a fallback.
 	FetchPollInterval time.Duration
 
-	JobTimeout time.Duration
-	MaxWorkers int
+	JobMiddleware []rivertype.JobMiddleware
+	JobTimeout    time.Duration
+	MaxWorkers    int
 
 	// Notifier is a notifier for subscribing to new job inserts and job
 	// control. If nil, the producer will operate in poll-only mode.
@@ -579,6 +580,7 @@ func (p *producer) startNewExecutors(workCtx context.Context, jobs []*rivertype.
 			Completer:              p.completer,
 			ErrorHandler:           p.errorHandler,
 			InformProducerDoneFunc: p.handleWorkerDone,
+			JobMiddleware:          p.config.JobMiddleware,
 			JobRow:                 job,
 			SchedulerInterval:      p.config.SchedulerInterval,
 			WorkUnit:               workUnit,

--- a/producer_test.go
+++ b/producer_test.go
@@ -105,7 +105,7 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 		insertParams, _, err := insertParamsFromConfigArgsAndOptions(archetype, config, WithJobNumArgs{JobNum: i}, nil)
 		require.NoError(err)
 
-		params[i] = insertParams
+		params[i] = (*riverdriver.JobInsertFastParams)(insertParams)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -280,7 +280,7 @@ func testProducer(t *testing.T, makeProducer func(ctx context.Context, t *testin
 		insertParams, _, err := insertParamsFromConfigArgsAndOptions(bundle.archetype, bundle.config, args, nil)
 		require.NoError(t, err)
 
-		_, err = bundle.exec.JobInsertFast(ctx, insertParams)
+		_, err = bundle.exec.JobInsertFast(ctx, (*riverdriver.JobInsertFastParams)(insertParams))
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Here, experiment with a middleware-like system that adds middleware
functions to job lifecycles, which results in them being invoked during
specific phases of a job like as it's being inserted or worked.

The most obvious unlock for this is telemetry (e.g. logging, metrics),
but it also acts as a building block for features like encrypted jobs.