### PR TITLE
Drop internalized random number generators in favor of `math/rand/v2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Dropped internal random generators in favor of `math/rand/v2`, which will have the effect of making code fully incompatible with Go 1.21 (`go.mod` has specified a minimum of 1.22 for some time already though). [PR #691](https://github.com/riverqueue/river/pull/691).
+
 ## [0.14.2] - 2024-11-16
 
 ### Fixed

--- a/client_test.go
+++ b/client_test.go
@@ -984,7 +984,7 @@ func Test_Client_Stop(t *testing.T) {
 					require.NoError(t, err)
 
 					// Sleep a brief time between inserts.
-					serviceutil.CancellableSleep(ctx, randutil.DurationBetween(client.baseService.Rand, 1*time.Microsecond, 10*time.Millisecond))
+					serviceutil.CancellableSleep(ctx, randutil.DurationBetween(1*time.Microsecond, 10*time.Millisecond))
 				}
 			}()
 		}

--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -548,7 +548,7 @@ func withRetries[T any](logCtx context.Context, baseService *baseservice.BaseSer
 			}
 
 			lastErr = err
-			sleepDuration := serviceutil.ExponentialBackoff(baseService.Rand, attempt, serviceutil.MaxAttemptsBeforeResetDefault)
+			sleepDuration := serviceutil.ExponentialBackoff(attempt, serviceutil.MaxAttemptsBeforeResetDefault)
 			baseService.Logger.ErrorContext(logCtx, baseService.Name+": Completer error (will retry after sleep)",
 				"attempt", attempt, "err", err, "sleep_duration", sleepDuration, "timeout", timeout)
 			if !disableSleep {

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -186,7 +186,7 @@ func (s *JobCleaner) runOnce(ctx context.Context) (*jobCleanerRunOnceResult, err
 			slog.Int("num_jobs_deleted", numDeleted),
 		)
 
-		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -236,7 +236,7 @@ func (s *JobRescuer) runOnce(ctx context.Context) (*rescuerRunOnceResult, error)
 			break
 		}
 
-		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -199,7 +199,7 @@ func (s *JobScheduler) runOnce(ctx context.Context) (*schedulerRunOnceResult, er
 			break
 		}
 
-		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -493,8 +493,8 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		randomSleep := func() time.Duration {
-			return time.Duration(randutil.IntBetween(svc.Rand, 1, 5)) * time.Millisecond
+		randomSleep := func() {
+			time.Sleep(time.Duration(randutil.IntBetween(1, 5)) * time.Millisecond)
 		}
 
 		for i := 0; i < 10; i++ {

--- a/internal/maintenance/queue_cleaner.go
+++ b/internal/maintenance/queue_cleaner.go
@@ -154,7 +154,7 @@ func (s *QueueCleaner) runOnce(ctx context.Context) (*queueCleanerRunOnceResult,
 			break
 		}
 
-		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, BatchBackoffMin, BatchBackoffMax))
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(BatchBackoffMin, BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/queue_maintainer.go
+++ b/internal/maintenance/queue_maintainer.go
@@ -123,7 +123,7 @@ func (s *queueMaintainerServiceBase) StaggerStart(ctx context.Context) {
 		return
 	}
 
-	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(s.Rand, 0*time.Second, 1*time.Second))
+	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(0*time.Second, 1*time.Second))
 }
 
 // StaggerStartupDisable sets whether the short staggered sleep on start up

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -127,7 +127,7 @@ func (n *Notifier) Start(ctx context.Context) error {
 					break
 				}
 
-				sleepDuration := serviceutil.ExponentialBackoff(n.Rand, attempt, serviceutil.MaxAttemptsBeforeResetDefault)
+				sleepDuration := serviceutil.ExponentialBackoff(attempt, serviceutil.MaxAttemptsBeforeResetDefault)
 				n.Logger.ErrorContext(ctx, n.Name+": Error running listener (will attempt reconnect after backoff)",
 					"attempt", attempt, "err", err, "sleep_duration", sleepDuration)
 				n.testSignals.BackoffError.Signal(err)

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -439,7 +439,7 @@ func TestNotifier(t *testing.T) {
 					require.NoError(t, err)
 
 					// Pause a random brief amount of time.
-					serviceutil.CancellableSleep(ctx, randutil.DurationBetween(notifier.Rand, 15*time.Millisecond, 50*time.Millisecond))
+					serviceutil.CancellableSleep(ctx, randutil.DurationBetween(15*time.Millisecond, 50*time.Millisecond))
 
 					sub.Unlisten(ctx)
 				}

--- a/producer.go
+++ b/producer.go
@@ -681,7 +681,7 @@ func (p *producer) fetchQueueSettings(ctx context.Context) (*rivertype.Queue, er
 }
 
 func (p *producer) reportQueueStatusLoop(ctx context.Context) {
-	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(p.Rand, 0, time.Second))
+	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(0, time.Second))
 	reportTicker := time.NewTicker(p.config.QueueReportInterval)
 	for {
 		select {

--- a/rivermigrate/river_migrate.go
+++ b/rivermigrate/river_migrate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/levenshtein"
 	"github.com/riverqueue/river/rivershared/util/maputil"
-	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -114,7 +113,6 @@ func New[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Migrator[TTx
 
 	archetype := &baseservice.Archetype{
 		Logger: logger,
-		Rand:   randutil.NewCryptoSeededConcurrentSafeRand(),
 		Time:   &baseservice.UnStubbableTimeGenerator{},
 	}
 

--- a/rivershared/baseservice/base_service_test.go
+++ b/rivershared/baseservice/base_service_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/riverqueue/river/rivershared/util/randutil"
 )
 
 func TestInit(t *testing.T) {
@@ -29,7 +27,6 @@ type MyService struct {
 func archetype() *Archetype {
 	return &Archetype{
 		Logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
-		Rand:   randutil.NewCryptoSeededConcurrentSafeRand(),
 		Time:   &UnStubbableTimeGenerator{},
 	}
 }

--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -8,8 +8,7 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-type StandardPilot struct {
-}
+type StandardPilot struct{}
 
 func (p *StandardPilot) JobInsertMany(
 	ctx context.Context,

--- a/rivershared/riversharedtest/riversharedtest.go
+++ b/rivershared/riversharedtest/riversharedtest.go
@@ -13,12 +13,7 @@ import (
 
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/slogtest"
-	"github.com/riverqueue/river/rivershared/util/randutil"
 )
-
-// Shared rand instance for archetypes. Random number generation is rare
-// enough that it's not likely to produce much contention.
-var rand = randutil.NewCryptoSeededConcurrentSafeRand() //nolint:gochecknoglobals
 
 // BaseServiceArchetype returns a new base service suitable for use in tests.
 // Returns a new instance so that it's not possible to accidentally taint a
@@ -28,7 +23,6 @@ func BaseServiceArchetype(tb testing.TB) *baseservice.Archetype {
 
 	return &baseservice.Archetype{
 		Logger: Logger(tb),
-		Rand:   rand,
 		Time:   &TimeStub{},
 	}
 }

--- a/rivershared/util/randutil/rand_util.go
+++ b/rivershared/util/randutil/rand_util.go
@@ -2,31 +2,14 @@ package randutil
 
 import (
 	cryptorand "crypto/rand"
-	"encoding/binary"
 	"encoding/hex"
-	mathrand "math/rand"
-	"sync"
+	"math/rand/v2"
 	"time"
 )
 
-// NewCryptoSeededConcurrentSafeSource generates a new pseudo-random source
-// that's been created with a cryptographically secure seed to ensure reasonable
-// distribution of randomness between nodes and services, and wrapped so that
-// access to it is concurrent safe.
-//
-// This project uses this technique instead of falling back on crypto/rand
-// because uses of randomness don't need to be cryptographically secure, and the
-// non-crypto variant is about twenty times faster.
-func NewCryptoSeededConcurrentSafeRand() *mathrand.Rand {
-	return mathrand.New(newCryptoSeededConcurrentSafeSource())
-}
-
 // DurationBetween generates a random duration in the range of [lowerLimit, upperLimit).
-//
-// TODO: When we drop Go 1.21 support, switch to `math/rand/v2` and kill the
-// `rand.Rand` argument.
-func DurationBetween(rand *mathrand.Rand, lowerLimit, upperLimit time.Duration) time.Duration {
-	return time.Duration(IntBetween(rand, int(lowerLimit), int(upperLimit)))
+func DurationBetween(lowerLimit, upperLimit time.Duration) time.Duration {
+	return time.Duration(IntBetween(int(lowerLimit), int(upperLimit)))
 }
 
 func Hex(length int) string {
@@ -38,38 +21,6 @@ func Hex(length int) string {
 }
 
 // IntBetween generates a random number in the range of [lowerLimit, upperLimit).
-//
-// TODO: When we drop Go 1.21 support, switch to `math/rand/v2` and kill the
-// `rand.Rand` argument.
-func IntBetween(rand *mathrand.Rand, lowerLimit, upperLimit int) int {
-	return rand.Intn(upperLimit-lowerLimit) + lowerLimit
-}
-
-func newCryptoSeededConcurrentSafeSource() mathrand.Source {
-	var seed int64
-
-	if err := binary.Read(cryptorand.Reader, binary.BigEndian, &seed); err != nil {
-		panic(err)
-	}
-
-	return &concurrentSafeSource{innerSource: mathrand.NewSource(seed)}
-}
-
-type concurrentSafeSource struct {
-	innerSource mathrand.Source
-	mu          sync.Mutex
-}
-
-func (s *concurrentSafeSource) Int63() int64 {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.innerSource.Int63()
-}
-
-func (s *concurrentSafeSource) Seed(seed int64) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.innerSource.Seed(seed)
+func IntBetween(lowerLimit, upperLimit int) int {
+	return rand.IntN(upperLimit-lowerLimit) + lowerLimit
 }

--- a/rivershared/util/randutil/rand_util_test.go
+++ b/rivershared/util/randutil/rand_util_test.go
@@ -3,46 +3,23 @@ package randutil
 import (
 	cryptorand "crypto/rand"
 	"math/big"
-	mathrand "math/rand"
-	"sync"
+	"math/rand/v2"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCryptoSeededConcurrentSafeRand(t *testing.T) {
-	t.Parallel()
-
-	var wg sync.WaitGroup
-	rand := NewCryptoSeededConcurrentSafeRand()
-
-	// Hit the source with a bunch of goroutines to help suss out any problems
-	// with concurrent safety (when combined with `-race`).
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			for j := 0; j < 100; j++ {
-				_ = rand.Intn(1984)
-			}
-			wg.Done()
-		}()
-	}
-
-	wg.Wait()
-}
-
 func TestDurationBetween(t *testing.T) {
 	t.Parallel()
 
 	const lowerLimit, upperLimit = 5 * time.Second, 8 * time.Second
-	rand := NewCryptoSeededConcurrentSafeRand()
 
 	// Not exactly a super exhaustive test, but choose a relatively small range,
 	// generate numbers and check they're within bounds, and run enough times
 	// that we'd expect an offender to be generated if one was likely to be.
 	for i := 0; i < int(upperLimit/time.Second-lowerLimit/time.Second)*2; i++ {
-		n := DurationBetween(rand, lowerLimit, upperLimit)
+		n := DurationBetween(lowerLimit, upperLimit)
 		require.GreaterOrEqual(t, n, lowerLimit)
 		require.Less(t, n, upperLimit)
 	}
@@ -52,13 +29,12 @@ func TestIntBetween(t *testing.T) {
 	t.Parallel()
 
 	const lowerLimit, upperLimit = 5, 8
-	rand := NewCryptoSeededConcurrentSafeRand()
 
 	// Not exactly a super exhaustive test, but choose a relatively small range,
 	// generate numbers and check they're within bounds, and run enough times
 	// that we'd expect an offender to be generated if one was likely to be.
 	for i := 0; i < int(upperLimit-lowerLimit)*2; i++ {
-		n := IntBetween(rand, lowerLimit, upperLimit)
+		n := IntBetween(lowerLimit, upperLimit)
 		require.GreaterOrEqual(t, n, lowerLimit)
 		require.Less(t, n, upperLimit)
 	}
@@ -77,10 +53,9 @@ func TestIntBetween(t *testing.T) {
 // ok      github.com/riverqueue/river/internal/util/randutil 3.552s
 //
 
-func BenchmarkConcurrentSafeSource(b *testing.B) {
-	rand := mathrand.New(newCryptoSeededConcurrentSafeSource())
+func BenchmarkRandV2(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		_ = rand.Intn(1984)
+		_ = rand.IntN(1984)
 	}
 }
 

--- a/rivershared/util/serviceutil/service_util.go
+++ b/rivershared/util/serviceutil/service_util.go
@@ -52,10 +52,7 @@ const MaxAttemptsBeforeResetDefault = 10
 // +/- 10% random jitter. Sleep is cancelled if the given context is cancelled.
 //
 // Attempt should start at one for the first backoff/failure.
-//
-// TODO: When we drop Go 1.21 support, switch to `math/rand/v2` and kill the
-// `rand.Rand` argument.
-func ExponentialBackoff(rand *rand.Rand, attempt, maxAttemptsBeforeReset int) time.Duration {
+func ExponentialBackoff(attempt, maxAttemptsBeforeReset int) time.Duration {
 	retrySeconds := exponentialBackoffSecondsWithoutJitter(attempt, maxAttemptsBeforeReset)
 
 	// Jitter number of seconds +/- 10%.

--- a/rivershared/util/serviceutil/service_util_test.go
+++ b/rivershared/util/serviceutil/service_util_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/riverqueue/river/rivershared/util/randutil"
 )
 
 func TestCancellableSleep(t *testing.T) {
@@ -73,14 +71,12 @@ func TestCancellableSleep(t *testing.T) {
 func TestExponentialBackoff(t *testing.T) {
 	t.Parallel()
 
-	rand := randutil.NewCryptoSeededConcurrentSafeRand()
-
-	require.InDelta(t, 1.0, ExponentialBackoff(rand, 1, MaxAttemptsBeforeResetDefault).Seconds(), 1.0*0.1)
-	require.InDelta(t, 2.0, ExponentialBackoff(rand, 2, MaxAttemptsBeforeResetDefault).Seconds(), 2.0*0.1)
-	require.InDelta(t, 4.0, ExponentialBackoff(rand, 3, MaxAttemptsBeforeResetDefault).Seconds(), 4.0*0.1)
-	require.InDelta(t, 8.0, ExponentialBackoff(rand, 4, MaxAttemptsBeforeResetDefault).Seconds(), 8.0*0.1)
-	require.InDelta(t, 16.0, ExponentialBackoff(rand, 5, MaxAttemptsBeforeResetDefault).Seconds(), 16.0*0.1)
-	require.InDelta(t, 32.0, ExponentialBackoff(rand, 6, MaxAttemptsBeforeResetDefault).Seconds(), 32.0*0.1)
+	require.InDelta(t, 1.0, ExponentialBackoff(1, MaxAttemptsBeforeResetDefault).Seconds(), 1.0*0.1)
+	require.InDelta(t, 2.0, ExponentialBackoff(2, MaxAttemptsBeforeResetDefault).Seconds(), 2.0*0.1)
+	require.InDelta(t, 4.0, ExponentialBackoff(3, MaxAttemptsBeforeResetDefault).Seconds(), 4.0*0.1)
+	require.InDelta(t, 8.0, ExponentialBackoff(4, MaxAttemptsBeforeResetDefault).Seconds(), 8.0*0.1)
+	require.InDelta(t, 16.0, ExponentialBackoff(5, MaxAttemptsBeforeResetDefault).Seconds(), 16.0*0.1)
+	require.InDelta(t, 32.0, ExponentialBackoff(6, MaxAttemptsBeforeResetDefault).Seconds(), 32.0*0.1)
 }
 
 func TestExponentialBackoffSecondsWithoutJitter(t *testing.T) {


### PR DESCRIPTION
The service archetype and a number of functions internalized a random
source because in Go, that used to be the only way that you could
guarantee that a non-crypto generated was actually seeded.

Go 1.22 introduced `math/rand/v2` which fixed that problem. Now that Go
1.21 support's been dropped, it's a nice clean up to move to the V2
package and get rid of random sources being passed around everywhere.