### PR TITLE
enable dependabot across all dirs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
+    directories:
+      - "**/*"
     groups:
       go-dependencies:
         update-types:


### PR DESCRIPTION
Since we have many `go.mod` files in submodules, this should take care of updating all of them each time Dependabot runs (I think). Haven't tried this setting before so I'm not certain if it groups them in a reasonable way (i.e. one PR for a given dep across _all_ `go.mod` files, vs one per module) but we'll find out.