### PR TITLE
riverpgxv5: hijack raw listener conn to assume control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `riverpgxv5` driver: `Hijack()` the underlying listener connection as soon as it is acquired from the `pgxpool.Pool` in order to prevent the pool from automatically closing it after it reaches its max age. A max lifetime makes sense in the context of a pool with many conns, but a long-lived listener does not need a max lifetime as long as it can ensure the conn remains healthy. [PR #661](https://github.com/riverqueue/river/pull/661).
+
 ## [0.13.0] - 2024-10-07
 
 ⚠️ Version 0.13.0 removes the original advisory lock based unique jobs implementation that was deprecated in v0.12.0. See details in the note below or the v0.12.0 release notes.


### PR DESCRIPTION
The previous implementation of the driver would `Acquire()` a conn from the `pgxpool.Pool`, but keep the pool in control of the conn. This meant that the pool would still do its regular maintenance checks on the conn, such as closing it after it had reached its max lifetime.

This isn't actually desirable in the case of a `LISTEN` listener—we want the listener to stay alive as long as possible and to avoid missing any notifications. We perform our own health checks on the conn in the form of periodic pings, which should be sufficient to make sure the conn is still connected and functioning properly.

As such, adjust the driver so that it calls `Hijack()` on the conn immediately after acquiring it, assuming full control of it from the underlying pool. The listener is still responsible for closing the conn at shutdown.

Fixes #660.