### PR TITLE
decrement attempt on snooze, don't touch max_attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The reindexer maintenance process has been enabled. As of now, it will reindex only the `river_job_args_index` and `river_jobs_metadata_index` `GIN` indexes, which are more prone to bloat than b-tree indexes. By default it runs daily at midnight UTC, but can be customized on the `river.Config` type via `ReindexerSchedule`. Most installations will benefit from this process, but it can be disabled altogether using `NeverSchedule`. [PR #718](https://github.com/riverqueue/river/pull/718).
 - Periodic jobs now have a `"periodic": true` attribute set in their metadata to make them more easily distinguishable from other types of jobs. [PR #728](https://github.com/riverqueue/river/pull/728).
+- Snoozing a job now causes its `attempt` to be _decremented_, whereas previously the `max_attempts` would be incremented. In either case, this avoids allowing a snooze to exhaust a job's retries; however the new behavior also avoids potential issues with wrapping the `max_attempts` value, and makes it simpler to implement a `RetryPolicy` based on either `attempt` or `max_attempts`. The number of snoozes is also tracked in the job's metadata as `snoozes` for debugging purposes.
+
+  The implementation of the builtin `RetryPolicy` implementations is not changed, so this change should not cause any user-facing breakage unless you're relying on `attempt - len(errors)` for some reason. [PR #730](https://github.com/riverqueue/river/pull/730).
 
 ## [0.15.0] - 2024-12-26
 

--- a/client_test.go
+++ b/client_test.go
@@ -438,6 +438,7 @@ func Test_Client(t *testing.T) {
 
 		updatedJob, err := client.JobGet(ctx, insertRes.Job.ID)
 		require.NoError(t, err)
+		require.Equal(t, 0, updatedJob.Attempt)
 		require.Equal(t, rivertype.JobStateScheduled, updatedJob.State)
 		require.WithinDuration(t, time.Now().Add(15*time.Minute), updatedJob.ScheduledAt, 2*time.Second)
 	})

--- a/example_job_snooze_test.go
+++ b/example_job_snooze_test.go
@@ -34,8 +34,8 @@ func (w *SnoozingWorker) Work(ctx context.Context, job *river.Job[SnoozingArgs])
 
 // Example_jobSnooze demonstrates how to snooze a job from within Work using
 // JobSnooze. The job will be run again after 5 minutes and the snooze attempt
-// will increment the job's max attempts, ensuring that one can snooze as many
-// times as desired.
+// will decrement the job's attempt count, ensuring that one can snooze as many
+// times as desired without being impacted by the max attempts.
 func Example_jobSnooze() { //nolint:dupl
 	ctx := context.Background()
 

--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -377,20 +377,22 @@ func (c *BatchCompleter) handleBatch(ctx context.Context) error {
 	// it's done this way to allocate as few new slices as necessary.
 	mapBatch := func(setStateBatch map[int64]*batchCompleterSetState) *riverdriver.JobSetStateIfRunningManyParams {
 		params := &riverdriver.JobSetStateIfRunningManyParams{
-			ID:          make([]int64, len(setStateBatch)),
-			ErrData:     make([][]byte, len(setStateBatch)),
-			FinalizedAt: make([]*time.Time, len(setStateBatch)),
-			MaxAttempts: make([]*int, len(setStateBatch)),
-			ScheduledAt: make([]*time.Time, len(setStateBatch)),
-			State:       make([]rivertype.JobState, len(setStateBatch)),
+			ID:                make([]int64, len(setStateBatch)),
+			Attempt:           make([]*int, len(setStateBatch)),
+			ErrData:           make([][]byte, len(setStateBatch)),
+			FinalizedAt:       make([]*time.Time, len(setStateBatch)),
+			ScheduledAt:       make([]*time.Time, len(setStateBatch)),
+			SnoozeDoIncrement: make([]bool, len(setStateBatch)),
+			State:             make([]rivertype.JobState, len(setStateBatch)),
 		}
 		var i int
 		for _, setState := range setStateBatch {
 			params.ID[i] = setState.Params.ID
+			params.Attempt[i] = setState.Params.Attempt
 			params.ErrData[i] = setState.Params.ErrData
 			params.FinalizedAt[i] = setState.Params.FinalizedAt
-			params.MaxAttempts[i] = setState.Params.MaxAttempts
 			params.ScheduledAt[i] = setState.Params.ScheduledAt
+			params.SnoozeDoIncrement[i] = setState.Params.SnoozeDoIncrement
 			params.State[i] = setState.Params.State
 			i++
 		}
@@ -412,12 +414,13 @@ func (c *BatchCompleter) handleBatch(ctx context.Context) error {
 		for i := 0; i < len(setStateBatch); i += c.completionMaxSize {
 			endIndex := min(i+c.completionMaxSize, len(params.ID)) // beginning of next sub-batch or end of slice
 			subBatch := &riverdriver.JobSetStateIfRunningManyParams{
-				ID:          params.ID[i:endIndex],
-				ErrData:     params.ErrData[i:endIndex],
-				FinalizedAt: params.FinalizedAt[i:endIndex],
-				MaxAttempts: params.MaxAttempts[i:endIndex],
-				ScheduledAt: params.ScheduledAt[i:endIndex],
-				State:       params.State[i:endIndex],
+				ID:                params.ID[i:endIndex],
+				Attempt:           params.Attempt[i:endIndex],
+				ErrData:           params.ErrData[i:endIndex],
+				FinalizedAt:       params.FinalizedAt[i:endIndex],
+				ScheduledAt:       params.ScheduledAt[i:endIndex],
+				SnoozeDoIncrement: params.SnoozeDoIncrement[i:endIndex],
+				State:             params.State[i:endIndex],
 			}
 			jobRowsSubBatch, err := completeSubBatch(subBatch)
 			if err != nil {

--- a/job_complete_tx.go
+++ b/job_complete_tx.go
@@ -39,12 +39,13 @@ func JobCompleteTx[TDriver riverdriver.Driver[TTx], TTx any, TArgs JobArgs](ctx 
 	execTx := driver.UnwrapExecutor(tx)
 	params := riverdriver.JobSetStateCompleted(job.ID, time.Now())
 	rows, err := pilot.JobSetStateIfRunningMany(ctx, execTx, &riverdriver.JobSetStateIfRunningManyParams{
-		ID:          []int64{params.ID},
-		ErrData:     [][]byte{params.ErrData},
-		FinalizedAt: []*time.Time{params.FinalizedAt},
-		MaxAttempts: []*int{params.MaxAttempts},
-		ScheduledAt: []*time.Time{params.ScheduledAt},
-		State:       []rivertype.JobState{params.State},
+		ID:                []int64{params.ID},
+		Attempt:           []*int{params.Attempt},
+		ErrData:           [][]byte{params.ErrData},
+		FinalizedAt:       []*time.Time{params.FinalizedAt},
+		ScheduledAt:       []*time.Time{params.ScheduledAt},
+		SnoozeDoIncrement: []bool{params.SnoozeDoIncrement},
+		State:             []rivertype.JobState{params.State},
 	})
 	if err != nil {
 		return nil, err

--- a/job_executor.go
+++ b/job_executor.go
@@ -293,9 +293,9 @@ func (e *jobExecutor) reportResult(ctx context.Context, res *jobExecutorResult) 
 		// smaller than the scheduler's run interval.
 		var params *riverdriver.JobSetStateIfRunningParams
 		if nextAttemptScheduledAt.Sub(e.Time.NowUTC()) <= e.SchedulerInterval {
-			params = riverdriver.JobSetStateSnoozedAvailable(e.JobRow.ID, nextAttemptScheduledAt, e.JobRow.MaxAttempts+1)
+			params = riverdriver.JobSetStateSnoozedAvailable(e.JobRow.ID, nextAttemptScheduledAt, e.JobRow.Attempt-1)
 		} else {
-			params = riverdriver.JobSetStateSnoozed(e.JobRow.ID, nextAttemptScheduledAt, e.JobRow.MaxAttempts+1)
+			params = riverdriver.JobSetStateSnoozed(e.JobRow.ID, nextAttemptScheduledAt, e.JobRow.Attempt-1)
 		}
 		if err := e.Completer.JobSetStateIfRunning(ctx, e.stats, params); err != nil {
 			e.Logger.ErrorContext(ctx, e.Name+": Error snoozing job",

--- a/retry_policy.go
+++ b/retry_policy.go
@@ -36,10 +36,12 @@ type DefaultClientRetryPolicy struct {
 // try will be scheduled in 1 seconds, 16 seconds after the second, 1 minute and
 // 21 seconds after the third, etc.
 //
-// In order to avoid penalizing jobs that are snoozed, the number of errors is
-// used instead of the attempt count. This means that snoozing a job (even
-// repeatedly) will not lead to a future error having a longer than expected
-// retry delay.
+// Snoozes do not count as attempts and do not influence retry behavior.
+// Earlier versions of River would allow the attempt to increment each time a
+// job was snoozed. Although this has been changed and snoozes now decrement the
+// attempt count, we can maintain the same retry schedule even for pre-existing
+// jobs by using the number of errors instead of the attempt count. This ensures
+// consistent behavior across River versions.
 //
 // At degenerately high retry counts (>= 310) the policy starts adding the
 // equivalent of the maximum of time.Duration to each retry, about 292 years.

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -320,12 +320,13 @@ type JobSetCompleteIfRunningManyParams struct {
 // running job. Use one of the constructors below to ensure a correct
 // combination of parameters.
 type JobSetStateIfRunningParams struct {
-	ID          int64
-	ErrData     []byte
-	FinalizedAt *time.Time
-	MaxAttempts *int
-	ScheduledAt *time.Time
-	State       rivertype.JobState
+	ID                int64
+	Attempt           *int
+	ErrData           []byte
+	FinalizedAt       *time.Time
+	ScheduledAt       *time.Time
+	SnoozeDoIncrement bool
+	State             rivertype.JobState
 }
 
 func JobSetStateCancelled(id int64, finalizedAt time.Time, errData []byte) *JobSetStateIfRunningParams {
@@ -348,24 +349,25 @@ func JobSetStateErrorRetryable(id int64, scheduledAt time.Time, errData []byte) 
 	return &JobSetStateIfRunningParams{ID: id, ErrData: errData, ScheduledAt: &scheduledAt, State: rivertype.JobStateRetryable}
 }
 
-func JobSetStateSnoozed(id int64, scheduledAt time.Time, maxAttempts int) *JobSetStateIfRunningParams {
-	return &JobSetStateIfRunningParams{ID: id, MaxAttempts: &maxAttempts, ScheduledAt: &scheduledAt, State: rivertype.JobStateScheduled}
+func JobSetStateSnoozed(id int64, scheduledAt time.Time, attempt int) *JobSetStateIfRunningParams {
+	return &JobSetStateIfRunningParams{ID: id, Attempt: &attempt, ScheduledAt: &scheduledAt, SnoozeDoIncrement: true, State: rivertype.JobStateScheduled}
 }
 
-func JobSetStateSnoozedAvailable(id int64, scheduledAt time.Time, maxAttempts int) *JobSetStateIfRunningParams {
-	return &JobSetStateIfRunningParams{ID: id, MaxAttempts: &maxAttempts, ScheduledAt: &scheduledAt, State: rivertype.JobStateAvailable}
+func JobSetStateSnoozedAvailable(id int64, scheduledAt time.Time, attempt int) *JobSetStateIfRunningParams {
+	return &JobSetStateIfRunningParams{ID: id, Attempt: &attempt, ScheduledAt: &scheduledAt, SnoozeDoIncrement: true, State: rivertype.JobStateAvailable}
 }
 
 // JobSetStateIfRunningManyParams are parameters to update the state of
 // currently running jobs. Use one of the constructors below to ensure a correct
 // combination of parameters.
 type JobSetStateIfRunningManyParams struct {
-	ID          []int64
-	ErrData     [][]byte
-	FinalizedAt []*time.Time
-	MaxAttempts []*int
-	ScheduledAt []*time.Time
-	State       []rivertype.JobState
+	ID                []int64
+	Attempt           []*int
+	ErrData           [][]byte
+	FinalizedAt       []*time.Time
+	ScheduledAt       []*time.Time
+	SnoozeDoIncrement []bool
+	State             []rivertype.JobState
 }
 
 type JobUpdateParams struct {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -1132,17 +1132,20 @@ WITH job_to_update AS (
 updated_job AS (
     UPDATE river_job
     SET
-        state        = CASE WHEN should_cancel                                           THEN 'cancelled'::river_job_state
-                            ELSE $1::river_job_state END,
-        finalized_at = CASE WHEN should_cancel                                           THEN now()
-                            WHEN $3::boolean                        THEN $4
-                            ELSE finalized_at END,
+        attempt      = CASE WHEN NOT should_cancel AND $3::boolean          THEN $4
+                            ELSE attempt END,
         errors       = CASE WHEN $5::boolean                               THEN array_append(errors, $6::jsonb)
                             ELSE errors       END,
-        max_attempts = CASE WHEN NOT should_cancel AND $7::boolean     THEN $8
-                            ELSE max_attempts END,
-        scheduled_at = CASE WHEN NOT should_cancel AND $9::boolean  THEN $10::timestamptz
-                            ELSE scheduled_at END
+        finalized_at = CASE WHEN should_cancel                                           THEN now()
+                            WHEN $7::boolean                        THEN $8
+                            ELSE finalized_at END,
+        metadata     = CASE WHEN $9::boolean
+                            THEN river_job.metadata || jsonb_build_object('snoozes', coalesce((river_job.metadata->>'snoozes')::int, 0) + 1)
+                            ELSE river_job.metadata END,
+        scheduled_at = CASE WHEN NOT should_cancel AND $10::boolean  THEN $11::timestamptz
+                            ELSE scheduled_at END,
+        state        = CASE WHEN should_cancel                                           THEN 'cancelled'::river_job_state
+                            ELSE $1::river_job_state END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id
         AND river_job.state = 'running'
@@ -1160,12 +1163,13 @@ FROM updated_job
 type JobSetStateIfRunningParams struct {
 	State               RiverJobState
 	ID                  int64
-	FinalizedAtDoUpdate bool
-	FinalizedAt         *time.Time
+	AttemptUpdate       bool
+	Attempt             int16
 	ErrorDoUpdate       bool
 	Error               string
-	MaxAttemptsUpdate   bool
-	MaxAttempts         int16
+	FinalizedAtDoUpdate bool
+	FinalizedAt         *time.Time
+	SnoozeDoIncrement   bool
 	ScheduledAtDoUpdate bool
 	ScheduledAt         *time.Time
 }
@@ -1174,12 +1178,13 @@ func (q *Queries) JobSetStateIfRunning(ctx context.Context, db DBTX, arg *JobSet
 	row := db.QueryRowContext(ctx, jobSetStateIfRunning,
 		arg.State,
 		arg.ID,
-		arg.FinalizedAtDoUpdate,
-		arg.FinalizedAt,
+		arg.AttemptUpdate,
+		arg.Attempt,
 		arg.ErrorDoUpdate,
 		arg.Error,
-		arg.MaxAttemptsUpdate,
-		arg.MaxAttempts,
+		arg.FinalizedAtDoUpdate,
+		arg.FinalizedAt,
+		arg.SnoozeDoIncrement,
 		arg.ScheduledAtDoUpdate,
 		arg.ScheduledAt,
 	)
@@ -1211,31 +1216,33 @@ const jobSetStateIfRunningMany = `-- name: JobSetStateIfRunningMany :many
 WITH job_input AS (
     SELECT
         unnest($1::bigint[]) AS id,
+        unnest($2::boolean[]) AS attempt_do_update,
+        unnest($3::int[]) AS attempt,
+        unnest($4::boolean[]) AS errors_do_update,
+        unnest($5::jsonb[]) AS errors,
+        unnest($6::boolean[]) AS finalized_at_do_update,
+        unnest($7::timestamptz[]) AS finalized_at,
+        unnest($8::boolean[]) AS scheduled_at_do_update,
+        unnest($9::timestamptz[]) AS scheduled_at,
+        unnest($10::boolean[]) AS snooze_do_increment,
         -- To avoid requiring pgx users to register the OID of the river_job_state[]
         -- type, we cast the array to text[] and then to river_job_state.
-        unnest($2::text[])::river_job_state AS state,
-        unnest($3::boolean[]) AS finalized_at_do_update,
-        unnest($4::timestamptz[]) AS finalized_at,
-        unnest($5::boolean[]) AS errors_do_update,
-        unnest($6::jsonb[]) AS errors,
-        unnest($7::boolean[]) AS max_attempts_do_update,
-        unnest($8::int[]) AS max_attempts,
-        unnest($9::boolean[]) AS scheduled_at_do_update,
-        unnest($10::timestamptz[]) AS scheduled_at
+        unnest($11::text[])::river_job_state AS state
 ),
 job_to_update AS (
     SELECT
         river_job.id,
-        job_input.state,
+        job_input.attempt,
+        job_input.attempt_do_update,
         job_input.finalized_at,
-        job_input.errors,
-        job_input.max_attempts,
-        job_input.scheduled_at,
-        (job_input.state IN ('retryable', 'scheduled') AND river_job.metadata ? 'cancel_attempted_at') AS should_cancel,
         job_input.finalized_at_do_update,
+        job_input.errors,
         job_input.errors_do_update,
-        job_input.max_attempts_do_update,
-        job_input.scheduled_at_do_update
+        job_input.scheduled_at,
+        job_input.scheduled_at_do_update,
+        job_input.snooze_do_increment,
+        (job_input.state IN ('retryable', 'scheduled') AND river_job.metadata ? 'cancel_attempted_at') AS should_cancel,
+        job_input.state
     FROM river_job
     JOIN job_input ON river_job.id = job_input.id
     WHERE river_job.state = 'running'
@@ -1244,17 +1251,20 @@ job_to_update AS (
 updated_job AS (
     UPDATE river_job
     SET
-        state        = CASE WHEN job_to_update.should_cancel THEN 'cancelled'::river_job_state
-                            ELSE job_to_update.state END,
+        attempt      = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.attempt_do_update THEN job_to_update.attempt
+                            ELSE river_job.attempt END,
+        errors       = CASE WHEN job_to_update.errors_do_update THEN array_append(river_job.errors, job_to_update.errors)
+                            ELSE river_job.errors END,
         finalized_at = CASE WHEN job_to_update.should_cancel THEN now()
                             WHEN job_to_update.finalized_at_do_update THEN job_to_update.finalized_at
                             ELSE river_job.finalized_at END,
-        errors       = CASE WHEN job_to_update.errors_do_update THEN array_append(river_job.errors, job_to_update.errors)
-                            ELSE river_job.errors END,
-        max_attempts = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.max_attempts_do_update THEN job_to_update.max_attempts
-                            ELSE river_job.max_attempts END,
+        metadata     = CASE WHEN job_to_update.snooze_do_increment
+                            THEN river_job.metadata || jsonb_build_object('snoozes', coalesce((river_job.metadata->>'snoozes')::int, 0) + 1)
+                            ELSE river_job.metadata END,
         scheduled_at = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.scheduled_at_do_update THEN job_to_update.scheduled_at
-                            ELSE river_job.scheduled_at END
+                            ELSE river_job.scheduled_at END,
+        state        = CASE WHEN job_to_update.should_cancel THEN 'cancelled'::river_job_state
+                            ELSE job_to_update.state END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id
     RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags, river_job.unique_key, river_job.unique_states
@@ -1270,29 +1280,31 @@ FROM updated_job
 
 type JobSetStateIfRunningManyParams struct {
 	IDs                 []int64
-	State               []string
-	FinalizedAtDoUpdate []bool
-	FinalizedAt         []time.Time
+	AttemptDoUpdate     []bool
+	Attempt             []int32
 	ErrorsDoUpdate      []bool
 	Errors              []string
-	MaxAttemptsDoUpdate []bool
-	MaxAttempts         []int32
+	FinalizedAtDoUpdate []bool
+	FinalizedAt         []time.Time
 	ScheduledAtDoUpdate []bool
 	ScheduledAt         []time.Time
+	SnoozeDoIncrement   []bool
+	State               []string
 }
 
 func (q *Queries) JobSetStateIfRunningMany(ctx context.Context, db DBTX, arg *JobSetStateIfRunningManyParams) ([]*RiverJob, error) {
 	rows, err := db.QueryContext(ctx, jobSetStateIfRunningMany,
 		pq.Array(arg.IDs),
-		pq.Array(arg.State),
-		pq.Array(arg.FinalizedAtDoUpdate),
-		pq.Array(arg.FinalizedAt),
+		pq.Array(arg.AttemptDoUpdate),
+		pq.Array(arg.Attempt),
 		pq.Array(arg.ErrorsDoUpdate),
 		pq.Array(arg.Errors),
-		pq.Array(arg.MaxAttemptsDoUpdate),
-		pq.Array(arg.MaxAttempts),
+		pq.Array(arg.FinalizedAtDoUpdate),
+		pq.Array(arg.FinalizedAt),
 		pq.Array(arg.ScheduledAtDoUpdate),
 		pq.Array(arg.ScheduledAt),
+		pq.Array(arg.SnoozeDoIncrement),
+		pq.Array(arg.State),
 	)
 	if err != nil {
 		return nil, err

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -529,21 +529,22 @@ func (e *Executor) JobSetCompleteIfRunningMany(ctx context.Context, params *rive
 }
 
 func (e *Executor) JobSetStateIfRunning(ctx context.Context, params *riverdriver.JobSetStateIfRunningParams) (*rivertype.JobRow, error) {
-	var maxAttempts int16
-	if params.MaxAttempts != nil {
-		maxAttempts = int16(min(*params.MaxAttempts, math.MaxInt16)) //nolint:gosec
+	var attempt int16
+	if params.Attempt != nil {
+		attempt = int16(min(*params.Attempt, math.MaxInt16)) //nolint:gosec
 	}
 
 	job, err := dbsqlc.New().JobSetStateIfRunning(ctx, e.dbtx, &dbsqlc.JobSetStateIfRunningParams{
 		ID:                  params.ID,
+		AttemptUpdate:       params.Attempt != nil,
+		Attempt:             attempt,
 		ErrorDoUpdate:       params.ErrData != nil,
 		Error:               valutil.ValOrDefault(string(params.ErrData), "{}"),
 		FinalizedAtDoUpdate: params.FinalizedAt != nil,
 		FinalizedAt:         params.FinalizedAt,
-		MaxAttemptsUpdate:   params.MaxAttempts != nil,
-		MaxAttempts:         maxAttempts,
 		ScheduledAtDoUpdate: params.ScheduledAt != nil,
 		ScheduledAt:         params.ScheduledAt,
+		SnoozeDoIncrement:   params.SnoozeDoIncrement,
 		State:               dbsqlc.RiverJobState(params.State),
 	})
 	if err != nil {
@@ -555,14 +556,15 @@ func (e *Executor) JobSetStateIfRunning(ctx context.Context, params *riverdriver
 func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error) {
 	setStateParams := &dbsqlc.JobSetStateIfRunningManyParams{
 		IDs:                 params.ID,
+		Attempt:             make([]int32, len(params.ID)),
+		AttemptDoUpdate:     make([]bool, len(params.ID)),
 		Errors:              make([]string, len(params.ID)),
 		ErrorsDoUpdate:      make([]bool, len(params.ID)),
 		FinalizedAt:         make([]time.Time, len(params.ID)),
 		FinalizedAtDoUpdate: make([]bool, len(params.ID)),
-		MaxAttempts:         make([]int32, len(params.ID)),
-		MaxAttemptsDoUpdate: make([]bool, len(params.ID)),
 		ScheduledAt:         make([]time.Time, len(params.ID)),
 		ScheduledAtDoUpdate: make([]bool, len(params.ID)),
+		SnoozeDoIncrement:   make([]bool, len(params.ID)),
 		State:               make([]string, len(params.ID)),
 	}
 
@@ -570,6 +572,10 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 
 	for i := 0; i < len(params.ID); i++ {
 		setStateParams.Errors[i] = valutil.ValOrDefault(string(params.ErrData[i]), defaultObject)
+		if params.Attempt[i] != nil {
+			setStateParams.AttemptDoUpdate[i] = true
+			setStateParams.Attempt[i] = int32(*params.Attempt[i]) //nolint:gosec
+		}
 		if params.ErrData[i] != nil {
 			setStateParams.ErrorsDoUpdate[i] = true
 		}
@@ -577,14 +583,11 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 			setStateParams.FinalizedAtDoUpdate[i] = true
 			setStateParams.FinalizedAt[i] = *params.FinalizedAt[i]
 		}
-		if params.MaxAttempts[i] != nil {
-			setStateParams.MaxAttemptsDoUpdate[i] = true
-			setStateParams.MaxAttempts[i] = int32(*params.MaxAttempts[i]) //nolint:gosec
-		}
 		if params.ScheduledAt[i] != nil {
 			setStateParams.ScheduledAtDoUpdate[i] = true
 			setStateParams.ScheduledAt[i] = *params.ScheduledAt[i]
 		}
+		setStateParams.SnoozeDoIncrement[i] = params.SnoozeDoIncrement[i]
 		setStateParams.State[i] = string(params.State[i])
 	}
 

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -1110,17 +1110,20 @@ WITH job_to_update AS (
 updated_job AS (
     UPDATE river_job
     SET
-        state        = CASE WHEN should_cancel                                           THEN 'cancelled'::river_job_state
-                            ELSE $1::river_job_state END,
-        finalized_at = CASE WHEN should_cancel                                           THEN now()
-                            WHEN $3::boolean                        THEN $4
-                            ELSE finalized_at END,
+        attempt      = CASE WHEN NOT should_cancel AND $3::boolean          THEN $4
+                            ELSE attempt END,
         errors       = CASE WHEN $5::boolean                               THEN array_append(errors, $6::jsonb)
                             ELSE errors       END,
-        max_attempts = CASE WHEN NOT should_cancel AND $7::boolean     THEN $8
-                            ELSE max_attempts END,
-        scheduled_at = CASE WHEN NOT should_cancel AND $9::boolean  THEN $10::timestamptz
-                            ELSE scheduled_at END
+        finalized_at = CASE WHEN should_cancel                                           THEN now()
+                            WHEN $7::boolean                        THEN $8
+                            ELSE finalized_at END,
+        metadata     = CASE WHEN $9::boolean
+                            THEN river_job.metadata || jsonb_build_object('snoozes', coalesce((river_job.metadata->>'snoozes')::int, 0) + 1)
+                            ELSE river_job.metadata END,
+        scheduled_at = CASE WHEN NOT should_cancel AND $10::boolean  THEN $11::timestamptz
+                            ELSE scheduled_at END,
+        state        = CASE WHEN should_cancel                                           THEN 'cancelled'::river_job_state
+                            ELSE $1::river_job_state END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id
         AND river_job.state = 'running'
@@ -1138,12 +1141,13 @@ FROM updated_job
 type JobSetStateIfRunningParams struct {
 	State               RiverJobState
 	ID                  int64
-	FinalizedAtDoUpdate bool
-	FinalizedAt         *time.Time
+	AttemptUpdate       bool
+	Attempt             int16
 	ErrorDoUpdate       bool
 	Error               []byte
-	MaxAttemptsUpdate   bool
-	MaxAttempts         int16
+	FinalizedAtDoUpdate bool
+	FinalizedAt         *time.Time
+	SnoozeDoIncrement   bool
 	ScheduledAtDoUpdate bool
 	ScheduledAt         *time.Time
 }
@@ -1152,12 +1156,13 @@ func (q *Queries) JobSetStateIfRunning(ctx context.Context, db DBTX, arg *JobSet
 	row := db.QueryRow(ctx, jobSetStateIfRunning,
 		arg.State,
 		arg.ID,
-		arg.FinalizedAtDoUpdate,
-		arg.FinalizedAt,
+		arg.AttemptUpdate,
+		arg.Attempt,
 		arg.ErrorDoUpdate,
 		arg.Error,
-		arg.MaxAttemptsUpdate,
-		arg.MaxAttempts,
+		arg.FinalizedAtDoUpdate,
+		arg.FinalizedAt,
+		arg.SnoozeDoIncrement,
 		arg.ScheduledAtDoUpdate,
 		arg.ScheduledAt,
 	)
@@ -1189,31 +1194,33 @@ const jobSetStateIfRunningMany = `-- name: JobSetStateIfRunningMany :many
 WITH job_input AS (
     SELECT
         unnest($1::bigint[]) AS id,
+        unnest($2::boolean[]) AS attempt_do_update,
+        unnest($3::int[]) AS attempt,
+        unnest($4::boolean[]) AS errors_do_update,
+        unnest($5::jsonb[]) AS errors,
+        unnest($6::boolean[]) AS finalized_at_do_update,
+        unnest($7::timestamptz[]) AS finalized_at,
+        unnest($8::boolean[]) AS scheduled_at_do_update,
+        unnest($9::timestamptz[]) AS scheduled_at,
+        unnest($10::boolean[]) AS snooze_do_increment,
         -- To avoid requiring pgx users to register the OID of the river_job_state[]
         -- type, we cast the array to text[] and then to river_job_state.
-        unnest($2::text[])::river_job_state AS state,
-        unnest($3::boolean[]) AS finalized_at_do_update,
-        unnest($4::timestamptz[]) AS finalized_at,
-        unnest($5::boolean[]) AS errors_do_update,
-        unnest($6::jsonb[]) AS errors,
-        unnest($7::boolean[]) AS max_attempts_do_update,
-        unnest($8::int[]) AS max_attempts,
-        unnest($9::boolean[]) AS scheduled_at_do_update,
-        unnest($10::timestamptz[]) AS scheduled_at
+        unnest($11::text[])::river_job_state AS state
 ),
 job_to_update AS (
     SELECT
         river_job.id,
-        job_input.state,
+        job_input.attempt,
+        job_input.attempt_do_update,
         job_input.finalized_at,
-        job_input.errors,
-        job_input.max_attempts,
-        job_input.scheduled_at,
-        (job_input.state IN ('retryable', 'scheduled') AND river_job.metadata ? 'cancel_attempted_at') AS should_cancel,
         job_input.finalized_at_do_update,
+        job_input.errors,
         job_input.errors_do_update,
-        job_input.max_attempts_do_update,
-        job_input.scheduled_at_do_update
+        job_input.scheduled_at,
+        job_input.scheduled_at_do_update,
+        job_input.snooze_do_increment,
+        (job_input.state IN ('retryable', 'scheduled') AND river_job.metadata ? 'cancel_attempted_at') AS should_cancel,
+        job_input.state
     FROM river_job
     JOIN job_input ON river_job.id = job_input.id
     WHERE river_job.state = 'running'
@@ -1222,17 +1229,20 @@ job_to_update AS (
 updated_job AS (
     UPDATE river_job
     SET
-        state        = CASE WHEN job_to_update.should_cancel THEN 'cancelled'::river_job_state
-                            ELSE job_to_update.state END,
+        attempt      = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.attempt_do_update THEN job_to_update.attempt
+                            ELSE river_job.attempt END,
+        errors       = CASE WHEN job_to_update.errors_do_update THEN array_append(river_job.errors, job_to_update.errors)
+                            ELSE river_job.errors END,
         finalized_at = CASE WHEN job_to_update.should_cancel THEN now()
                             WHEN job_to_update.finalized_at_do_update THEN job_to_update.finalized_at
                             ELSE river_job.finalized_at END,
-        errors       = CASE WHEN job_to_update.errors_do_update THEN array_append(river_job.errors, job_to_update.errors)
-                            ELSE river_job.errors END,
-        max_attempts = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.max_attempts_do_update THEN job_to_update.max_attempts
-                            ELSE river_job.max_attempts END,
+        metadata     = CASE WHEN job_to_update.snooze_do_increment
+                            THEN river_job.metadata || jsonb_build_object('snoozes', coalesce((river_job.metadata->>'snoozes')::int, 0) + 1)
+                            ELSE river_job.metadata END,
         scheduled_at = CASE WHEN NOT job_to_update.should_cancel AND job_to_update.scheduled_at_do_update THEN job_to_update.scheduled_at
-                            ELSE river_job.scheduled_at END
+                            ELSE river_job.scheduled_at END,
+        state        = CASE WHEN job_to_update.should_cancel THEN 'cancelled'::river_job_state
+                            ELSE job_to_update.state END
     FROM job_to_update
     WHERE river_job.id = job_to_update.id
     RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags, river_job.unique_key, river_job.unique_states
@@ -1248,29 +1258,31 @@ FROM updated_job
 
 type JobSetStateIfRunningManyParams struct {
 	IDs                 []int64
-	State               []string
-	FinalizedAtDoUpdate []bool
-	FinalizedAt         []time.Time
+	AttemptDoUpdate     []bool
+	Attempt             []int32
 	ErrorsDoUpdate      []bool
 	Errors              [][]byte
-	MaxAttemptsDoUpdate []bool
-	MaxAttempts         []int32
+	FinalizedAtDoUpdate []bool
+	FinalizedAt         []time.Time
 	ScheduledAtDoUpdate []bool
 	ScheduledAt         []time.Time
+	SnoozeDoIncrement   []bool
+	State               []string
 }
 
 func (q *Queries) JobSetStateIfRunningMany(ctx context.Context, db DBTX, arg *JobSetStateIfRunningManyParams) ([]*RiverJob, error) {
 	rows, err := db.Query(ctx, jobSetStateIfRunningMany,
 		arg.IDs,
-		arg.State,
-		arg.FinalizedAtDoUpdate,
-		arg.FinalizedAt,
+		arg.AttemptDoUpdate,
+		arg.Attempt,
 		arg.ErrorsDoUpdate,
 		arg.Errors,
-		arg.MaxAttemptsDoUpdate,
-		arg.MaxAttempts,
+		arg.FinalizedAtDoUpdate,
+		arg.FinalizedAt,
 		arg.ScheduledAtDoUpdate,
 		arg.ScheduledAt,
+		arg.SnoozeDoIncrement,
+		arg.State,
 	)
 	if err != nil {
 		return nil, err

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -51,7 +51,8 @@ type JobRow struct {
 
 	// Attempt is the attempt number of the job. Jobs are inserted at 0, the
 	// number is incremented to 1 the first time work its worked, and may
-	// increment further if it's either snoozed or errors.
+	// increment further if it errors. Attempt will decrement on snooze so that
+	// repeated snoozes don't increment this value.
 	Attempt int
 
 	// AttemptedAt is the time that the job was last worked. Starts out as `nil`


### PR DESCRIPTION
When snoozing was implemented, we needed to ensure that snoozes didn't count against a job's attempts so that it could keep snoozing repeatedly if desired. The design chosen for this was to increment `max_attempts` since `attempt` is automatically incremented when a job is fetched.

This choice turns out to have some downsides:

* It leads to situations where `max_attempts` could accidentally overflow the `smallint` range, even if the job wasn't erroring and was just meant to snooze indefinitely. This _could_ be worked around by avoiding incrementing when the max is reached, but doing so isn't great.

* The implementation of a `RetryPolicy` is a little trickier because one can't merely rely on the `attempt` since it gets inflated by snoozes. Instead, you'd need to use `len(job.errors)` to determine retry backoffs.

To resolve both these situations, change the implementation so that snoozing causes `attempt` to be _decremented_ rather than _incrementing_ `max_attempts`. In order to make this easier to detect, set a `snoozes` attribute in the job's metadata and increment it each time a snooze occurs.

The implementation of the builtin `RetryPolicy` implementations is not changed, so this change should not cause any user-facing breakage unless you're relying on `attempt - len(errors)` for some reason.

Fixes #720.