### PR TITLE
testfactory: automatically set FinalizedAt if finalized state

### DIFF
--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -1091,9 +1091,11 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 					exec, _ := setup(ctx, t)
 					// Create a job with the target state but without a finalized_at,
 					// expect an error:
-					_, err := exec.JobInsertFull(ctx, testfactory.Job_Build(t, &testfactory.JobOpts{
+					params := testfactory.Job_Build(t, &testfactory.JobOpts{
 						State: &state,
-					}))
+					})
+					params.FinalizedAt = nil
+					_, err := exec.JobInsertFull(ctx, params)
 					require.ErrorContains(t, err, "violates check constraint \"finalized_or_finalized_at_null\"")
 				})
 

--- a/internal/riverinternaltest/testfactory/test_factory.go
+++ b/internal/riverinternaltest/testfactory/test_factory.go
@@ -52,6 +52,13 @@ func Job_Build(tb testing.TB, opts *JobOpts) *riverdriver.JobInsertFullParams { 
 		encodedArgs = []byte("{}")
 	}
 
+	finalizedAt := opts.FinalizedAt
+	if finalizedAt == nil && (opts.State != nil && (*opts.State == rivertype.JobStateCompleted ||
+		*opts.State == rivertype.JobStateCancelled ||
+		*opts.State == rivertype.JobStateDiscarded)) {
+		finalizedAt = ptrutil.Ptr(time.Now())
+	}
+
 	metadata := opts.Metadata
 	if opts.Metadata == nil {
 		metadata = []byte("{}")
@@ -68,7 +75,7 @@ func Job_Build(tb testing.TB, opts *JobOpts) *riverdriver.JobInsertFullParams { 
 		CreatedAt:   opts.CreatedAt,
 		EncodedArgs: encodedArgs,
 		Errors:      opts.Errors,
-		FinalizedAt: opts.FinalizedAt,
+		FinalizedAt: finalizedAt,
 		Kind:        ptrutil.ValOrDefault(opts.Kind, "fake_job"),
 		MaxAttempts: ptrutil.ValOrDefault(opts.MaxAttempts, rivercommon.MaxAttemptsDefault),
 		Metadata:    metadata,

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -211,9 +211,9 @@ type Notification struct {
 }
 
 type JobCancelParams struct {
-	ID                int64
 	CancelAttemptedAt time.Time
 	ControlTopic      string
+	ID                int64
 }
 
 type JobDeleteBeforeParams struct {


### PR DESCRIPTION
This was a small quality of life improvement I ran into while working on Pro stuff. I figure that by default, the `testfactory` package should try to do the right thing and avoid requiring every field to be specified when there are reasonable defaults that could be set based on other values.

In that vein, if the job being created is in a finalized state, automatically set the `FinalizedAt` timestamp so that callers don't always have to do so. There was only one test that this broke, which was an easy fix.