### PR TITLE
Enable the reindexer by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `NeverSchedule` returns a `PeriodicSchedule` that never runs. This can be used to effectively disable the reindexer or any other maintenance service. [PR #718](https://github.com/riverqueue/river/pull/718).
+
 ### Changed
 
+- The reindexer maintenance process has been enabled. As of now, it will reindex only the `river_job_args_index` and `river_jobs_metadata_index` `GIN` indexes, which are more prone to bloat than b-tree indexes. By default it runs daily at midnight UTC, but can be customized on the `river.Config` type via `ReindexerSchedule`. Most installations will benefit from this process, but it can be disabled altogether using `NeverSchedule`. [PR #718](https://github.com/riverqueue/river/pull/718).
 - Periodic jobs now have a `"periodic": true` attribute set in their metadata to make them more easily distinguishable from other types of jobs. [PR #728](https://github.com/riverqueue/river/pull/728).
 
 ## [0.15.0] - 2024-12-26

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -18,7 +18,7 @@ const (
 	ReindexerTimeoutDefault  = 15 * time.Second
 )
 
-var defaultIndexNames = []string{} //nolint:gochecknoglobals
+var defaultIndexNames = []string{"river_job_args_index", "river_job_metadata_index"} //nolint:gochecknoglobals
 
 // Test-only properties.
 type ReindexerTestSignals struct {
@@ -74,7 +74,7 @@ func NewReindexer(archetype *baseservice.Archetype, config *ReindexerConfig, exe
 
 	scheduleFunc := config.ScheduleFunc
 	if scheduleFunc == nil {
-		scheduleFunc = (&defaultReindexerSchedule{}).Next
+		scheduleFunc = (&DefaultReindexerSchedule{}).Next
 	}
 
 	return baseservice.Init(archetype, &Reindexer{
@@ -165,11 +165,11 @@ func (s *Reindexer) reindexOne(ctx context.Context, indexName string) error {
 	return nil
 }
 
-// defaultReindexerSchedule is a default schedule for the reindexer job which
+// DefaultReindexerSchedule is a default schedule for the reindexer job which
 // runs at midnight UTC daily.
-type defaultReindexerSchedule struct{}
+type DefaultReindexerSchedule struct{}
 
 // Next returns the next scheduled time for the reindexer job.
-func (s *defaultReindexerSchedule) Next(t time.Time) time.Time {
+func (s *DefaultReindexerSchedule) Next(t time.Time) time.Time {
 	return t.Add(24 * time.Hour).Truncate(24 * time.Hour)
 }

--- a/internal/maintenance/reindexer_test.go
+++ b/internal/maintenance/reindexer_test.go
@@ -128,7 +128,7 @@ func TestReindexer(t *testing.T) {
 
 		require.Equal(t, defaultIndexNames, svc.Config.IndexNames)
 		require.Equal(t, ReindexerTimeoutDefault, svc.Config.Timeout)
-		require.Equal(t, svc.Config.ScheduleFunc(bundle.now), (&defaultReindexerSchedule{}).Next(bundle.now))
+		require.Equal(t, svc.Config.ScheduleFunc(bundle.now), (&DefaultReindexerSchedule{}).Next(bundle.now))
 	})
 }
 
@@ -138,7 +138,7 @@ func TestDefaultReindexerSchedule(t *testing.T) {
 	t.Run("WithMidnightInputReturnsMidnight24HoursLater", func(t *testing.T) {
 		t.Parallel()
 
-		schedule := &defaultReindexerSchedule{}
+		schedule := &DefaultReindexerSchedule{}
 		result := schedule.Next(time.Date(2023, 8, 31, 0, 0, 0, 0, time.UTC))
 		require.Equal(t, time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC), result)
 	})
@@ -146,7 +146,7 @@ func TestDefaultReindexerSchedule(t *testing.T) {
 	t.Run("WithMidnightInputReturnsMidnight24HoursLater", func(t *testing.T) {
 		t.Parallel()
 
-		schedule := &defaultReindexerSchedule{}
+		schedule := &DefaultReindexerSchedule{}
 		result := schedule.Next(time.Date(2023, 8, 31, 0, 0, 0, 0, time.UTC))
 		require.Equal(t, time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC), result)
 	})
@@ -154,7 +154,7 @@ func TestDefaultReindexerSchedule(t *testing.T) {
 	t.Run("With1NanosecondBeforeMidnightItReturnsUpcomingMidnight", func(t *testing.T) {
 		t.Parallel()
 
-		schedule := &defaultReindexerSchedule{}
+		schedule := &DefaultReindexerSchedule{}
 		result := schedule.Next(time.Date(2023, 8, 31, 23, 59, 59, 999999999, time.UTC))
 		require.Equal(t, time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC), result)
 	})

--- a/periodic_job.go
+++ b/periodic_job.go
@@ -73,6 +73,18 @@ func NewPeriodicJob(scheduleFunc PeriodicSchedule, constructorFunc PeriodicJobCo
 	}
 }
 
+type neverSchedule struct{}
+
+func (s *neverSchedule) Next(t time.Time) time.Time {
+	// Return the maximum future time so that the schedule never runs.
+	return time.Unix(1<<63-1, 0)
+}
+
+// NeverSchedule returns a PeriodicSchedule that never runs.
+func NeverSchedule() PeriodicSchedule {
+	return &neverSchedule{}
+}
+
 type periodicIntervalSchedule struct {
 	interval time.Duration
 }

--- a/periodic_job_test.go
+++ b/periodic_job_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 )
 
+func TestNeverSchedule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NextReturnsMaximumTime", func(t *testing.T) {
+		t.Parallel()
+
+		schedule := NeverSchedule()
+		require.Equal(t, time.Unix(1<<63-1, 0), schedule.Next(time.Now()))
+	})
+}
+
 func TestPeriodicJobBundle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Following the questions and discussion in https://github.com/riverqueue/river/discussions/717, this PR enables the reindexer by default. It was originally disabled in #34 in the lead up to release because we felt we may want to spend more time addressing potential downsides (like multiple simultaneous reindexings).

Just from looking at the demo app, it's clear that the GIN indexes are particularly prone to long-term bloat. Pulling from what I posted in that discussion, here's the relevant index sizes before and after a manual concurrent reindex call:

```
riverdemo=# SELECT
    indexrelname AS index_name,
    pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
FROM pg_stat_user_indexes;
               index_name               | index_size 
----------------------------------------+------------
 river_job_prioritized_fetching_index   | 80 MB
 river_job_args_index                   | 4013 MB
 river_job_metadata_index               | 645 MB
...
```

```
riverdemo=# SELECT                                    
    indexrelname AS index_name,
    pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
FROM pg_stat_user_indexes;
               index_name               | index_size 
----------------------------------------+------------
 river_job_prioritized_fetching_index   | 38 MB
 river_job_args_index                   | 35 MB
 river_job_metadata_index               | 5656 kB
...
```

This is likely the reason the Fly deployment where the demo is running keeps running out of disk space on its Postgres instance. There might be situations where `river_job_prioritized_fetching_index` would also benefit from reindexing, but it's not clear that it _needs_ it to the same extent. Perhaps with a higher throughput use case (i.e. Heroku's API per https://github.com/riverqueue/river/issues/59) it might matter.