### PR TITLE
docs: update MaxWorkers behaviour as it propagates down to the producer

### DIFF
--- a/client.go
+++ b/client.go
@@ -309,7 +309,8 @@ func (c *Config) willExecuteJobs() bool {
 // QueueConfig contains queue-specific configuration.
 type QueueConfig struct {
 	// MaxWorkers is the maximum number of workers to run for the queue, or put
-	// otherwise, the maximum parallelism to run.
+	// otherwise, the the upper limit on the number of executor goroutines that
+	// will be spawned for the queue, not counting workers already processing jobs.
 	//
 	// This is the maximum number of workers within this particular client
 	// instance, but note that it doesn't control the total number of workers

--- a/client.go
+++ b/client.go
@@ -309,7 +309,7 @@ func (c *Config) willExecuteJobs() bool {
 // QueueConfig contains queue-specific configuration.
 type QueueConfig struct {
 	// MaxWorkers is the maximum number of workers to run for the queue, or put
-	// otherwise, the the upper limit on the number of executor goroutines that
+	// otherwise, the upper limit on the number of executor goroutines that
 	// will be spawned for the queue, not counting workers already processing jobs.
 	//
 	// This is the maximum number of workers within this particular client


### PR DESCRIPTION
refs:

*https://github.com/riverqueue/river/blob/master/producer.go#L598

I think this makes it clear on how the max workers value should be tuned based on the job type.