### PR TITLE
Log sleep durations more definitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sleep durations are now logged as Go-like duration strings (e.g. "10s") in either text or JSON instead of duration strings in text and nanoseconds in JSON. [PR #699](https://github.com/riverqueue/river/pull/699).
+
 ### Fixed
 
 - Exponential backoffs at degenerately high job attempts (>= 310) no longer risk overflowing `time.Duration`. [PR #698](https://github.com/riverqueue/river/pull/698).

--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -3,6 +3,7 @@ package jobcompleter
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -550,7 +551,11 @@ func withRetries[T any](logCtx context.Context, baseService *baseservice.BaseSer
 			lastErr = err
 			sleepDuration := serviceutil.ExponentialBackoff(attempt, serviceutil.MaxAttemptsBeforeResetDefault)
 			baseService.Logger.ErrorContext(logCtx, baseService.Name+": Completer error (will retry after sleep)",
-				"attempt", attempt, "err", err, "sleep_duration", sleepDuration, "timeout", timeout)
+				slog.Int("attempt", attempt),
+				slog.String("err", err.Error()),
+				slog.String("sleep_duration", sleepDuration.String()),
+				slog.String("timeout", timeout.String()),
+			)
 			if !disableSleep {
 				serviceutil.CancellableSleep(logCtx, sleepDuration)
 			}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sync"
 	"time"
@@ -129,7 +130,10 @@ func (n *Notifier) Start(ctx context.Context) error {
 
 				sleepDuration := serviceutil.ExponentialBackoff(attempt, serviceutil.MaxAttemptsBeforeResetDefault)
 				n.Logger.ErrorContext(ctx, n.Name+": Error running listener (will attempt reconnect after backoff)",
-					"attempt", attempt, "err", err, "sleep_duration", sleepDuration)
+					slog.Int("attempt", attempt),
+					slog.String("err", err.Error()),
+					slog.String("sleep_duration", sleepDuration.String()),
+				)
 				n.testSignals.BackoffError.Signal(err)
 				if !n.disableSleep {
 					serviceutil.CancellableSleep(ctx, sleepDuration)


### PR DESCRIPTION
While looking into #695 the other day, I was reminded that the handling
of `time.Duration` in things like logging is potentially not very good.

`time.Duration` has a good `String()` override that tends to get used
with text handlers, but for various legacy reasons it doesn't have a
`MarshalJSON` implementation, so when dumped to JSON it gets put in
nanoseconds, which isn't very readable for human or computer.

This is relevant to use because slog's `JSONHandler` and `TextHandler`
will probably be the most common logging instruments for River. e.g.

    func main() {
        dur := 500 * time.Millisecond

        loggerText := slog.New(slog.NewTextHandler(os.Stdout, nil))
        loggerText.Info("with text handler", "sleep_duration", dur)

        loggerJSON := slog.New(slog.NewJSONHandler(os.Stdout, nil))
        loggerJSON.Info("with JSON handler", "sleep_duration", dur)
    }

    time=2024-12-19T21:36:41.948-07:00 level=INFO msg="with text handler" sleep_duration=500ms
    {"time":"2024-12-19T21:36:41.949239-07:00","level":"INFO","msg":"with JSONtext handler","sleep_duration":500000000}

Here, change the various places that we log sleep to use a more
definitive value for purposes of the log. In this case a duration string
representation like `10s`.

I debated making this a float instead that'd be represented in seconds
because the float would be more parseable for ingestion engines like
Splunk. I went with the former option in the end though because it's
probably better for humans and most other cases, and we could always add
an alternative `sleep_seconds` field that's a float later if someone
asks for it.