### PR TITLE
Reduce slice allocations during unique insertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sleep durations are now logged as Go-like duration strings (e.g. "10s") in either text or JSON instead of duration strings in text and nanoseconds in JSON. [PR #699](https://github.com/riverqueue/river/pull/699).
 - Altered the migration comments from `river migrate-get` to include the "line" of the migration being run (`main`, or for River Pro `workflow` and `sequence`) to make them more distinguishable. [PR #703](https://github.com/riverqueue/river/pull/703).
+- Fewer slice allocations during unique insertions. [PR #705](https://github.com/riverqueue/river/pull/705).
 
 ### Fixed
 

--- a/insert_opts.go
+++ b/insert_opts.go
@@ -184,6 +184,13 @@ func (o *UniqueOpts) isEmpty() bool {
 
 var jobStateAll = rivertype.JobStates() //nolint:gochecknoglobals
 
+var requiredV3states = []rivertype.JobState{ //nolint:gochecknoglobals
+	rivertype.JobStateAvailable,
+	rivertype.JobStatePending,
+	rivertype.JobStateRunning,
+	rivertype.JobStateScheduled,
+}
+
 func (o *UniqueOpts) validate() error {
 	if o.isEmpty() {
 		return nil
@@ -209,13 +216,7 @@ func (o *UniqueOpts) validate() error {
 		return nil
 	}
 
-	requiredV3states := []rivertype.JobState{
-		rivertype.JobStateAvailable,
-		rivertype.JobStatePending,
-		rivertype.JobStateRunning,
-		rivertype.JobStateScheduled,
-	}
-	missingStates := []string{}
+	var missingStates []string
 	for _, state := range requiredV3states {
 		if !slices.Contains(o.ByState, state) {
 			missingStates = append(missingStates, string(state))


### PR DESCRIPTION
Just reduce some really easy to avoid slice allocations for every unique
insertion:

* No reason to have `requiredV3states` allocated every time a new unique
  opts is validated. It never changes.

* Leave `missingStates` unallocated by default. Most of the time a
  unique insertion will have have no missing unique states, so this
  skips a unique allocation completely the overwhelmingly majority of
  the time.