### PR TITLE
Add middleware system for jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ⚠️ Version 0.13.0 removes the original advisory lock based unique jobs implementation that was deprecated in v0.12.0. See details in the note below or the v0.12.0 release notes.
 
+### Added
+
+- A middleware system was added for job insertion and execution, providing the ability to extract shared functionality across workers. Both `JobInsertMiddleware` and `WorkerMiddleware` can be configured globally on the `Client`, and `WorkerMiddleware` can also be added on a per-worker basis using the new `Middleware` method on `Worker[T]`. Middleware can be useful for logging, telemetry, or for building higher level abstractions on top of base River functionality.
+
+  Despite the interface expansion, users should not encounter any breakage if they're embedding the `WorkerDefaults` type in their workers as recommended. [PR #632](https://github.com/riverqueue/river/pull/632).
+
 ### Changed
 
 - **Breaking change:** The advisory lock unique jobs implementation which was deprecated in v0.12.0 has been removed. Users of that feature should first upgrade to v0.12.1 to ensure they don't see any warning logs about using the deprecated advisory lock uniqueness. The new, faster unique implementation will be used automatically as long as the `UniqueOpts.ByState` list hasn't been customized to remove [required states](https://riverqueue.com/docs/unique-jobs#unique-by-state) (`pending`, `scheduled`, `available`, and `running`). As of this release, customizing `ByState` without these required states returns an error. [PR #614](https://github.com/riverqueue/river/pull/614).

--- a/internal/dbunique/db_unique.go
+++ b/internal/dbunique/db_unique.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
-	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
@@ -64,7 +63,7 @@ func (o *UniqueOpts) StateBitmask() byte {
 	return UniqueStatesToBitmask(states)
 }
 
-func UniqueKey(timeGen baseservice.TimeGenerator, uniqueOpts *UniqueOpts, params *riverdriver.JobInsertFastParams) ([]byte, error) {
+func UniqueKey(timeGen baseservice.TimeGenerator, uniqueOpts *UniqueOpts, params *rivertype.JobInsertParams) ([]byte, error) {
 	uniqueKeyString, err := buildUniqueKeyString(timeGen, uniqueOpts, params)
 	if err != nil {
 		return nil, err
@@ -74,9 +73,8 @@ func UniqueKey(timeGen baseservice.TimeGenerator, uniqueOpts *UniqueOpts, params
 }
 
 // Builds a unique key made up of the unique options in place. The key is hashed
-// to become a value for `unique_key` in the fast insertion path, or hashed and
-// used for an advisory lock on the slow insertion path.
-func buildUniqueKeyString(timeGen baseservice.TimeGenerator, uniqueOpts *UniqueOpts, params *riverdriver.JobInsertFastParams) (string, error) {
+// to become a value for `unique_key`.
+func buildUniqueKeyString(timeGen baseservice.TimeGenerator, uniqueOpts *UniqueOpts, params *rivertype.JobInsertParams) (string, error) {
 	var sb strings.Builder
 
 	if !uniqueOpts.ExcludeKind {

--- a/internal/dbunique/db_unique_test.go
+++ b/internal/dbunique/db_unique_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -229,7 +228,7 @@ func TestUniqueKey(t *testing.T) {
 				states = tt.uniqueOpts.ByState
 			}
 
-			jobParams := &riverdriver.JobInsertFastParams{
+			jobParams := &rivertype.JobInsertParams{
 				Args:         args,
 				CreatedAt:    &now,
 				EncodedArgs:  encodedArgs,

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -38,10 +38,11 @@ type callbackWorkUnit struct {
 	timeout  time.Duration // defaults to 0, which signals default timeout
 }
 
-func (w *callbackWorkUnit) NextRetry() time.Time           { return time.Now().Add(30 * time.Second) }
-func (w *callbackWorkUnit) Timeout() time.Duration         { return w.timeout }
-func (w *callbackWorkUnit) Work(ctx context.Context) error { return w.callback(ctx, w.jobRow) }
-func (w *callbackWorkUnit) UnmarshalJob() error            { return nil }
+func (w *callbackWorkUnit) Middleware() []rivertype.WorkerMiddleware { return nil }
+func (w *callbackWorkUnit) NextRetry() time.Time                     { return time.Now().Add(30 * time.Second) }
+func (w *callbackWorkUnit) Timeout() time.Duration                   { return w.timeout }
+func (w *callbackWorkUnit) Work(ctx context.Context) error           { return w.callback(ctx, w.jobRow) }
+func (w *callbackWorkUnit) UnmarshalJob() error                      { return nil }
 
 type SimpleClientRetryPolicy struct{}
 

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -38,7 +38,7 @@ func (ts *PeriodicJobEnqueuerTestSignals) Init() {
 // river.PeriodicJobArgs, but needs a separate type because the enqueuer is in a
 // subpackage.
 type PeriodicJob struct {
-	ConstructorFunc func() (*riverdriver.JobInsertFastParams, error)
+	ConstructorFunc func() (*rivertype.JobInsertParams, error)
 	RunOnStart      bool
 	ScheduleFunc    func(time.Time) time.Time
 
@@ -373,7 +373,7 @@ func (s *PeriodicJobEnqueuer) insertBatch(ctx context.Context, insertParamsMany 
 	s.TestSignals.InsertedJobs.Signal(struct{}{})
 }
 
-func (s *PeriodicJobEnqueuer) insertParamsFromConstructor(ctx context.Context, constructorFunc func() (*riverdriver.JobInsertFastParams, error), scheduledAt time.Time) (*riverdriver.JobInsertFastParams, bool) {
+func (s *PeriodicJobEnqueuer) insertParamsFromConstructor(ctx context.Context, constructorFunc func() (*rivertype.JobInsertParams, error), scheduledAt time.Time) (*riverdriver.JobInsertFastParams, bool) {
 	insertParams, err := constructorFunc()
 	if err != nil {
 		if errors.Is(err, ErrNoJobToInsert) {
@@ -389,7 +389,7 @@ func (s *PeriodicJobEnqueuer) insertParamsFromConstructor(ctx context.Context, c
 		insertParams.ScheduledAt = &scheduledAt
 	}
 
-	return insertParams, true
+	return (*riverdriver.JobInsertFastParams)(insertParams), true
 }
 
 const periodicJobEnqueuerVeryLongDuration = 24 * time.Hour

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -40,9 +40,9 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 	stubSvc := &riversharedtest.TimeStub{}
 	stubSvc.StubNowUTC(time.Now().UTC())
 
-	jobConstructorWithQueueFunc := func(name string, unique bool, queue string) func() (*riverdriver.JobInsertFastParams, error) {
-		return func() (*riverdriver.JobInsertFastParams, error) {
-			params := &riverdriver.JobInsertFastParams{
+	jobConstructorWithQueueFunc := func(name string, unique bool, queue string) func() (*rivertype.JobInsertParams, error) {
+		return func() (*rivertype.JobInsertParams, error) {
+			params := &rivertype.JobInsertParams{
 				Args:        noOpArgs{},
 				EncodedArgs: []byte("{}"),
 				Kind:        name,
@@ -66,7 +66,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		}
 	}
 
-	jobConstructorFunc := func(name string, unique bool) func() (*riverdriver.JobInsertFastParams, error) {
+	jobConstructorFunc := func(name string, unique bool) func() (*rivertype.JobInsertParams, error) {
 		return jobConstructorWithQueueFunc(name, unique, rivercommon.QueueDefault)
 	}
 
@@ -256,7 +256,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc.AddMany([]*PeriodicJob{
 			// skip this insert when it returns nil:
-			{ScheduleFunc: periodicIntervalSchedule(time.Second), ConstructorFunc: func() (*riverdriver.JobInsertFastParams, error) {
+			{ScheduleFunc: periodicIntervalSchedule(time.Second), ConstructorFunc: func() (*rivertype.JobInsertParams, error) {
 				return nil, ErrNoJobToInsert
 			}, RunOnStart: true},
 		})

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/riverinternaltest/sharedtx"
-	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivertype"
 )
 
 type testService struct {
@@ -107,7 +107,7 @@ func TestQueueMaintainer(t *testing.T) {
 			NewPeriodicJobEnqueuer(archetype, &PeriodicJobEnqueuerConfig{
 				PeriodicJobs: []*PeriodicJob{
 					{
-						ConstructorFunc: func() (*riverdriver.JobInsertFastParams, error) {
+						ConstructorFunc: func() (*rivertype.JobInsertParams, error) {
 							return nil, ErrNoJobToInsert
 						},
 						ScheduleFunc: cron.Every(15 * time.Minute).Next,

--- a/internal/workunit/work_unit.go
+++ b/internal/workunit/work_unit.go
@@ -15,6 +15,7 @@ import (
 //
 // Implemented by river.wrapperWorkUnit.
 type WorkUnit interface {
+	Middleware() []rivertype.WorkerMiddleware
 	NextRetry() time.Time
 	Timeout() time.Duration
 	UnmarshalJob() error

--- a/middleware_defaults.go
+++ b/middleware_defaults.go
@@ -1,0 +1,23 @@
+package river
+
+import (
+	"context"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+// JobInsertMiddlewareDefaults is an embeddable struct that provides default
+// implementations for the rivertype.JobInsertMiddleware. Use of this struct is
+// recommended in case rivertype.JobInsertMiddleware is expanded in the future so that
+// existing code isn't unexpectedly broken during an upgrade.
+type JobInsertMiddlewareDefaults struct{}
+
+func (d *JobInsertMiddlewareDefaults) InsertMany(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error) {
+	return doInner(ctx)
+}
+
+type WorkerMiddlewareDefaults struct{}
+
+func (d *WorkerMiddlewareDefaults) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+	return doInner(ctx)
+}

--- a/middleware_defaults_test.go
+++ b/middleware_defaults_test.go
@@ -1,0 +1,8 @@
+package river
+
+import "github.com/riverqueue/river/rivertype"
+
+var (
+	_ rivertype.JobInsertMiddleware = &JobInsertMiddlewareDefaults{}
+	_ rivertype.WorkerMiddleware    = &WorkerMiddlewareDefaults{}
+)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,29 @@
+package river
+
+import (
+	"context"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+type overridableJobMiddleware struct {
+	JobInsertMiddlewareDefaults
+	WorkerMiddlewareDefaults
+
+	insertManyFunc func(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error)
+	workFunc       func(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error
+}
+
+func (m *overridableJobMiddleware) InsertMany(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error) {
+	if m.insertManyFunc != nil {
+		return m.insertManyFunc(ctx, manyParams, doInner)
+	}
+	return m.JobInsertMiddlewareDefaults.InsertMany(ctx, manyParams, doInner)
+}
+
+func (m *overridableJobMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+	if m.workFunc != nil {
+		return m.workFunc(ctx, job, doInner)
+	}
+	return m.WorkerMiddlewareDefaults.Work(ctx, job, doInner)
+}

--- a/periodic_job.go
+++ b/periodic_job.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/riverqueue/river/internal/maintenance"
-	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -180,7 +179,7 @@ func (b *PeriodicJobBundle) toInternal(periodicJob *PeriodicJob) *maintenance.Pe
 		opts = periodicJob.opts
 	}
 	return &maintenance.PeriodicJob{
-		ConstructorFunc: func() (*riverdriver.JobInsertFastParams, error) {
+		ConstructorFunc: func() (*rivertype.JobInsertParams, error) {
 			args, options := periodicJob.constructorFunc()
 			if args == nil {
 				return nil, maintenance.ErrNoJobToInsert

--- a/producer.go
+++ b/producer.go
@@ -63,8 +63,9 @@ type producerConfig struct {
 	// LISTEN/NOTIFY, but this provides a fallback.
 	FetchPollInterval time.Duration
 
-	JobTimeout time.Duration
-	MaxWorkers int
+	GlobalMiddleware []rivertype.WorkerMiddleware
+	JobTimeout       time.Duration
+	MaxWorkers       int
 
 	// Notifier is a notifier for subscribing to new job inserts and job
 	// control. If nil, the producer will operate in poll-only mode.
@@ -579,6 +580,7 @@ func (p *producer) startNewExecutors(workCtx context.Context, jobs []*rivertype.
 			Completer:              p.completer,
 			ErrorHandler:           p.errorHandler,
 			InformProducerDoneFunc: p.handleWorkerDone,
+			GlobalMiddleware:       p.config.GlobalMiddleware,
 			JobRow:                 job,
 			SchedulerInterval:      p.config.SchedulerInterval,
 			WorkUnit:               workUnit,

--- a/producer_test.go
+++ b/producer_test.go
@@ -105,7 +105,7 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 		insertParams, err := insertParamsFromConfigArgsAndOptions(archetype, config, WithJobNumArgs{JobNum: i}, nil)
 		require.NoError(err)
 
-		params[i] = insertParams
+		params[i] = (*riverdriver.JobInsertFastParams)(insertParams)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -295,7 +295,7 @@ func testProducer(t *testing.T, makeProducer func(ctx context.Context, t *testin
 			insertParams.ScheduledAt = &bundle.timeBeforeStart
 		}
 
-		_, err = bundle.exec.JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{insertParams})
+		_, err = bundle.exec.JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{(*riverdriver.JobInsertFastParams)(insertParams)})
 		require.NoError(t, err)
 	}
 

--- a/work_unit_wrapper.go
+++ b/work_unit_wrapper.go
@@ -29,6 +29,10 @@ func (w *wrapperWorkUnit[T]) NextRetry() time.Time           { return w.worker.N
 func (w *wrapperWorkUnit[T]) Timeout() time.Duration         { return w.worker.Timeout(w.job) }
 func (w *wrapperWorkUnit[T]) Work(ctx context.Context) error { return w.worker.Work(ctx, w.job) }
 
+func (w *wrapperWorkUnit[T]) Middleware() []rivertype.WorkerMiddleware {
+	return w.worker.Middleware(w.job)
+}
+
 func (w *wrapperWorkUnit[T]) UnmarshalJob() error {
 	w.job = &Job[T]{
 		JobRow: w.jobRow,

--- a/worker.go
+++ b/worker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/riverqueue/river/internal/workunit"
+	"github.com/riverqueue/river/rivertype"
 )
 
 // Worker is an interface that can perform a job with args of type T. A typical
@@ -36,6 +37,9 @@ import (
 // In addition to fulfilling the Worker interface, workers must be registered
 // with the client using the AddWorker function.
 type Worker[T JobArgs] interface {
+	// Middleware returns the type-specific middleware for this job.
+	Middleware(job *Job[T]) []rivertype.WorkerMiddleware
+
 	// NextRetry calculates when the next retry for a failed job should take
 	// place given when it was last attempted and its number of attempts, or any
 	// other of the job's properties a user-configured retry policy might want
@@ -69,6 +73,8 @@ type Worker[T JobArgs] interface {
 // WorkerDefaults is an empty struct that can be embedded in your worker
 // struct to make it fulfill the Worker interface with default values.
 type WorkerDefaults[T JobArgs] struct{}
+
+func (w WorkerDefaults[T]) Middleware(*Job[T]) []rivertype.WorkerMiddleware { return nil }
 
 // NextRetry returns an empty time.Time{} to avoid setting any job or
 // Worker-specific overrides on the next retry time. This means that the


### PR DESCRIPTION
This is a rebased version of #584 that's been adapted for recent changes including consolidated insert logic and the newer unique jobs implementation.

Here, implement a middleware system that adds middleware functions to job lifecycles, which results in them being invoked during specific phases of a job like as it's being inserted or worked.

The most obvious unlock for this is telemetry (e.g. logging, metrics), but it also acts as a building block for features like encrypted jobs.

There are two middleware interfaces added: `JobInsertMiddleware` and `WorkerMiddleware`. A user could implement these on the same struct type for something like telemetry where you want to inject a trace ID at job insertion, and then resurrect it into the context at execution time. In other cases, such as execution-specific logic, it may only make sense to implement one of these.

The `Worker[T]` type has been extended with a `Middleware()` method that allows each individual worker type to define its own added lists of middleware which will be run _after_ the global `WorkerMiddleware` at the client config level. There are also global `JobInsertMiddleware` on the client config.