### PR TITLE
Set periodic attribute in periodic job metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Periodic jobs now have a `"periodic": true` attribute set in their metadata to make them more easily distinguishable from other types of jobs. [PR #728](https://github.com/riverqueue/river/pull/728).
+
 ## [0.15.0] - 2024-12-26
 
 ### Added

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tidwall/sjson"
+
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
@@ -369,6 +371,11 @@ func (s *PeriodicJobEnqueuer) insertParamsFromConstructor(ctx context.Context, c
 
 	if insertParams.ScheduledAt == nil {
 		insertParams.ScheduledAt = &scheduledAt
+	}
+
+	if insertParams.Metadata, err = sjson.SetBytes(insertParams.Metadata, "periodic", true); err != nil {
+		s.Logger.ErrorContext(ctx, s.Name+": Error setting periodic metadata", "error", err.Error())
+		return nil, false
 	}
 
 	return insertParams, true


### PR DESCRIPTION
This is a minor improvement coming out of https://github.com/riverqueue/river/discussions/727#discussioncomment-11923628. Periodic jobs are currently indistinguishable from jobs inserted normally, which can make debugging more difficult. This PR changes the periodic job enqueuer to set a `"periodic": true` attribute on all periodic jobs' metadata to make them identifiable.