### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,7 +333,7 @@ river migrate-up --database-url "$DATABASE_URL"
 
 - **Breaking change:** There are a number of small breaking changes in the job list API using `JobList`/`JobListTx`:
   - Now support querying jobs by a list of Job Kinds and States. Also allows for filtering by specific timestamp values. Thank you Jos Kraaijeveld (@thatjos)! 🙏🏻 [PR #236](https://github.com/riverqueue/river/pull/236).
-  - Job listing now defaults to ordering by job ID (`JobListOrderByID`) instead of a job timestamp dependent on on requested job state. The previous ordering behavior is still available with `NewJobListParams().OrderBy(JobListOrderByTime, SortOrderAsc)`. [PR #307](https://github.com/riverqueue/river/pull/307).
+  - Job listing now defaults to ordering by job ID (`JobListOrderByID`) instead of a job timestamp dependent on requested job state. The previous ordering behavior is still available with `NewJobListParams().OrderBy(JobListOrderByTime, SortOrderAsc)`. [PR #307](https://github.com/riverqueue/river/pull/307).
   - The function `JobListCursorFromJob` no longer needs a sort order parameter. Instead, sort order is determined based on the job list parameters that the cursor is subsequently used with. [PR #307](https://github.com/riverqueue/river/pull/307).
 - **Breaking change:** Client `Insert` and `InsertTx` functions now return a `JobInsertResult` struct instead of a `JobRow`. This allows the result to include metadata like the new `UniqueSkippedAsDuplicate` property, so callers can tell whether an inserted job was skipped due to unique constraint. [PR #292](https://github.com/riverqueue/river/pull/292).
 - **Breaking change:** Client `InsertMany` and `InsertManyTx` now return number of jobs inserted as `int` instead of `int64`. This change was made to make the type in use a little more idiomatic. [PR #293](https://github.com/riverqueue/river/pull/293).
@@ -407,7 +407,7 @@ Although it comes with a number of improvements, there's nothing particularly no
 
 - Fixed a memory leak caused by allocating a new random source on every job execution. Thank you @shawnstephens for reporting ❤️ [PR #240](https://github.com/riverqueue/river/pull/240).
 - Fix a problem where `JobListParams.Queues()` didn't filter correctly based on its arguments. [PR #212](https://github.com/riverqueue/river/pull/212).
-- Fix a problem in `DebouncedChan` where it would fire on its "out" channel too often when it was being signaled continuousy on its "in" channel. This would have caused work to be fetched more often than intended in busy systems. [PR #222](https://github.com/riverqueue/river/pull/222).
+- Fix a problem in `DebouncedChan` where it would fire on its "out" channel too often when it was being signaled continuously on its "in" channel. This would have caused work to be fetched more often than intended in busy systems. [PR #222](https://github.com/riverqueue/river/pull/222).
 
 ## [0.0.22] - 2024-02-19
 
@@ -429,7 +429,7 @@ Although it comes with a number of improvements, there's nothing particularly no
 
 ### Added
 
-- Added an `ID` setting to the `Client` `Config` type to allow users to override client IDs with their own naming convention. Expose the client ID programatically (in case it's generated) in a new `Client.ID()` method. [PR #206](https://github.com/riverqueue/river/pull/206).
+- Added an `ID` setting to the `Client` `Config` type to allow users to override client IDs with their own naming convention. Expose the client ID programmatically (in case it's generated) in a new `Client.ID()` method. [PR #206](https://github.com/riverqueue/river/pull/206).
 
 ### Fixed
 
@@ -469,7 +469,7 @@ Although it comes with a number of improvements, there's nothing particularly no
 
 - Fixed incorrect default value handling for `ScheduledAt` option with `InsertMany` / `InsertManyTx`. [PR #149](https://github.com/riverqueue/river/pull/149).
 - Add missing `t.Helper()` calls in `rivertest` internal functions that caused it to report itself as the site of a test failure. [PR #151](https://github.com/riverqueue/river/pull/151).
-- Fixed problem where job uniqueness wasn't being respected when used in conjuction with periodic jobs. [PR #168](https://github.com/riverqueue/river/pull/168).
+- Fixed problem where job uniqueness wasn't being respected when used in conjunction with periodic jobs. [PR #168](https://github.com/riverqueue/river/pull/168).
 
 ## [0.0.16] - 2024-01-06
 
@@ -564,7 +564,7 @@ Although it comes with a number of improvements, there's nothing particularly no
 
 ### Changed
 
-- `JobRow`, `JobState`, and a other related types move into `river/rivertype` so they can more easily be shared amongst packages. Most of the River API doesn't change because `JobRow` is embedded on `river.Job`, which doesn't move.
+- `JobRow`, `JobState`, and other related types move into `river/rivertype` so they can more easily be shared amongst packages. Most of the River API doesn't change because `JobRow` is embedded on `river.Job`, which doesn't move.
 
 ## [0.0.5] - 2023-11-19
 
@@ -579,7 +579,7 @@ Although it comes with a number of improvements, there's nothing particularly no
 - Allow River clients to be created with a driver with `nil` database pool for use in testing.
 - Update River test helpers API to use River drivers like `riverdriver/riverpgxv5` to make them agnostic to the third party database package in use.
 - Document `Config.JobTimeout`'s default value.
-- Functionally disable the `Reindexer` queue maintenance service. It'd previously only operated on currently unused indexes anyway, indexes probably do _not_ need to be rebuilt except under fairly rare circumstances, and it needs more work to make sure it's shored up against edge cases like indexes that fail to rebuild before a clien restart.
+- Functionally disable the `Reindexer` queue maintenance service. It'd previously only operated on currently unused indexes anyway, indexes probably do _not_ need to be rebuilt except under fairly rare circumstances, and it needs more work to make sure it's shored up against edge cases like indexes that fail to rebuild before a client restart.
 
 ## [0.0.3] - 2023-11-13
 

--- a/client.go
+++ b/client.go
@@ -97,7 +97,7 @@ type Config struct {
 
 	// FetchCooldown is the minimum amount of time to wait between fetches of new
 	// jobs. Jobs will only be fetched *at most* this often, but if no new jobs
-	// are coming in via LISTEN/NOTIFY then feches may be delayed as long as
+	// are coming in via LISTEN/NOTIFY then fetches may be delayed as long as
 	// FetchPollInterval.
 	//
 	// Throughput is limited by this value.
@@ -457,7 +457,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 
 	// For convenience, in case the user's specified a large JobTimeout but no
 	// RescueStuckJobsAfter, since RescueStuckJobsAfter must be greater than
-	// JobTimeout, set a reasonable default value that's longer thah JobTimeout.
+	// JobTimeout, set a reasonable default value that's longer than JobTimeout.
 	rescueAfter := maintenance.JobRescuerRescueAfterDefault
 	if config.JobTimeout > 0 && config.RescueStuckJobsAfter < 1 && config.JobTimeout > config.RescueStuckJobsAfter {
 		rescueAfter = config.JobTimeout + maintenance.JobRescuerRescueAfterDefault
@@ -921,7 +921,7 @@ type SubscribeConfig struct {
 	// Requiring that kinds are specified explicitly allows for forward
 	// compatibility in case new kinds of events are added in future versions.
 	// If new event kinds are added, callers will have to explicitly add them to
-	// their requested list and esnure they can be handled correctly.
+	// their requested list and ensure they can be handled correctly.
 	Kinds []EventKind
 }
 
@@ -1059,7 +1059,7 @@ func (c *Client[TTx]) JobCancel(ctx context.Context, jobID int64) (*rivertype.Jo
 
 // JobCancelTx cancels the job with the given ID within the specified
 // transaction. This variant lets a caller cancel a job atomically alongside
-// other database changes. An cancelled job doesn't take effect until the
+// other database changes. A cancelled job doesn't take effect until the
 // transaction commits, and if the transaction rolls back, so too is the
 // cancelled job.
 //

--- a/cmd/river/rivercli/river_cli_test.go
+++ b/cmd/river/rivercli/river_cli_test.go
@@ -107,7 +107,7 @@ func TestBaseCommandSetIntegration(t *testing.T) {
 		}
 	}
 
-	t.Run("DebugVerboseMutallyExclusive", func(t *testing.T) {
+	t.Run("DebugVerboseMutuallyExclusive", func(t *testing.T) {
 		t.Parallel()
 
 		cmd, _ := setup(t)

--- a/docs/README.md
+++ b/docs/README.md
@@ -178,7 +178,7 @@ See [developing River].
 
 ## Thank you
 
-River was in large part inspired by our experiences with other background job libaries over the years, most notably:
+River was in large part inspired by our experiences with other background job libraries over the years, most notably:
 
 - [Oban](https://github.com/sorentwo/oban) in Elixir.
 - [Que](https://github.com/que-rb/que), [Sidekiq](https://github.com/sidekiq/sidekiq), [Delayed::Job](https://github.com/collectiveidea/delayed_job), and [GoodJob](https://github.com/bensheldon/good_job) in Ruby.

--- a/insert_opts.go
+++ b/insert_opts.go
@@ -157,7 +157,7 @@ type UniqueOpts struct {
 	// or `discarded`), though only `retryable` may be safely _removed_ from the
 	// list.
 	//
-	// Warning: Removing any states from the default list (other than `retryable`
+	// Warning: Removing any states from the default list (other than `retryable`)
 	// forces a fallback to a slower insertion path that takes an advisory lock
 	// and performs a look up before insertion. This path is deprecated and should
 	// be avoided if possible.

--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -514,7 +514,7 @@ func (c *BatchCompleter) waitOrInitBacklogChannel(ctx context.Context) {
 	c.Logger.WarnContext(ctx, c.Name+": Hit maximum backlog; completions will wait until below threshold", "max_backlog", c.maxBacklog)
 }
 
-// As configued, total time asleep from initial attempt is ~7 seconds (1 + 2 +
+// As configured, total time asleep from initial attempt is ~7 seconds (1 + 2 +
 // 4) (not including jitter). However, if each attempt times out, that's up to
 // ~37 seconds (7 seconds + 3 * 10 seconds).
 const numRetries = 3

--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -316,7 +316,7 @@ func (e *Elector) keepLeadershipLoop(ctx context.Context) error {
 			return ctx.Err()
 
 		case <-timer.C:
-			// Reelect timer expired; attempt releection below.
+			// Reelect timer expired; attempt reelection below.
 
 		case <-e.leadershipNotificationChan:
 			// Used only in tests for force an immediately reelect attempt.
@@ -463,7 +463,7 @@ func (e *Elector) tryUnlisten(sub *Subscription) bool {
 	return false
 }
 
-// leaderTTL is at least the relect run interval used by clients to try and gain
+// leaderTTL is at least the reelect run interval used by clients to try and gain
 // leadership or reelect themselves as leader, plus a little padding to account
 // to give the leader a little breathing room in its reelection loop.
 func (e *Elector) leaderTTL() time.Duration {

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -43,7 +43,7 @@ func (ts *JobRescuerTestSignals) Init() {
 
 type JobRescuerConfig struct {
 	// ClientRetryPolicy is the default retry policy to use for workers that don't
-	// overide NextRetry.
+	// override NextRetry.
 	ClientRetryPolicy ClientRetryPolicy
 
 	// Interval is the amount of time to wait between runs of the rescuer.

--- a/internal/maintenance/queue_maintainer.go
+++ b/internal/maintenance/queue_maintainer.go
@@ -138,7 +138,7 @@ func (s *queueMaintainerServiceBase) StaggerStartupIsDisabled() bool {
 }
 
 // withStaggerStartupDisable is an interface to a service whose stagger startup
-// sleep can be disable.
+// sleep can be disabled.
 type withStaggerStartupDisable interface {
 	// StaggerStartupDisable sets whether the short staggered sleep on start up
 	// is disabled. This is useful in tests where the extra sleep involved in a

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -480,7 +480,7 @@ func TestNotifier(t *testing.T) {
 
 		start(t, notifier)
 
-		// The service normally sleeps with a exponential backoff after an
+		// The service normally sleeps with an exponential backoff after an
 		// error, but we've disabled sleep above, so we can pull errors out of
 		// the test signal as quickly as we want.
 		require.EqualError(t, notifier.testSignals.BackoffError.WaitOrTimeout(), "error during wait 1")

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -2767,7 +2767,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			tBefore := time.Now().UTC()
 			queueBefore, err := exec.QueueCreateOrSetUpdatedAt(ctx, &riverdriver.QueueCreateOrSetUpdatedAtParams{
 				Metadata:  metadata,
-				Name:      "updateable-queue",
+				Name:      "updatable-queue",
 				UpdatedAt: &tBefore,
 			})
 			require.NoError(t, err)
@@ -2776,7 +2776,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			tAfter := tBefore.Add(2 * time.Second)
 			queueAfter, err := exec.QueueCreateOrSetUpdatedAt(ctx, &riverdriver.QueueCreateOrSetUpdatedAtParams{
 				Metadata:  []byte(`{"other": "metadata"}`),
-				Name:      "updateable-queue",
+				Name:      "updatable-queue",
 				UpdatedAt: &tAfter,
 			})
 			require.NoError(t, err)
@@ -2784,7 +2784,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			// unchanged:
 			require.Equal(t, queueBefore.CreatedAt, queueAfter.CreatedAt)
 			require.Equal(t, metadata, queueAfter.Metadata)
-			require.Equal(t, "updateable-queue", queueAfter.Name)
+			require.Equal(t, "updatable-queue", queueAfter.Name)
 			require.Nil(t, queueAfter.PausedAt)
 
 			// Timestamp is bumped:

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -29,7 +29,7 @@ import (
 // always end up in a `retryable` state rather than `available`. Normally, the
 // job executor sets `available` if the retry delay is smaller than the
 // scheduler's interval. To simplify things so errors are always `retryable`,
-// this time is picked to be smaller than the any retry delay that the default
+// this time is picked to be smaller than any retry delay that the default
 // retry policy will ever produce. It's shared so we can document/explain it all
 // in one place.
 const SchedulerShortInterval = 500 * time.Millisecond

--- a/internal/util/hashutil/hash_util_test.go
+++ b/internal/util/hashutil/hash_util_test.go
@@ -31,7 +31,7 @@ func TestAdvisoryLockHash(t *testing.T) {
 		// The output hash isn't guaranteed to be larger than MaxInt32 of
 		// course, but given a reasonable hash function like FNV that produces
 		// good distribution, it's far more likely to be than not. We're using a
-		// fixed input in this test, so we know that it always be in this case.
+		// fixed input in this test, so we know that it'll always be in this case.
 		require.Greater(t, int(key), math.MaxInt32)
 	})
 }

--- a/job_args_reflect_kind_test.go
+++ b/job_args_reflect_kind_test.go
@@ -24,7 +24,7 @@ import "reflect"
 //
 // We're not sure yet whether it's appropriate to expose this publicly, so for
 // now we've localized it to the test suite only. When a test case needs a job
-// type that won't be reused, its preferrable to make use of JobArgsReflectKind
+// type that won't be reused, it's preferable to make use of JobArgsReflectKind
 // so the type doesn't pollute the global namespace.
 type JobArgsReflectKind[TKind any] struct{}
 

--- a/producer.go
+++ b/producer.go
@@ -54,7 +54,7 @@ type producerConfig struct {
 
 	// FetchCooldown is the minimum amount of time to wait between fetches of new
 	// jobs. Jobs will only be fetched *at most* this often, but if no new jobs
-	// are coming in via LISTEN/NOTIFY then feches may be delayed as long as
+	// are coming in via LISTEN/NOTIFY then fetches may be delayed as long as
 	// FetchPollInterval.
 	FetchCooldown time.Duration
 
@@ -206,7 +206,7 @@ func newProducer(archetype *baseservice.Archetype, exec riverdriver.Executor, co
 //
 // This variant uses a single context as fetchCtx and workCtx, and is here to
 // implement startstop.Service so that the producer can be stored as a service
-// variable and used with various serviec utilties. StartWorkContext below
+// variable and used with various service utilities. StartWorkContext below
 // should be preferred for production use.
 func (p *producer) Start(ctx context.Context) error {
 	return p.StartWorkContext(ctx, ctx)
@@ -514,7 +514,7 @@ func (p *producer) maybeCancelJob(id int64) {
 }
 
 func (p *producer) dispatchWork(workCtx context.Context, count int, fetchResultCh chan<- producerFetchResult) {
-	// This intentionally removes any deadlines or cancelleation from the parent
+	// This intentionally removes any deadlines or cancellation from the parent
 	// context because we don't want it to get cancelled if the producer is asked
 	// to shut down. In that situation, we want to finish fetching any jobs we are
 	// in the midst of fetching, work them, and then stop. Otherwise we'd have a

--- a/retry_policy.go
+++ b/retry_policy.go
@@ -47,7 +47,7 @@ type DefaultClientRetryPolicy struct {
 func (p *DefaultClientRetryPolicy) NextRetry(job *rivertype.JobRow) time.Time {
 	// For the purposes of calculating the backoff, we can look solely at the
 	// number of errors. If we were to use the raw attempt count, this would be
-	// incemented and influenced by snoozes. However the use case for snoozing is
+	// incremented and influenced by snoozes. However the use case for snoozing is
 	// to try again later *without* counting as an error.
 	//
 	// Note that we explicitly add 1 here, because the error hasn't been appended

--- a/riverdriver/riverdatabasesql/internal/pgtypealias/pgtype_alias.go
+++ b/riverdriver/riverdatabasesql/internal/pgtypealias/pgtype_alias.go
@@ -1,4 +1,4 @@
-// package pgtypealias exists to work aronud sqlc bugs with being able to
+// package pgtypealias exists to work around sqlc bugs with being able to
 // reference v5 the pgtype package from within a dbsql package.
 package pgtypealias
 

--- a/riverdriver/riverdatabasesql/migration/main/002_initial_schema.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/002_initial_schema.up.sql
@@ -66,7 +66,7 @@ DECLARE
   payload json;
 BEGIN
   IF NEW.state = 'available' THEN
-    -- Notify will coalesce duplicate notificiations within a transaction, so
+    -- Notify will coalesce duplicate notifications within a transaction, so
     -- keep these payloads generalized:
     payload = json_build_object('queue', NEW.queue);
     PERFORM

--- a/riverdriver/riverdatabasesql/migration/main/004_pending_and_more.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/004_pending_and_more.down.sql
@@ -18,7 +18,7 @@ DECLARE
   payload json;
 BEGIN
   IF NEW.state = 'available' THEN
-    -- Notify will coalesce duplicate notificiations within a transaction, so
+    -- Notify will coalesce duplicate notifications within a transaction, so
     -- keep these payloads generalized:
     payload = json_build_object('queue', NEW.queue);
     PERFORM

--- a/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.up.sql
@@ -22,7 +22,7 @@ $$;
 --
 ALTER TABLE river_job ADD COLUMN unique_states BIT(8);
 
--- This statements uses `IF NOT EXISTS` to allow users with a `river_job` table
+-- This statement uses `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this
 -- migration, then follow by completing the migration.
 CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON river_job (unique_key)

--- a/riverdriver/riverpgxv5/migration/main/002_initial_schema.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/002_initial_schema.up.sql
@@ -66,7 +66,7 @@ DECLARE
   payload json;
 BEGIN
   IF NEW.state = 'available' THEN
-    -- Notify will coalesce duplicate notificiations within a transaction, so
+    -- Notify will coalesce duplicate notifications within a transaction, so
     -- keep these payloads generalized:
     payload = json_build_object('queue', NEW.queue);
     PERFORM

--- a/riverdriver/riverpgxv5/migration/main/004_pending_and_more.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/004_pending_and_more.down.sql
@@ -18,7 +18,7 @@ DECLARE
   payload json;
 BEGIN
   IF NEW.state = 'available' THEN
-    -- Notify will coalesce duplicate notificiations within a transaction, so
+    -- Notify will coalesce duplicate notifications within a transaction, so
     -- keep these payloads generalized:
     payload = json_build_object('queue', NEW.queue);
     PERFORM

--- a/riverdriver/riverpgxv5/migration/main/006_bulk_unique.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/006_bulk_unique.up.sql
@@ -22,7 +22,7 @@ $$;
 --
 ALTER TABLE river_job ADD COLUMN unique_states BIT(8);
 
--- This statements uses `IF NOT EXISTS` to allow users with a `river_job` table
+-- This statement uses `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this
 -- migration, then follow by completing the migration.
 CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON river_job (unique_key)

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -751,7 +751,7 @@ func (l *Listener) Close(ctx context.Context) error {
 
 	// Release below would take care of cleanup and potentially put the
 	// connection back into rotation, but in case a Listen was invoked without a
-	// subsequent Unlisten on the same tpic, close the connection explicitly to
+	// subsequent Unlisten on the same topic, close the connection explicitly to
 	// guarantee no other caller will receive a partially tainted connection.
 	err := l.conn.Conn().Close(ctx)
 

--- a/rivermigrate/river_migrate.go
+++ b/rivermigrate/river_migrate.go
@@ -219,7 +219,7 @@ type MigrateOpts struct {
 	// version, so when starting at version 0 and requesting version 3, versions
 	// 1, 2, and 3 would be applied. When applying migrations down, down
 	// migrations are applied excluding the target version, so when starting at
-	// version 5 an requesting version 3, down migrations for versions 5 and 4
+	// version 5 and requesting version 3, down migrations for versions 5 and 4
 	// would be applied, leaving the final schema at version 3.
 	//
 	// When migrating down, TargetVersion can be set to the special value of -1
@@ -654,7 +654,7 @@ func migrationsFromFS(migrationFS fs.FS, line string) ([]Migration, error) {
 			return fmt.Errorf("error walking FS: %w", err)
 		}
 
-		// The WalkDir callback is invoked for each embdedded subdirectory and
+		// The WalkDir callback is invoked for each embedded subdirectory and
 		// file. For our purposes here, we're only interested in files.
 		if entry.IsDir() {
 			return nil

--- a/rivershared/baseservice/base_service.go
+++ b/rivershared/baseservice/base_service.go
@@ -125,7 +125,7 @@ func (g *UnStubbableTimeGenerator) StubNowUTC(nowUTC time.Time) time.Time {
 
 var stripGenericTypePathRE = regexp.MustCompile(`\[([\[\]\*]*).*/([^/]+)\]`)
 
-// Simplies the name of a Go type that uses generics for cleaner logging output.
+// Simplifies the name of a Go type that uses generics for cleaner logging output.
 //
 // So this:
 //

--- a/rivershared/cmd/update-mod-go/main_test.go
+++ b/rivershared/cmd/update-mod-go/main_test.go
@@ -66,7 +66,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 		// changes were made.
 		requireDirectives(t, filename, "1.22", "go1.22.6")
 
-		// Running again is allowed and should be idempontent. This time it'll
+		// Running again is allowed and should be idempotent. This time it'll
 		// return that no changes were made.
 		anyMismatch, err = parseAndUpdateGoModFile(false, filename, "go.work", "1.22", "go1.22.6")
 		require.NoError(t, err)

--- a/rivershared/cmd/update-mod-version/main_test.go
+++ b/rivershared/cmd/update-mod-version/main_test.go
@@ -78,7 +78,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 			{Path: "github.com/riverqueue/river/rivershared", Version: "v0.0.13"},
 		}, versions)
 
-		// Running again is allowed and should be idempontent. This time it'll
+		// Running again is allowed and should be idempotent. This time it'll
 		// return that no changes were made.
 		anyChanges, err = parseAndUpdateGoModFile(filename, "v0.0.13")
 		require.NoError(t, err)

--- a/rivershared/riversharedtest/riversharedtest.go
+++ b/rivershared/riversharedtest/riversharedtest.go
@@ -151,7 +151,7 @@ func WaitTimeout() time.Duration {
 }
 
 var IgnoredKnownGoroutineLeaks = []goleak.Option{ //nolint:gochecknoglobals
-	// This goroutine contains a 500 ms uninterruptable sleep that may still be
+	// This goroutine contains a 500 ms uninterruptible sleep that may still be
 	// running by the time the test suite finishes and cause a failure. This
 	// might be something that should be fixed in pgx, but ignore it for the
 	// time being lest we have intermittent tests.

--- a/rivershared/startstop/start_stop.go
+++ b/rivershared/startstop/start_stop.go
@@ -167,7 +167,7 @@ func (s *BaseStartStop) Stop() {
 }
 
 // StopInit provides a way to build a more customized Stop implementation. It
-// should be avoided unless there'a an exceptional reason not to because Stop
+// should be avoided unless there's an exceptional reason not to because Stop
 // should be fine in the vast majority of situations.
 //
 // It returns a boolean indicating whether the service should do any additional

--- a/rivershared/testsignal/test_signal_test.go
+++ b/rivershared/testsignal/test_signal_test.go
@@ -28,7 +28,7 @@ func TestTestSignal(t *testing.T) {
 		signal := TestSignal[struct{}]{}
 		signal.Init()
 
-		// Signal can invoked many times, but not infinitely
+		// Signal can be invoked many times, but not infinitely
 		for i := 0; i < testSignalInternalChanSize; i++ {
 			signal.Signal(struct{}{})
 		}

--- a/rivershared/util/randutil/rand_util.go
+++ b/rivershared/util/randutil/rand_util.go
@@ -21,7 +21,7 @@ func NewCryptoSeededConcurrentSafeRand() *mathrand.Rand {
 	return mathrand.New(newCryptoSeededConcurrentSafeSource())
 }
 
-// DurationBetween generates a random duraiton in the range of [lowerLimit, upperLimit).
+// DurationBetween generates a random duration in the range of [lowerLimit, upperLimit).
 //
 // TODO: When we drop Go 1.21 support, switch to `math/rand/v2` and kill the
 // `rand.Rand` argument.

--- a/rivershared/util/serviceutil/service_util.go
+++ b/rivershared/util/serviceutil/service_util.go
@@ -26,7 +26,7 @@ func CancellableSleep(ctx context.Context, sleepDuration time.Duration) {
 // CancellableSleep sleeps for the given duration, but returns early if context
 // has been cancelled.
 //
-// This variant returns a channel that should be waited on and which wll be
+// This variant returns a channel that should be waited on and which will be
 // closed when either the sleep or context is done.
 func CancellableSleepC(ctx context.Context, sleepDuration time.Duration) <-chan struct{} {
 	doneChan := make(chan struct{})

--- a/rivertest/rivertest.go
+++ b/rivertest/rivertest.go
@@ -34,7 +34,7 @@ type testingT interface {
 // Options for RequireInserted functions including expectations for various
 // queuing properties that stem from InsertOpts.
 //
-// Multiple properties set on this struct increase the specifity on a job to
+// Multiple properties set on this struct increase the specificity on a job to
 // match, acting like an AND condition on each.
 //
 // In the case of RequireInserted or RequireInsertedMany, if multiple properties
@@ -188,7 +188,7 @@ func requireInsertedErr[TDriver riverdriver.Driver[TTx], TTx any, TArgs river.Jo
 // A RequireInsertedOpts struct can be provided as the last argument, and if it
 // is, its properties (e.g. max attempts, priority, queue name) will act as
 // requirements on a found row. If any fields are set, then the test will fail
-// if a job is found that maches all of them. If any property doesn't match a
+// if a job is found that matches all of them. If any property doesn't match a
 // found row, the row isn't considered a match, and the assertion doesn't fail.
 //
 // If more rows than one were found, the assertion fails if any of them match
@@ -217,7 +217,7 @@ func requireNotInserted[TDriver riverdriver.Driver[TTx], TTx any, TArgs river.Jo
 // A RequireInsertedOpts struct can be provided as the last argument, and if it
 // is, its properties (e.g. max attempts, priority, queue name) will act as
 // requirements on a found row. If any fields are set, then the test will fail
-// if a job is found that maches all of them. If any property doesn't match a
+// if a job is found that matches all of them. If any property doesn't match a
 // found row, the row isn't considered a match, and the assertion doesn't fail.
 //
 // If more rows than one were found, the assertion fails if any of them match
@@ -540,7 +540,7 @@ func failureString(format string, a ...any) string {
 // WorkContext returns a realistic context that can be used to test JobArgs.Work
 // implementations.
 //
-// In particual, adds a client to the context so that river.ClientFromContext is
+// In particular, adds a client to the context so that river.ClientFromContext is
 // usable in the test suite.
 func WorkContext[TTx any](ctx context.Context, client *river.Client[TTx]) context.Context {
 	return context.WithValue(ctx, rivercommon.ContextKeyClient{}, client)

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -255,7 +255,7 @@ type JobInsertParams struct {
 type JobInsertMiddleware interface {
 	// InsertMany is invoked around a batch insert operation. Implementations
 	// must always include a call to doInner to call down the middleware stack
-	// and perfom the batch insertion, and may run custom code before and after.
+	// and perform the batch insertion, and may run custom code before and after.
 	//
 	// Returning an error from this function will fail the overarching insert
 	// operation, even if the inner insertion originally succeeded.
@@ -265,7 +265,7 @@ type JobInsertMiddleware interface {
 type WorkerMiddleware interface {
 	// Work is invoked after a job's JSON args being unmarshaled and before the
 	// job is worked. Implementations must always include a call to doInner to
-	// call down the middleware stack and perfom the batch insertion, and may run
+	// call down the middleware stack and perform the batch insertion, and may run
 	// custom code before and after.
 	//
 	// Returning an error from this function will fail the overarching work


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on. Nothing controversial (hopefully).

Use the following command to get a quick summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the top typos are:
* notificiations
* updateable
* feches
* idempontent
* maches
* perfom
* relect
* releection
* serviec
* specifity
* thah
* tpic
* wll