### PR TITLE
Prepare release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2024-12-26
+
 ### Added
 
 - The River CLI will now respect the standard set of `PG*` environment variables like `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, and `PGSSLMODE` to configure a target database when the `--database-url` parameter is omitted. [PR #702](https://github.com/riverqueue/river/pull/702).

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,11 +7,11 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/lmittmann/tint v1.0.4
-	github.com/riverqueue/river v0.14.3
-	github.com/riverqueue/river/riverdriver v0.14.3
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.14.3
-	github.com/riverqueue/river/rivershared v0.14.3
-	github.com/riverqueue/river/rivertype v0.14.3
+	github.com/riverqueue/river v0.15.0
+	github.com/riverqueue/river/riverdriver v0.15.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.15.0
+	github.com/riverqueue/river/rivershared v0.15.0
+	github.com/riverqueue/river/rivertype v0.15.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.14.3
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.14.3
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.14.3
-	github.com/riverqueue/river/rivershared v0.14.3
-	github.com/riverqueue/river/rivertype v0.14.3
+	github.com/riverqueue/river/riverdriver v0.15.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.15.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.15.0
+	github.com/riverqueue/river/rivershared v0.15.0
+	github.com/riverqueue/river/rivertype v0.15.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,4 +4,4 @@ go 1.22
 
 toolchain go1.23.0
 
-require github.com/riverqueue/river/rivertype v0.14.3
+require github.com/riverqueue/river/rivertype v0.15.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.14.3
-	github.com/riverqueue/river/riverdriver v0.14.3
-	github.com/riverqueue/river/rivershared v0.14.3
-	github.com/riverqueue/river/rivertype v0.14.3
+	github.com/riverqueue/river v0.15.0
+	github.com/riverqueue/river/riverdriver v0.15.0
+	github.com/riverqueue/river/rivershared v0.15.0
+	github.com/riverqueue/river/rivertype v0.15.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.0
 require (
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river v0.14.3
-	github.com/riverqueue/river/riverdriver v0.14.3
-	github.com/riverqueue/river/rivershared v0.14.3
-	github.com/riverqueue/river/rivertype v0.14.3
+	github.com/riverqueue/river v0.15.0
+	github.com/riverqueue/river/riverdriver v0.15.0
+	github.com/riverqueue/river/rivershared v0.15.0
+	github.com/riverqueue/river/rivertype v0.15.0
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -5,9 +5,9 @@ go 1.22
 toolchain go1.23.0
 
 require (
-	github.com/riverqueue/river v0.14.3
-	github.com/riverqueue/river/riverdriver v0.14.3
-	github.com/riverqueue/river/rivertype v0.14.3
+	github.com/riverqueue/river v0.15.0
+	github.com/riverqueue/river/riverdriver v0.15.0
+	github.com/riverqueue/river/rivertype v0.15.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.17.0


### PR DESCRIPTION
We've got a few changes queued up in `master` and it's been a while
since the last release so go for a Boxing Day gift with 0.15.0.

[skip ci]