### PR TITLE
prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.12.0-rc.1] - 2024-09-22
+## [0.12.0] - 2024-09-23
 
 ⚠️ Version 0.12.0 contains a new database migration, version 6. See [documentation on running River migrations](https://riverqueue.com/docs/migrations). If migrating with the CLI, make sure to update it to its latest version:
 
@@ -85,7 +85,7 @@ river migrate-up --database-url "$DATABASE_URL"
 
   In-flight unique jobs using the previous designs will continue to be executed successfully with these changes, so there should be no need for downtime as part of the migration. However the v6 migration adds a new unique job index while also removing the old one, so users with in-flight unique jobs may also wish to avoid removing the old index until the new River release has been deployed in order to guarantee that jobs aren't duplicated by old River code once that index is removed.
 
-  **Deprecated**: The original unique jobs implementation which relied on advisory locks has been deprecated, but not yet removed. The only way to trigger this old code path is with a single insert (`Insert`/`InsertTx`) and using `UniqueOpts.ByState` with a custom list of states that omits some of the now-required states for unique jobs. Specifically, `pending`, `scheduled`, `available`, and `running` can not be removed from the `ByState` list with the new implementation. These are included in the default list so only the places which customize this attribute need to be updated to opt into the new (much faster) unique jobs. The advisory lock unique implementation will be removed in an upcoming release.
+  **Deprecated**: The original unique jobs implementation which relied on advisory locks has been deprecated, but not yet removed. The only way to trigger this old code path is with a single insert (`Insert`/`InsertTx`) and using `UniqueOpts.ByState` with a custom list of states that omits some of the now-required states for unique jobs. Specifically, `pending`, `scheduled`, `available`, and `running` can not be removed from the `ByState` list with the new implementation. These are included in the default list so only the places which customize this attribute need to be updated to opt into the new (much faster) unique jobs. The advisory lock unique implementation will be removed in an upcoming release, and until then emits warning level logs when it's used.
 
   [PR #590](https://github.com/riverqueue/river/pull/590).
 

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,11 +7,11 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/lmittmann/tint v1.0.4
-	github.com/riverqueue/river v0.12.0-rc.1
-	github.com/riverqueue/river/riverdriver v0.12.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.12.0-rc.1
-	github.com/riverqueue/river/rivershared v0.12.0-rc.1
-	github.com/riverqueue/river/rivertype v0.12.0-rc.1
+	github.com/riverqueue/river v0.12.0
+	github.com/riverqueue/river/riverdriver v0.12.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.12.0
+	github.com/riverqueue/river/rivershared v0.12.0
+	github.com/riverqueue/river/rivertype v0.12.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.12.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.12.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.12.0-rc.1
-	github.com/riverqueue/river/rivershared v0.12.0-rc.1
-	github.com/riverqueue/river/rivertype v0.12.0-rc.1
+	github.com/riverqueue/river/riverdriver v0.12.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.12.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.12.0
+	github.com/riverqueue/river/rivershared v0.12.0
+	github.com/riverqueue/river/rivertype v0.12.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.17.3

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.21
 
 toolchain go1.23.0
 
-require github.com/riverqueue/river/rivertype v0.12.0-rc.1
+require github.com/riverqueue/river/rivertype v0.12.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,9 +7,9 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.12.0-rc.1
-	github.com/riverqueue/river/rivershared v0.12.0-rc.1
-	github.com/riverqueue/river/rivertype v0.12.0-rc.1
+	github.com/riverqueue/river/riverdriver v0.12.0
+	github.com/riverqueue/river/rivershared v0.12.0
+	github.com/riverqueue/river/rivertype v0.12.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,9 +7,9 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.5.0
 	github.com/jackc/puddle/v2 v2.2.1
-	github.com/riverqueue/river/riverdriver v0.12.0-rc.1
-	github.com/riverqueue/river/rivershared v0.12.0-rc.1
-	github.com/riverqueue/river/rivertype v0.12.0-rc.1
+	github.com/riverqueue/river/riverdriver v0.12.0
+	github.com/riverqueue/river/rivershared v0.12.0
+	github.com/riverqueue/river/rivertype v0.12.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -5,9 +5,9 @@ go 1.21
 toolchain go1.23.0
 
 require (
-	github.com/riverqueue/river v0.12.0-rc.1
-	github.com/riverqueue/river/riverdriver v0.12.0-rc.1
-	github.com/riverqueue/river/rivertype v0.12.0-rc.1
+	github.com/riverqueue/river v0.12.0
+	github.com/riverqueue/river/riverdriver v0.12.0
+	github.com/riverqueue/river/rivertype v0.12.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.9.0


### PR DESCRIPTION
I've tested [`v0.12.0-rc.1`](https://github.com/riverqueue/river/releases/tag/v0.12.0-rc.1) on internal apps as well as riverpro and the transition went smoothly. Feeling good about moving forward with a proper release on both sides.