### PR TITLE
remove deprecated advisory lock uniqueness, consolidate insert logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+⚠️ Version 0.13.0 removes the original advisory lock based unique jobs implementation that was deprecated in v0.12.0. See details in the note below or the v0.12.0 release notes.
+
+### Changed
+
+- **Breaking change:** The advisory lock unique jobs implementation which was deprecated in v0.12.0 has been removed. Users of that feature should first upgrade to v0.12.1 to ensure they don't see any warning logs about using the deprecated advisory lock uniqueness. The new, faster unique implementation will be used automatically as long as the `UniqueOpts.ByState` list hasn't been customized to remove [required states](https://riverqueue.com/docs/unique-jobs#unique-by-state) (`pending`, `scheduled`, `available`, and `running`). As of this release, customizing `ByState` without these required states returns an error. [PR #614](https://github.com/riverqueue/river/pull/614).
+- Single job inserts are now unified under the hood to use the `InsertMany` bulk insert query. This should not be noticeable to users, and the unified code path will make it easier to build new features going forward. [PR #614](https://github.com/riverqueue/river/pull/614).
+
 ## [0.12.1] - 2024-09-26
 
 ### Changed

--- a/driver_test.go
+++ b/driver_test.go
@@ -98,8 +98,8 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 		return driver.UnwrapExecutor(tx), &testBundle{}
 	}
 
-	makeInsertParams := func() *riverdriver.JobInsertFastParams {
-		return &riverdriver.JobInsertFastParams{
+	makeInsertParams := func() []*riverdriver.JobInsertFastParams {
+		return []*riverdriver.JobInsertFastParams{{
 			EncodedArgs: []byte(`{}`),
 			Kind:        "fake_job",
 			MaxAttempts: rivercommon.MaxAttemptsDefault,
@@ -108,7 +108,7 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 			Queue:       rivercommon.QueueDefault,
 			ScheduledAt: nil,
 			State:       rivertype.JobStateAvailable,
-		}
+		}}
 	}
 
 	b.Run("JobInsert_Sequential", func(b *testing.B) {
@@ -118,7 +118,7 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 		exec, _ := setupTx(b)
 
 		for i := 0; i < b.N; i++ {
-			if _, err := exec.JobInsertFast(ctx, makeInsertParams()); err != nil {
+			if _, err := exec.JobInsertFastMany(ctx, makeInsertParams()); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -133,7 +133,7 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			i := 0
 			for pb.Next() {
-				if _, err := exec.JobInsertFast(ctx, makeInsertParams()); err != nil {
+				if _, err := exec.JobInsertFastMany(ctx, makeInsertParams()); err != nil {
 					b.Fatal(err)
 				}
 				i++
@@ -148,7 +148,7 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 		exec, _ := setupTx(b)
 
 		for i := 0; i < b.N*100; i++ {
-			if _, err := exec.JobInsertFast(ctx, makeInsertParams()); err != nil {
+			if _, err := exec.JobInsertFastMany(ctx, makeInsertParams()); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -173,7 +173,7 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 		exec, _ := setupPool(b)
 
 		for i := 0; i < b.N*100*runtime.NumCPU(); i++ {
-			if _, err := exec.JobInsertFast(ctx, makeInsertParams()); err != nil {
+			if _, err := exec.JobInsertFastMany(ctx, makeInsertParams()); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -218,27 +218,27 @@ func BenchmarkDriverRiverPgxV5Insert(b *testing.B) {
 		return driver, bundle
 	}
 
-	b.Run("InsertFast", func(b *testing.B) {
+	b.Run("InsertFastMany", func(b *testing.B) {
 		_, bundle := setup(b)
 
 		for n := 0; n < b.N; n++ {
-			_, err := bundle.exec.JobInsertFast(ctx, &riverdriver.JobInsertFastParams{
+			_, err := bundle.exec.JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{{
 				EncodedArgs: []byte(`{"encoded": "args"}`),
 				Kind:        "test_kind",
 				MaxAttempts: rivercommon.MaxAttemptsDefault,
 				Priority:    rivercommon.PriorityDefault,
 				Queue:       rivercommon.QueueDefault,
 				State:       rivertype.JobStateAvailable,
-			})
+			}})
 			require.NoError(b, err)
 		}
 	})
 
-	b.Run("InsertFast_WithUnique", func(b *testing.B) {
+	b.Run("InsertFastMany_WithUnique", func(b *testing.B) {
 		_, bundle := setup(b)
 
 		for i := 0; i < b.N; i++ {
-			_, err := bundle.exec.JobInsertFast(ctx, &riverdriver.JobInsertFastParams{
+			_, err := bundle.exec.JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{{
 				EncodedArgs:  []byte(`{"encoded": "args"}`),
 				Kind:         "test_kind",
 				MaxAttempts:  rivercommon.MaxAttemptsDefault,
@@ -247,7 +247,7 @@ func BenchmarkDriverRiverPgxV5Insert(b *testing.B) {
 				State:        rivertype.JobStateAvailable,
 				UniqueKey:    []byte("test_unique_key_" + strconv.Itoa(i)),
 				UniqueStates: 0xFB,
-			})
+			}})
 			require.NoError(b, err)
 		}
 	})

--- a/insert_opts_test.go
+++ b/insert_opts_test.go
@@ -32,7 +32,7 @@ func TestTagRE(t *testing.T) {
 	require.NotRegexp(t, tagRE, "commas,never,allowed")
 }
 
-func TestJobUniqueOpts_validate(t *testing.T) {
+func TestUniqueOpts_validate(t *testing.T) {
 	t.Parallel()
 
 	require.NoError(t, (&UniqueOpts{}).validate())
@@ -40,42 +40,39 @@ func TestJobUniqueOpts_validate(t *testing.T) {
 		ByArgs:   true,
 		ByPeriod: 1 * time.Second,
 		ByQueue:  true,
-		ByState:  []rivertype.JobState{rivertype.JobStateAvailable},
 	}).validate())
 
-	require.EqualError(t, (&UniqueOpts{ByPeriod: 1 * time.Millisecond}).validate(), "JobUniqueOpts.ByPeriod should not be less than 1 second")
-	require.EqualError(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobState("invalid")}}).validate(), `JobUniqueOpts.ByState contains invalid state "invalid"`)
-}
+	require.EqualError(t, (&UniqueOpts{ByPeriod: 1 * time.Millisecond}).validate(), "UniqueOpts.ByPeriod should not be less than 1 second")
+	require.EqualError(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobState("invalid")}}).validate(), `UniqueOpts.ByState contains invalid state "invalid"`)
 
-func TestJobUniqueOpts_isV1(t *testing.T) {
-	t.Parallel()
-
-	// Test when ByState is empty
-	require.False(t, (&UniqueOpts{}).isV1())
-
-	// Test when ByState contains none of the required V3 states
-	require.True(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobStateCompleted}}).isV1())
-
-	// Test when ByState contains some but not all required V3 states
-	require.True(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobStatePending}}).isV1())
-	require.True(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobStateScheduled}}).isV1())
-	require.True(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobStateAvailable}}).isV1())
-	require.True(t, (&UniqueOpts{ByState: []rivertype.JobState{rivertype.JobStateRunning}}).isV1())
-
-	// Test when ByState contains all required V3 states
-	require.False(t, (&UniqueOpts{ByState: []rivertype.JobState{
-		rivertype.JobStatePending,
-		rivertype.JobStateScheduled,
+	requiredStates := []rivertype.JobState{
 		rivertype.JobStateAvailable,
-		rivertype.JobStateRunning,
-	}}).isV1())
-
-	// Test when ByState contains more than the required V3 states
-	require.False(t, (&UniqueOpts{ByState: []rivertype.JobState{
 		rivertype.JobStatePending,
-		rivertype.JobStateScheduled,
-		rivertype.JobStateAvailable,
 		rivertype.JobStateRunning,
-		rivertype.JobStateCompleted,
-	}}).isV1())
+		rivertype.JobStateScheduled,
+	}
+
+	for _, state := range requiredStates {
+		// Test with each state individually removed from requiredStates to ensure
+		// it's validated.
+
+		// Create a copy of requiredStates without the current state
+		var testStates []rivertype.JobState
+		for _, s := range requiredStates {
+			if s != state {
+				testStates = append(testStates, s)
+			}
+		}
+
+		// Test validation
+		require.EqualError(t, (&UniqueOpts{ByState: testStates}).validate(), "UniqueOpts.ByState must contain all required states, missing: "+string(state))
+	}
+
+	// test with more than one required state missing:
+	require.EqualError(t, (&UniqueOpts{ByState: []rivertype.JobState{
+		rivertype.JobStateAvailable,
+		rivertype.JobStateScheduled,
+	}}).validate(), "UniqueOpts.ByState must contain all required states, missing: pending, running")
+
+	require.NoError(t, (&UniqueOpts{ByState: rivertype.JobStates()}).validate())
 }

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/riverinternaltest/sharedtx"
 	"github.com/riverqueue/river/riverdriver"
@@ -108,8 +107,8 @@ func TestQueueMaintainer(t *testing.T) {
 			NewPeriodicJobEnqueuer(archetype, &PeriodicJobEnqueuerConfig{
 				PeriodicJobs: []*PeriodicJob{
 					{
-						ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
-							return nil, nil, ErrNoJobToInsert
+						ConstructorFunc: func() (*riverdriver.JobInsertFastParams, error) {
+							return nil, ErrNoJobToInsert
 						},
 						ScheduleFunc: cron.Every(15 * time.Minute).Next,
 					},

--- a/job_test.go
+++ b/job_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-func TestJobUniqueOpts_isEmpty(t *testing.T) {
+func TestUniqueOpts_isEmpty(t *testing.T) {
 	t.Parallel()
 
 	require.True(t, (&UniqueOpts{}).isEmpty())

--- a/periodic_job.go
+++ b/periodic_job.go
@@ -3,7 +3,6 @@ package river
 import (
 	"time"
 
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/internal/maintenance"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
@@ -181,12 +180,12 @@ func (b *PeriodicJobBundle) toInternal(periodicJob *PeriodicJob) *maintenance.Pe
 		opts = periodicJob.opts
 	}
 	return &maintenance.PeriodicJob{
-		ConstructorFunc: func() (*riverdriver.JobInsertFastParams, *dbunique.UniqueOpts, error) {
+		ConstructorFunc: func() (*riverdriver.JobInsertFastParams, error) {
 			args, options := periodicJob.constructorFunc()
 			if args == nil {
-				return nil, nil, maintenance.ErrNoJobToInsert
+				return nil, maintenance.ErrNoJobToInsert
 			}
-			return insertParamsFromConfigArgsAndOptions(&b.periodicJobEnqueuer.Archetype, b.clientConfig, args, options, false)
+			return insertParamsFromConfigArgsAndOptions(&b.periodicJobEnqueuer.Archetype, b.clientConfig, args, options)
 		},
 		RunOnStart:   opts.RunOnStart,
 		ScheduleFunc: periodicJob.scheduleFunc.Next,

--- a/periodic_job_test.go
+++ b/periodic_job_test.go
@@ -51,11 +51,11 @@ func TestPeriodicJobBundle(t *testing.T) {
 
 		internalPeriodicJob := periodicJobBundle.toInternal(periodicJob)
 
-		insertParams1, _, err := internalPeriodicJob.ConstructorFunc()
+		insertParams1, err := internalPeriodicJob.ConstructorFunc()
 		require.NoError(t, err)
 		require.Equal(t, 1, mustUnmarshalJSON[TestJobArgs](t, insertParams1.EncodedArgs).JobNum)
 
-		insertParams2, _, err := internalPeriodicJob.ConstructorFunc()
+		insertParams2, err := internalPeriodicJob.ConstructorFunc()
 		require.NoError(t, err)
 		require.Equal(t, 2, mustUnmarshalJSON[TestJobArgs](t, insertParams2.EncodedArgs).JobNum)
 	})
@@ -76,7 +76,7 @@ func TestPeriodicJobBundle(t *testing.T) {
 
 		internalPeriodicJob := periodicJobBundle.toInternal(periodicJob)
 
-		_, _, err := internalPeriodicJob.ConstructorFunc()
+		_, err := internalPeriodicJob.ConstructorFunc()
 		require.ErrorIs(t, err, maintenance.ErrNoJobToInsert)
 	})
 }

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -115,7 +115,6 @@ type Executor interface {
 	JobGetByKindAndUniqueProperties(ctx context.Context, params *JobGetByKindAndUniquePropertiesParams) (*rivertype.JobRow, error)
 	JobGetByKindMany(ctx context.Context, kind []string) ([]*rivertype.JobRow, error)
 	JobGetStuck(ctx context.Context, params *JobGetStuckParams) ([]*rivertype.JobRow, error)
-	JobInsertFast(ctx context.Context, params *JobInsertFastParams) (*JobInsertFastResult, error)
 	JobInsertFastMany(ctx context.Context, params []*JobInsertFastParams) ([]*JobInsertFastResult, error)
 	JobInsertFastManyNoReturning(ctx context.Context, params []*JobInsertFastParams) (int, error)
 	JobInsertFull(ctx context.Context, params *JobInsertFullParams) (*rivertype.JobRow, error)
@@ -227,6 +226,7 @@ type JobDeleteBeforeParams struct {
 type JobGetAvailableParams struct {
 	AttemptedBy string
 	Max         int
+	Now         *time.Time
 	Queue       string
 }
 

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -141,6 +141,7 @@ func (e *Executor) JobGetAvailable(ctx context.Context, params *riverdriver.JobG
 	jobs, err := dbsqlc.New().JobGetAvailable(ctx, e.dbtx, &dbsqlc.JobGetAvailableParams{
 		AttemptedBy: params.AttemptedBy,
 		Max:         int32(min(params.Max, math.MaxInt32)), //nolint:gosec
+		Now:         params.Now,
 		Queue:       params.Queue,
 	})
 	if err != nil {
@@ -200,31 +201,6 @@ func (e *Executor) JobGetStuck(ctx context.Context, params *riverdriver.JobGetSt
 	return mapSliceError(jobs, jobRowFromInternal)
 }
 
-func (e *Executor) JobInsertFast(ctx context.Context, params *riverdriver.JobInsertFastParams) (*riverdriver.JobInsertFastResult, error) {
-	result, err := dbsqlc.New().JobInsertFast(ctx, e.dbtx, &dbsqlc.JobInsertFastParams{
-		Args:         string(params.EncodedArgs),
-		CreatedAt:    params.CreatedAt,
-		Kind:         params.Kind,
-		MaxAttempts:  int16(min(params.MaxAttempts, math.MaxInt16)), //nolint:gosec
-		Metadata:     valutil.ValOrDefault(string(params.Metadata), "{}"),
-		Priority:     int16(min(params.Priority, math.MaxInt16)), //nolint:gosec
-		Queue:        params.Queue,
-		ScheduledAt:  params.ScheduledAt,
-		State:        dbsqlc.RiverJobState(params.State),
-		Tags:         params.Tags,
-		UniqueKey:    params.UniqueKey,
-		UniqueStates: pgtypealias.Bits{Bits: pgtype.Bits{Bytes: []byte{params.UniqueStates}, Len: 8, Valid: params.UniqueStates != 0}},
-	})
-	if err != nil {
-		return nil, interpretError(err)
-	}
-	externalJob, err := jobRowFromInternal(&result.RiverJob)
-	if err != nil {
-		return nil, err
-	}
-	return &riverdriver.JobInsertFastResult{Job: externalJob, UniqueSkippedAsDuplicate: result.UniqueSkippedAsDuplicate}, nil
-}
-
 func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.JobInsertFastParams) ([]*riverdriver.JobInsertFastResult, error) {
 	insertJobsParams := &dbsqlc.JobInsertFastManyParams{
 		Args:         make([]string, len(params)),
@@ -239,7 +215,7 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 		UniqueKey:    make([][]byte, len(params)),
 		UniqueStates: make([]pgtypealias.Bits, len(params)),
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 
 	for i := 0; i < len(params); i++ {
 		params := params[i]
@@ -297,7 +273,7 @@ func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params []*r
 		UniqueKey:    make([][]byte, len(params)),
 		UniqueStates: make([]pgtypealias.Bits, len(params)),
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 
 	for i := 0; i < len(params); i++ {
 		params := params[i]

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -42,15 +42,7 @@ updated_job AS (
         finalized_at = CASE WHEN state = 'running' THEN finalized_at ELSE now() END,
         -- Mark the job as cancelled by query so that the rescuer knows not to
         -- rescue it, even if it gets stuck in the running state:
-        metadata = jsonb_set(metadata, '{cancel_attempted_at}'::text[], $3::jsonb, true),
-        -- Similarly, zero a ` + "`" + `unique_key` + "`" + ` if the job is transitioning directly
-        -- to cancelled. Otherwise, it'll be cleared in the job executor.
-        --
-        -- This is transition code to support existing jobs using the old v2
-        -- uniqueness design. We specifically avoid clearing this value if the
-        -- v3 unique_states field is populated, because the v3 design never
-        -- involves clearing unique_key.
-        unique_key = CASE WHEN (state = 'running' OR unique_states IS NOT NULL) THEN unique_key ELSE NULL END
+        metadata = jsonb_set(metadata, '{cancel_attempted_at}'::text[], $3::jsonb, true)
     FROM notification
     WHERE river_job.id = notification.id
     RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags, river_job.unique_key, river_job.unique_states
@@ -207,12 +199,12 @@ WITH locked_jobs AS (
     WHERE
         state = 'available'
         AND queue = $2::text
-        AND scheduled_at <= now()
+        AND scheduled_at <= coalesce($3::timestamptz, now())
     ORDER BY
         priority ASC,
         scheduled_at ASC,
         id ASC
-    LIMIT $3::integer
+    LIMIT $4::integer
     FOR UPDATE
     SKIP LOCKED
 )
@@ -234,11 +226,17 @@ RETURNING
 type JobGetAvailableParams struct {
 	AttemptedBy string
 	Queue       string
+	Now         *time.Time
 	Max         int32
 }
 
 func (q *Queries) JobGetAvailable(ctx context.Context, db DBTX, arg *JobGetAvailableParams) ([]*RiverJob, error) {
-	rows, err := db.Query(ctx, jobGetAvailable, arg.AttemptedBy, arg.Queue, arg.Max)
+	rows, err := db.Query(ctx, jobGetAvailable,
+		arg.AttemptedBy,
+		arg.Queue,
+		arg.Now,
+		arg.Max,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -512,107 +510,6 @@ func (q *Queries) JobGetStuck(ctx context.Context, db DBTX, arg *JobGetStuckPara
 		return nil, err
 	}
 	return items, nil
-}
-
-const jobInsertFast = `-- name: JobInsertFast :one
-INSERT INTO river_job(
-    args,
-    created_at,
-    finalized_at,
-    kind,
-    max_attempts,
-    metadata,
-    priority,
-    queue,
-    scheduled_at,
-    state,
-    tags,
-    unique_key,
-    unique_states
-) VALUES (
-    $1,
-    coalesce($2::timestamptz, now()),
-    $3,
-    $4,
-    $5,
-    coalesce($6::jsonb, '{}'),
-    $7,
-    $8,
-    coalesce($9::timestamptz, now()),
-    $10,
-    coalesce($11::varchar(255)[], '{}'),
-    $12,
-    $13
-)
-ON CONFLICT (unique_key)
-    WHERE unique_key IS NOT NULL
-      AND unique_states IS NOT NULL
-      AND river_job_state_in_bitmask(unique_states, state)
-    -- Something needs to be updated for a row to be returned on a conflict.
-    DO UPDATE SET kind = EXCLUDED.kind
-RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags, river_job.unique_key, river_job.unique_states, (xmax != 0) AS unique_skipped_as_duplicate
-`
-
-type JobInsertFastParams struct {
-	Args         []byte
-	CreatedAt    *time.Time
-	FinalizedAt  *time.Time
-	Kind         string
-	MaxAttempts  int16
-	Metadata     []byte
-	Priority     int16
-	Queue        string
-	ScheduledAt  *time.Time
-	State        RiverJobState
-	Tags         []string
-	UniqueKey    []byte
-	UniqueStates pgtype.Bits
-}
-
-type JobInsertFastRow struct {
-	RiverJob                 RiverJob
-	UniqueSkippedAsDuplicate bool
-}
-
-func (q *Queries) JobInsertFast(ctx context.Context, db DBTX, arg *JobInsertFastParams) (*JobInsertFastRow, error) {
-	row := db.QueryRow(ctx, jobInsertFast,
-		arg.Args,
-		arg.CreatedAt,
-		arg.FinalizedAt,
-		arg.Kind,
-		arg.MaxAttempts,
-		arg.Metadata,
-		arg.Priority,
-		arg.Queue,
-		arg.ScheduledAt,
-		arg.State,
-		arg.Tags,
-		arg.UniqueKey,
-		arg.UniqueStates,
-	)
-	var i JobInsertFastRow
-	err := row.Scan(
-		&i.RiverJob.ID,
-		&i.RiverJob.Args,
-		&i.RiverJob.Attempt,
-		&i.RiverJob.AttemptedAt,
-		&i.RiverJob.AttemptedBy,
-		&i.RiverJob.CreatedAt,
-		&i.RiverJob.Errors,
-		&i.RiverJob.FinalizedAt,
-		&i.RiverJob.Kind,
-		&i.RiverJob.MaxAttempts,
-		&i.RiverJob.Metadata,
-		&i.RiverJob.Priority,
-		&i.RiverJob.Queue,
-		&i.RiverJob.State,
-		&i.RiverJob.ScheduledAt,
-		&i.RiverJob.Tags,
-		&i.RiverJob.UniqueKey,
-		&i.RiverJob.UniqueStates,
-		&i.UniqueSkippedAsDuplicate,
-	)
-	return &i, err
 }
 
 const jobInsertFastMany = `-- name: JobInsertFastMany :many
@@ -1223,12 +1120,7 @@ updated_job AS (
         max_attempts = CASE WHEN NOT should_cancel AND $7::boolean     THEN $8
                             ELSE max_attempts END,
         scheduled_at = CASE WHEN NOT should_cancel AND $9::boolean  THEN $10::timestamptz
-                            ELSE scheduled_at END,
-        -- This is transitional code for the v2 uniqueness design. We specifically
-        -- avoid clearing this value if the v3 unique_states field is populated,
-        -- because the v3 design never involves clearing unique_key.
-        unique_key   = CASE WHEN (unique_states IS NULL AND ($1 IN ('cancelled', 'discarded') OR should_cancel)) THEN NULL
-                            ELSE unique_key END
+                            ELSE scheduled_at END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id
         AND river_job.state = 'running'
@@ -1424,11 +1316,8 @@ SET
     attempted_at = CASE WHEN $3::boolean THEN $4 ELSE attempted_at END,
     errors = CASE WHEN $5::boolean THEN $6::jsonb[] ELSE errors END,
     finalized_at = CASE WHEN $7::boolean THEN $8 ELSE finalized_at END,
-    state = CASE WHEN $9::boolean THEN $10 ELSE state END,
-    -- Transitional code to support tests for v2 uniqueness design. This field
-    -- is never modified in the v3 design.
-    unique_key = CASE WHEN $11::boolean THEN $12 ELSE unique_key END
-WHERE id = $13
+    state = CASE WHEN $9::boolean THEN $10 ELSE state END
+WHERE id = $11
 RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 `
 
@@ -1443,8 +1332,6 @@ type JobUpdateParams struct {
 	FinalizedAt         *time.Time
 	StateDoUpdate       bool
 	State               RiverJobState
-	UniqueKeyDoUpdate   bool
-	UniqueKey           []byte
 	ID                  int64
 }
 
@@ -1462,8 +1349,6 @@ func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) 
 		arg.FinalizedAt,
 		arg.StateDoUpdate,
 		arg.State,
-		arg.UniqueKeyDoUpdate,
-		arg.UniqueKey,
 		arg.ID,
 	)
 	var i RiverJob


### PR DESCRIPTION
This removes the original unique jobs implementation in its entirety. It was already deprecated in the previous release.

🗒️ I'm not quite ready to merge this yet (I'd like to get the Ruby + Python clients to ship the new unique jobs changes first) but I still wanted to prepare it while the context is fresh. It's also needed to simplify some upcoming Pro changes.

All known use cases are better supported with the new unique jobs implementation which is also dramatically faster and supports batch insertion.

As part of this change, single insertions now inherit the behavior of batch insertions as far as always setting a `scheduled_at` time in the job args prior to hitting the database. This is due to the difficulty of trying to pass an array of nullable timestamps for `scheduled_at` to the database using sqlc. One side effect of this is that some tests needed to be updated because they run in a transaction, which locks in a particular `now()` time used in `JobGetAvailble` by default. Jobs inserted _after_ the start of that transaction would pick up a scheduled timestamp from Go code that is _later_ than the database transaction's timestamp, and so those jobs would never run. This was fixed in some cases by allowing `now` to be overridden by lower level callers of that query, whereas other tests were updated to simply insert jobs with a past `scheduled_at` to ensure their visibility.

### TODO

* [x] Changelog entry

Currently based on #613.