### PR TITLE
BatchCompleter: batch all ops, not just completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `BatchCompleter` that marks jobs as completed can now batch database updates for _all_ states of jobs that have finished execution. Prior to this change, only `completed` jobs were batched into a single `UPDATE` call, while jobs moving to any other state used a single `UPDATE` per job. This change should significantly reduce database and pool contention on high volume system when jobs get retried, snoozed, cancelled, or discarded following execution. [PR #617](https://github.com/riverqueue/river/pull/617).
+
 ## [0.12.0] - 2024-09-23
 
 ⚠️ Version 0.12.0 contains a new database migration, version 6. See [documentation on running River migrations](https://riverqueue.com/docs/migrations). If migrating with the CLI, make sure to update it to its latest version:

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -126,6 +126,7 @@ type Executor interface {
 	JobSchedule(ctx context.Context, params *JobScheduleParams) ([]*JobScheduleResult, error)
 	JobSetCompleteIfRunningMany(ctx context.Context, params *JobSetCompleteIfRunningManyParams) ([]*rivertype.JobRow, error)
 	JobSetStateIfRunning(ctx context.Context, params *JobSetStateIfRunningParams) (*rivertype.JobRow, error)
+	JobSetStateIfRunningMany(ctx context.Context, params *JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error)
 	JobUpdate(ctx context.Context, params *JobUpdateParams) (*rivertype.JobRow, error)
 	LeaderAttemptElect(ctx context.Context, params *LeaderElectParams) (bool, error)
 	LeaderAttemptReelect(ctx context.Context, params *LeaderElectParams) (bool, error)
@@ -353,6 +354,18 @@ func JobSetStateSnoozed(id int64, scheduledAt time.Time, maxAttempts int) *JobSe
 
 func JobSetStateSnoozedAvailable(id int64, scheduledAt time.Time, maxAttempts int) *JobSetStateIfRunningParams {
 	return &JobSetStateIfRunningParams{ID: id, MaxAttempts: &maxAttempts, ScheduledAt: &scheduledAt, State: rivertype.JobStateAvailable}
+}
+
+// JobSetStateIfRunningManyParams are parameters to update the state of
+// currently running jobs. Use one of the constructors below to ensure a correct
+// combination of parameters.
+type JobSetStateIfRunningManyParams struct {
+	ID          []int64
+	ErrData     [][]byte
+	FinalizedAt []*time.Time
+	MaxAttempts []*int
+	ScheduledAt []*time.Time
+	State       []rivertype.JobState
 }
 
 type JobUpdateParams struct {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -1283,6 +1283,133 @@ func (q *Queries) JobSetStateIfRunning(ctx context.Context, db DBTX, arg *JobSet
 	return &i, err
 }
 
+const jobSetStateIfRunningMany = `-- name: JobSetStateIfRunningMany :many
+WITH job_input AS (
+    SELECT
+        unnest($1::bigint[]) AS id,
+        -- To avoid requiring pgx users to register the OID of the river_job_state[]
+        -- type, we cast the array to text[] and then to river_job_state.
+        unnest($2::text[])::river_job_state AS state,
+        unnest($3::boolean[]) AS finalized_at_do_update,
+        unnest($4::timestamptz[]) AS finalized_at,
+        unnest($5::boolean[]) AS errors_do_update,
+        unnest($6::jsonb[]) AS errors,
+        unnest($7::boolean[]) AS max_attempts_do_update,
+        unnest($8::int[]) AS max_attempts,
+        unnest($9::boolean[]) AS scheduled_at_do_update,
+        unnest($10::timestamptz[]) AS scheduled_at
+),
+job_to_update AS (
+    SELECT
+        river_job.id,
+        job_input.state,
+        job_input.finalized_at,
+        job_input.errors,
+        job_input.max_attempts,
+        job_input.scheduled_at,
+        (job_input.state IN ('retryable', 'scheduled') AND river_job.metadata ? 'cancel_attempted_at') AS should_cancel,
+        job_input.finalized_at_do_update,
+        job_input.errors_do_update,
+        job_input.max_attempts_do_update,
+        job_input.scheduled_at_do_update
+    FROM river_job
+    JOIN job_input ON river_job.id = job_input.id
+    WHERE river_job.state = 'running'
+    FOR UPDATE
+),
+updated_job AS (
+    UPDATE river_job
+    SET
+        state        = CASE WHEN job_to_update.should_cancel THEN 'cancelled'::river_job_state
+                            ELSE job_to_update.state END,
+        finalized_at = CASE WHEN job_to_update.should_cancel THEN now()
+                            WHEN job_to_update.finalized_at_do_update THEN job_to_update.finalized_at
+                            ELSE river_job.finalized_at END,
+        errors       = CASE WHEN job_to_update.errors_do_update THEN array_append(river_job.errors, job_to_update.errors)
+                            ELSE river_job.errors END,
+        max_attempts = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.max_attempts_do_update THEN job_to_update.max_attempts
+                            ELSE river_job.max_attempts END,
+        scheduled_at = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.scheduled_at_do_update THEN job_to_update.scheduled_at
+                            ELSE river_job.scheduled_at END
+    FROM job_to_update
+    WHERE river_job.id = job_to_update.id
+    RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags, river_job.unique_key, river_job.unique_states
+)
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+FROM river_job
+WHERE id IN (SELECT id FROM job_input)
+  AND id NOT IN (SELECT id FROM updated_job)
+UNION
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+FROM updated_job
+`
+
+type JobSetStateIfRunningManyParams struct {
+	IDs                 []int64
+	State               []string
+	FinalizedAtDoUpdate []bool
+	FinalizedAt         []time.Time
+	ErrorsDoUpdate      []bool
+	Errors              []string
+	MaxAttemptsDoUpdate []bool
+	MaxAttempts         []int32
+	ScheduledAtDoUpdate []bool
+	ScheduledAt         []time.Time
+}
+
+func (q *Queries) JobSetStateIfRunningMany(ctx context.Context, db DBTX, arg *JobSetStateIfRunningManyParams) ([]*RiverJob, error) {
+	rows, err := db.QueryContext(ctx, jobSetStateIfRunningMany,
+		pq.Array(arg.IDs),
+		pq.Array(arg.State),
+		pq.Array(arg.FinalizedAtDoUpdate),
+		pq.Array(arg.FinalizedAt),
+		pq.Array(arg.ErrorsDoUpdate),
+		pq.Array(arg.Errors),
+		pq.Array(arg.MaxAttemptsDoUpdate),
+		pq.Array(arg.MaxAttempts),
+		pq.Array(arg.ScheduledAtDoUpdate),
+		pq.Array(arg.ScheduledAt),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			pq.Array(&i.AttemptedBy),
+			&i.CreatedAt,
+			pq.Array(&i.Errors),
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			pq.Array(&i.Tags),
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const jobUpdate = `-- name: JobUpdate :one
 UPDATE river_job
 SET

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
@@ -28,6 +28,7 @@ sql:
         emit_result_struct_pointers: true
 
         rename:
+          ids: "IDs"
           ttl: "TTL"
 
         overrides:

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -523,6 +523,66 @@ UNION
 SELECT *
 FROM updated_job;
 
+-- name: JobSetStateIfRunningMany :many
+WITH job_input AS (
+    SELECT
+        unnest(@ids::bigint[]) AS id,
+        -- To avoid requiring pgx users to register the OID of the river_job_state[]
+        -- type, we cast the array to text[] and then to river_job_state.
+        unnest(@state::text[])::river_job_state AS state,
+        unnest(@finalized_at_do_update::boolean[]) AS finalized_at_do_update,
+        unnest(@finalized_at::timestamptz[]) AS finalized_at,
+        unnest(@errors_do_update::boolean[]) AS errors_do_update,
+        unnest(@errors::jsonb[]) AS errors,
+        unnest(@max_attempts_do_update::boolean[]) AS max_attempts_do_update,
+        unnest(@max_attempts::int[]) AS max_attempts,
+        unnest(@scheduled_at_do_update::boolean[]) AS scheduled_at_do_update,
+        unnest(@scheduled_at::timestamptz[]) AS scheduled_at
+),
+job_to_update AS (
+    SELECT
+        river_job.id,
+        job_input.state,
+        job_input.finalized_at,
+        job_input.errors,
+        job_input.max_attempts,
+        job_input.scheduled_at,
+        (job_input.state IN ('retryable', 'scheduled') AND river_job.metadata ? 'cancel_attempted_at') AS should_cancel,
+        job_input.finalized_at_do_update,
+        job_input.errors_do_update,
+        job_input.max_attempts_do_update,
+        job_input.scheduled_at_do_update
+    FROM river_job
+    JOIN job_input ON river_job.id = job_input.id
+    WHERE river_job.state = 'running'
+    FOR UPDATE
+),
+updated_job AS (
+    UPDATE river_job
+    SET
+        state        = CASE WHEN job_to_update.should_cancel THEN 'cancelled'::river_job_state
+                            ELSE job_to_update.state END,
+        finalized_at = CASE WHEN job_to_update.should_cancel THEN now()
+                            WHEN job_to_update.finalized_at_do_update THEN job_to_update.finalized_at
+                            ELSE river_job.finalized_at END,
+        errors       = CASE WHEN job_to_update.errors_do_update THEN array_append(river_job.errors, job_to_update.errors)
+                            ELSE river_job.errors END,
+        max_attempts = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.max_attempts_do_update THEN job_to_update.max_attempts
+                            ELSE river_job.max_attempts END,
+        scheduled_at = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.scheduled_at_do_update THEN job_to_update.scheduled_at
+                            ELSE river_job.scheduled_at END
+    FROM job_to_update
+    WHERE river_job.id = job_to_update.id
+    RETURNING river_job.*
+)
+SELECT *
+FROM river_job
+WHERE id IN (SELECT id FROM job_input)
+  AND id NOT IN (SELECT id FROM updated_job)
+UNION
+SELECT *
+FROM updated_job;
+
 -- A generalized update for any property on a job. This brings in a large number
 -- of parameters and therefore may be more suitable for testing than production.
 -- name: JobUpdate :one

--- a/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/sqlc.yaml
@@ -29,6 +29,7 @@ sql:
         emit_result_struct_pointers: true
 
         rename:
+          ids: "IDs"
           ttl: "TTL"
 
         overrides:

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -460,6 +460,46 @@ func (e *Executor) JobSetStateIfRunning(ctx context.Context, params *riverdriver
 	return jobRowFromInternal(job)
 }
 
+func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error) {
+	setStateParams := &dbsqlc.JobSetStateIfRunningManyParams{
+		IDs:                 params.ID,
+		Errors:              params.ErrData,
+		ErrorsDoUpdate:      make([]bool, len(params.ID)),
+		FinalizedAt:         make([]time.Time, len(params.ID)),
+		FinalizedAtDoUpdate: make([]bool, len(params.ID)),
+		MaxAttempts:         make([]int32, len(params.ID)),
+		MaxAttemptsDoUpdate: make([]bool, len(params.ID)),
+		ScheduledAt:         make([]time.Time, len(params.ID)),
+		ScheduledAtDoUpdate: make([]bool, len(params.ID)),
+		State:               make([]string, len(params.ID)),
+	}
+
+	for i := 0; i < len(params.ID); i++ {
+		if params.ErrData[i] != nil {
+			setStateParams.ErrorsDoUpdate[i] = true
+		}
+		if params.FinalizedAt[i] != nil {
+			setStateParams.FinalizedAtDoUpdate[i] = true
+			setStateParams.FinalizedAt[i] = *params.FinalizedAt[i]
+		}
+		if params.MaxAttempts[i] != nil {
+			setStateParams.MaxAttemptsDoUpdate[i] = true
+			setStateParams.MaxAttempts[i] = int32(*params.MaxAttempts[i]) //nolint:gosec
+		}
+		if params.ScheduledAt[i] != nil {
+			setStateParams.ScheduledAtDoUpdate[i] = true
+			setStateParams.ScheduledAt[i] = *params.ScheduledAt[i]
+		}
+		setStateParams.State[i] = string(params.State[i])
+	}
+
+	jobs, err := dbsqlc.New().JobSetStateIfRunningMany(ctx, e.dbtx, setStateParams)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return mapSliceError(jobs, jobRowFromInternal)
+}
+
 func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateParams) (*rivertype.JobRow, error) {
 	job, err := dbsqlc.New().JobUpdate(ctx, e.dbtx, &dbsqlc.JobUpdateParams{
 		ID:                  params.ID,


### PR DESCRIPTION
This adds a `JobSetStateIfRunningMany` query and corresponding driver API, with implementations for both pgxv5 and `database/sql`.

The `BatchCompleter` was updated to use this new query and to batch _all_ operations, not only those moving to a `complete` state. This means the `AsyncCompleter` (as well as the `InlineCompleter`) are both now unused and could be deleted, along with their underlying queries.

The intention of this is not just to facilitate improved performance even on snoozes, retries, errors, cancellations, etc., but also to get down to a single path for completions (similar to now having a single path for insertions).

## Benchmarks

These changes show a slight decrease in performance for the case of 100% completed jobs, but with the benefit of a significant improvement for a mix of jobs. With a normal workload including snoozes, cancellations, etc, we would expect this change to reduce overall contention due to fewer concurrent transactions and fewer conns active on a given database pool.

### Before

```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^(BenchmarkAsyncCompleter_Concurrency10|BenchmarkAsyncCompleter_Concurrency100|BenchmarkBatchCompleter|BenchmarkInlineCompleter)$ github.com/riverqueue/river/internal/jobcompleter

goos: darwin
goarch: arm64
pkg: github.com/riverqueue/river/internal/jobcompleter
cpu: Apple M1 Max
BenchmarkBatchCompleter/Completion-10                       	   79447	     16670 ns/op	    1535 B/op	      18 allocs/op
--- BENCH: BenchmarkBatchCompleter/Completion-10
    logger.go:257: time=2024-09-24T21:01:07.323-05:00 level=WARN msg="BatchCompleter: Hit maximum backlog; completions will wait until below threshold" max_backlog=20000
    logger.go:257: time=2024-09-24T21:01:07.756-05:00 level=WARN msg="BatchCompleter: Hit maximum backlog; completions will wait until below threshold" max_backlog=20000
    logger.go:257: time=2024-09-24T21:01:08.083-05:00 level=WARN msg="BatchCompleter: Hit maximum backlog; completions will wait until below threshold" max_backlog=20000
BenchmarkBatchCompleter/RotatingStates-10                   	   22052	     51476 ns/op	    3816 B/op	      54 allocs/op
PASS
ok  	github.com/riverqueue/river/internal/jobcompleter	19.210s
```

### After

```
Running tool: /opt/homebrew/bin/go test -benchmem -run=^$ -bench ^(BenchmarkAsyncCompleter_Concurrency10|BenchmarkAsyncCompleter_Concurrency100|BenchmarkBatchCompleter|BenchmarkInlineCompleter)$ github.com/riverqueue/river/internal/jobcompleter

goos: darwin
goarch: arm64
pkg: github.com/riverqueue/river/internal/jobcompleter
cpu: Apple M1 Max
BenchmarkBatchCompleter/Completion-10                       	   58850	     19416 ns/op	    2462 B/op	      26 allocs/op
--- BENCH: BenchmarkBatchCompleter/Completion-10
    logger.go:257: time=2024-09-24T21:07:05.374-05:00 level=WARN msg="BatchCompleter: Hit maximum backlog; completions will wait until below threshold" max_backlog=20000
    logger.go:257: time=2024-09-24T21:07:05.816-05:00 level=WARN msg="BatchCompleter: Hit maximum backlog; completions will wait until below threshold" max_backlog=20000
BenchmarkBatchCompleter/RotatingStates-10                   	   70927	     19355 ns/op	    2625 B/op	      30 allocs/op
--- BENCH: BenchmarkBatchCompleter/RotatingStates-10
    logger.go:257: time=2024-09-24T21:07:08.036-05:00 level=WARN msg="BatchCompleter: Hit maximum backlog; completions will wait until below threshold" max_backlog=20000
    logger.go:257: time=2024-09-24T21:07:08.505-05:00 level=WARN msg="BatchCompleter: Hit maximum backlog; completions will wait until below threshold" max_backlog=20000
PASS
ok  	github.com/riverqueue/river/internal/jobcompleter	18.182s
```
