### PR TITLE
Tolerate existing `unique_states` column in 006 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dropped internal random generators in favor of `math/rand/v2`, which will have the effect of making code fully incompatible with Go 1.21 (`go.mod` has specified a minimum of 1.22 for some time already though). [PR #691](https://github.com/riverqueue/river/pull/691).
 
+### Fixed
+
+- 006 migration now tolerates previous existence of a `unique_states` column in case it was added separately so that the new index could be raised with `CONCURRENTLY`. [PR #691](https://github.com/riverqueue/river/pull/691).
+
 ## [0.14.2] - 2024-11-16
 
 ### Fixed

--- a/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.up.sql
@@ -20,7 +20,10 @@ $$;
 --
 -- Add `river_job.unique_states` and bring up an index on it.
 --
-ALTER TABLE river_job ADD COLUMN unique_states BIT(8);
+-- This column may exist already if users manually created the column and index
+-- as instructed in the changelog so the index could be created `CONCURRENTLY`.
+--
+ALTER TABLE river_job ADD COLUMN IF NOT EXISTS unique_states BIT(8);
 
 -- This statement uses `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this

--- a/riverdriver/riverpgxv5/migration/main/006_bulk_unique.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/006_bulk_unique.up.sql
@@ -20,7 +20,10 @@ $$;
 --
 -- Add `river_job.unique_states` and bring up an index on it.
 --
-ALTER TABLE river_job ADD COLUMN unique_states BIT(8);
+-- This column may exist already if users manually created the column and index
+-- as instructed in the changelog so the index could be created `CONCURRENTLY`.
+--
+ALTER TABLE river_job ADD COLUMN IF NOT EXISTS unique_states BIT(8);
 
 -- This statement uses `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this


### PR DESCRIPTION
As described in #688, if a user has followed changelog instructions to
create the new index concurrently, they will encounter an error as they
try to run the 006 migration to finalize it.

Here, tolerate the column already existing to fix the problem. An
existing index is already tolerated.

Fixes #688.