### PR TITLE
unified insert path for periodic jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Cancellation of running jobs relied on a channel that was only being received when in the job fetch routine, meaning that jobs which were cancelled would not be cancelled until the next scheduled fetch. This was fixed by also receiving from the job cancellation channel when in the main producer loop, even if no fetches are happening. [PR #678](https://github.com/riverqueue/river/pull/678).
+- Job insert middleware were not being utilized for periodic jobs. This insertion path has been refactored to rely on the unified insertion path from the client. Fixes #675. [PR #679](https://github.com/riverqueue/river/pull/679).
 
 ## [0.14.1] - 2024-11-04
 

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
+	"github.com/riverqueue/river/rivertype"
 )
 
 const (
@@ -32,6 +33,8 @@ func (ts *JobSchedulerTestSignals) Init() {
 	ts.NotifiedQueues.Init()
 	ts.ScheduledBatch.Init()
 }
+
+type InsertFunc func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) ([]*rivertype.JobInsertResult, error)
 
 // NotifyInsert is a function to call to emit notifications for queues where
 // jobs were scheduled.

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -2,7 +2,6 @@ package maintenance
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -19,6 +18,7 @@ import (
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -76,6 +76,23 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		}
 	}
 
+	// A simplified version of `Client.insertMany` that only inserts jobs directly
+	// via the driver instead of using the pilot.
+	insertFunc := func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) ([]*rivertype.JobInsertResult, error) {
+		finalInsertParams := sliceutil.Map(insertParams, func(params *rivertype.JobInsertParams) *riverdriver.JobInsertFastParams {
+			return (*riverdriver.JobInsertFastParams)(params)
+		})
+		results, err := tx.JobInsertFastMany(ctx, finalInsertParams)
+		if err != nil {
+			return nil, err
+		}
+		return sliceutil.Map(results,
+			func(result *riverdriver.JobInsertFastResult) *rivertype.JobInsertResult {
+				return (*rivertype.JobInsertResult)(result)
+			},
+		), nil
+	}
+
 	setup := func(t *testing.T) (*PeriodicJobEnqueuer, *testBundle) {
 		t.Helper()
 
@@ -85,16 +102,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 			waitChan:             make(chan struct{}),
 		}
 
-		svc := NewPeriodicJobEnqueuer(
-			riversharedtest.BaseServiceArchetype(t),
-			&PeriodicJobEnqueuerConfig{
-				NotifyInsert: func(ctx context.Context, tx riverdriver.ExecutorTx, queues []string) error {
-					for _, queue := range queues {
-						bundle.notificationsByQueue[queue]++
-					}
-					return nil
-				},
-			}, bundle.exec)
+		svc := NewPeriodicJobEnqueuer(riversharedtest.BaseServiceArchetype(t), &PeriodicJobEnqueuerConfig{Insert: insertFunc}, bundle.exec)
 		svc.StaggerStartupDisable(true)
 		svc.TestSignals.Init()
 
@@ -208,8 +216,6 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 		requireNJobs(t, bundle.exec, "unique_periodic_job_500ms", 1)
-		// This initial insert should emit a notification:
-		svc.TestSignals.NotifiedQueues.WaitOrTimeout()
 
 		// Another insert was attempted, but there's still only one job due to
 		// uniqueness conditions.
@@ -218,14 +224,6 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 		requireNJobs(t, bundle.exec, "unique_periodic_job_500ms", 1)
-
-		// Ensure that no notifications were emitted beyond the first one because no
-		// additional jobs were inserted:
-		select {
-		case queues := <-svc.TestSignals.NotifiedQueues.WaitC():
-			t.Fatalf("Expected no notification to be emitted, but got one for queues: %v", queues)
-		case <-time.After(100 * time.Millisecond):
-		}
 	})
 
 	t.Run("RunOnStart", func(t *testing.T) {
@@ -350,7 +348,6 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		for i := 0; i < 100; i++ {
 			svc.TestSignals.InsertedJobs.WaitOrTimeout()
-			svc.TestSignals.NotifiedQueues.WaitOrTimeout()
 		}
 	})
 
@@ -362,7 +359,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		svc := NewPeriodicJobEnqueuer(
 			riversharedtest.BaseServiceArchetype(t),
 			&PeriodicJobEnqueuerConfig{
-				NotifyInsert: func(ctx context.Context, tx riverdriver.ExecutorTx, queues []string) error { return nil },
+				Insert: insertFunc,
 				PeriodicJobs: []*PeriodicJob{
 					{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false), RunOnStart: true},
 					{ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false), RunOnStart: true},
@@ -563,59 +560,6 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		stopped := svc.Stopped()
 		cancelFunc()
 		riversharedtest.WaitOrTimeout(t, stopped)
-	})
-
-	t.Run("TriggersNotificationsOnEachQueueWithNewlyAvailableJobs", func(t *testing.T) {
-		t.Parallel()
-
-		svc, _ := setup(t)
-
-		svc.AddMany([]*PeriodicJob{
-			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorWithQueueFunc("periodic_job_5s", false, rivercommon.QueueDefault), RunOnStart: true},
-			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorWithQueueFunc("periodic_job_15m", false, "queue2"), RunOnStart: true},
-			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorWithQueueFunc("unique_periodic_job_5s", true, "unique"), RunOnStart: true},
-		})
-
-		queueCh := make(chan []string, 1)
-		svc.Config.NotifyInsert = func(ctx context.Context, tx riverdriver.ExecutorTx, queues []string) error {
-			queueCh <- queues
-			return nil
-		}
-
-		startService(t, svc)
-		svc.TestSignals.EnteredLoop.WaitOrTimeout()
-
-		svc.TestSignals.InsertedJobs.WaitOrTimeout()
-		queues := svc.TestSignals.NotifiedQueues.WaitOrTimeout()
-		require.Equal(t, []string{rivercommon.QueueDefault, "queue2", "unique"}, queues)
-		require.Equal(t, queues, riversharedtest.WaitOrTimeout(t, queueCh))
-	})
-
-	t.Run("RollsBackUponErrorFromNotificationAttempt", func(t *testing.T) {
-		t.Parallel()
-
-		svc, bundle := setup(t)
-
-		svc.AddMany([]*PeriodicJob{
-			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("unique_periodic_job_500ms", true)},
-		})
-
-		svc.Config.NotifyInsert = func(ctx context.Context, tx riverdriver.ExecutorTx, queues []string) error {
-			return errors.New("test error")
-		}
-
-		startService(t, svc)
-		svc.TestSignals.EnteredLoop.WaitOrTimeout()
-
-		// Ensure that no jobs were inserted because the notification errored:
-		select {
-		case <-svc.TestSignals.InsertedJobs.WaitC():
-			t.Fatal("Expected no jobs to be inserted, but one was")
-		case <-time.After(100 * time.Millisecond):
-		}
-
-		// Should be no jobs in the DB either:
-		requireNJobs(t, bundle.exec, "unique_periodic_job_500ms", 0)
 	})
 
 	t.Run("TimeUntilNextRun", func(t *testing.T) {


### PR DESCRIPTION
Job insert middleware were not being utilized for periodic jobs, resulting in behavioral differences (especially Pro features). This periodic job insertion path has been refactored to utilize the unified insertion path from the client, which also makes these inserts pass through the Pilot instead of going directly to the driver.

Fixes #675.