### PR TITLE
add line name to migration comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Sleep durations are now logged as Go-like duration strings (e.g. "10s") in either text or JSON instead of duration strings in text and nanoseconds in JSON. [PR #699](https://github.com/riverqueue/river/pull/699).
+- Altered the migration comments from `river migrate-get` to include the "line" of the migration being run (`main`, or for River Pro `workflow` and `sequence`) to make them more distinguishable. [PR #703](https://github.com/riverqueue/river/pull/703).
 
 ### Fixed
 

--- a/cmd/river/rivercli/river_cli.go
+++ b/cmd/river/rivercli/river_cli.go
@@ -437,7 +437,7 @@ func migratePrintResult(out io.Writer, opts *migrateOpts, res *rivermigrate.Migr
 
 		if opts.ShowSQL {
 			fmt.Fprintf(out, "%s\n", strings.Repeat("-", 80))
-			fmt.Fprintf(out, "%s\n", migrationComment(migrateVersion.Version, direction))
+			fmt.Fprintf(out, "%s\n", migrationComment(opts.Line, migrateVersion.Version, direction))
 			fmt.Fprintf(out, "%s\n\n", strings.TrimSpace(migrateVersion.SQL))
 		}
 	}
@@ -451,8 +451,8 @@ func migratePrintResult(out io.Writer, opts *migrateOpts, res *rivermigrate.Migr
 // An informational comment that's tagged on top of any migration's SQL to help
 // attribute what it is for when it's copied elsewhere like other migration
 // frameworks.
-func migrationComment(version int, direction rivermigrate.Direction) string {
-	return fmt.Sprintf("-- River migration %03d [%s]", version, direction)
+func migrationComment(line string, version int, direction rivermigrate.Direction) string {
+	return fmt.Sprintf("-- River %s migration %03d [%s]", line, version, direction)
 }
 
 type migrateGetOpts struct {
@@ -523,7 +523,7 @@ func (c *migrateGet) Run(_ context.Context, opts *migrateGetOpts) (bool, error) 
 		}
 
 		printedOne = true
-		fmt.Fprintf(c.Out, "%s\n", migrationComment(migration.Version, direction))
+		fmt.Fprintf(c.Out, "%s\n", migrationComment(opts.Line, migration.Version, direction))
 		fmt.Fprintf(c.Out, "%s\n", strings.TrimSpace(sql))
 	}
 

--- a/cmd/river/rivercli/river_cli_test.go
+++ b/cmd/river/rivercli/river_cli_test.go
@@ -282,8 +282,8 @@ func withCommandBase[TCommand Command[TOpts], TOpts CommandOpts](t *testing.T, c
 func TestMigrationComment(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "-- River migration 001 [down]", migrationComment(1, rivermigrate.DirectionDown))
-	require.Equal(t, "-- River migration 002 [up]", migrationComment(2, rivermigrate.DirectionUp))
+	require.Equal(t, "-- River main migration 001 [down]", migrationComment("main", 1, rivermigrate.DirectionDown))
+	require.Equal(t, "-- River main migration 002 [up]", migrationComment("main", 2, rivermigrate.DirectionUp))
 }
 
 func TestRoundDuration(t *testing.T) {


### PR DESCRIPTION
When printing the pro sequence migration, I realized its comment was still:

```
-- River migration 001 [up]
```

Which is to say that it's the same no matter which line you're migrating, pro or non-pro. I thought this could be improved by adding the line name so it's instead:

```
-- River sequence migration 001 [up]
```

Still doesn't explicitly make pro vs non-pro clear, but it's a small improvement IMO.

Will add a changelog if you agree this is a good change.