### PR TITLE
prepare v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2024-01-27
+
 ### Added
 
 - `NeverSchedule` returns a `PeriodicSchedule` that never runs. This can be used to effectively disable the reindexer or any other maintenance service. [PR #718](https://github.com/riverqueue/river/pull/718).
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Snoozing a job now causes its `attempt` to be _decremented_, whereas previously the `max_attempts` would be incremented. In either case, this avoids allowing a snooze to exhaust a job's retries; however the new behavior also avoids potential issues with wrapping the `max_attempts` value, and makes it simpler to implement a `RetryPolicy` based on either `attempt` or `max_attempts`. The number of snoozes is also tracked in the job's metadata as `snoozes` for debugging purposes.
 
   The implementation of the builtin `RetryPolicy` implementations is not changed, so this change should not cause any user-facing breakage unless you're relying on `attempt - len(errors)` for some reason. [PR #730](https://github.com/riverqueue/river/pull/730).
+
 - `ByPeriod` uniqueness is now based off a job's `ScheduledAt` instead of the current time if it has a value. [PR #734](https://github.com/riverqueue/river/pull/734).
 
 ## [0.15.0] - 2024-12-26

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,11 +7,11 @@ toolchain go1.23.5
 require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/lmittmann/tint v1.0.6
-	github.com/riverqueue/river v0.15.0
-	github.com/riverqueue/river/riverdriver v0.15.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.15.0
-	github.com/riverqueue/river/rivershared v0.15.0
-	github.com/riverqueue/river/rivertype v0.15.0
+	github.com/riverqueue/river v0.16.0
+	github.com/riverqueue/river/riverdriver v0.16.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.16.0
+	github.com/riverqueue/river/rivershared v0.16.0
+	github.com/riverqueue/river/rivertype v0.16.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.15.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.15.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.15.0
-	github.com/riverqueue/river/rivershared v0.15.0
-	github.com/riverqueue/river/rivertype v0.15.0
+	github.com/riverqueue/river/riverdriver v0.16.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.16.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.16.0
+	github.com/riverqueue/river/rivershared v0.16.0
+	github.com/riverqueue/river/rivertype v0.16.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -4,6 +4,6 @@ go 1.22.0
 
 toolchain go1.23.5
 
-require github.com/riverqueue/river/rivertype v0.15.0
+require github.com/riverqueue/river/rivertype v0.16.0
 
 require github.com/stretchr/testify v1.10.0 // indirect

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.5
 require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.15.0
-	github.com/riverqueue/river/riverdriver v0.15.0
-	github.com/riverqueue/river/rivershared v0.15.0
-	github.com/riverqueue/river/rivertype v0.15.0
+	github.com/riverqueue/river v0.16.0
+	github.com/riverqueue/river/riverdriver v0.16.0
+	github.com/riverqueue/river/rivershared v0.16.0
+	github.com/riverqueue/river/rivertype v0.16.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.5
 require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river v0.15.0
-	github.com/riverqueue/river/riverdriver v0.15.0
-	github.com/riverqueue/river/rivershared v0.15.0
-	github.com/riverqueue/river/rivertype v0.15.0
+	github.com/riverqueue/river v0.16.0
+	github.com/riverqueue/river/riverdriver v0.16.0
+	github.com/riverqueue/river/rivershared v0.16.0
+	github.com/riverqueue/river/rivertype v0.16.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -5,9 +5,9 @@ go 1.22.0
 toolchain go1.23.5
 
 require (
-	github.com/riverqueue/river v0.15.0
-	github.com/riverqueue/river/riverdriver v0.15.0
-	github.com/riverqueue/river/rivertype v0.15.0
+	github.com/riverqueue/river v0.16.0
+	github.com/riverqueue/river/riverdriver v0.16.0
+	github.com/riverqueue/river/rivertype v0.16.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.22.0


### PR DESCRIPTION

### Added

- `NeverSchedule` returns a `PeriodicSchedule` that never runs. This can be used to effectively disable the reindexer or any other maintenance service. [PR #718](https://github.com/riverqueue/river/pull/718).
- Add `SkipUnknownJobCheck` client config option to skip job arg worker validation. [PR #731](https://github.com/riverqueue/river/pull/731).

### Changed

- The reindexer maintenance process has been enabled. As of now, it will reindex only the `river_job_args_index` and `river_jobs_metadata_index` `GIN` indexes, which are more prone to bloat than b-tree indexes. By default it runs daily at midnight UTC, but can be customized on the `river.Config` type via `ReindexerSchedule`. Most installations will benefit from this process, but it can be disabled altogether using `NeverSchedule`. [PR #718](https://github.com/riverqueue/river/pull/718).
- Periodic jobs now have a `"periodic": true` attribute set in their metadata to make them more easily distinguishable from other types of jobs. [PR #728](https://github.com/riverqueue/river/pull/728).
- Snoozing a job now causes its `attempt` to be _decremented_, whereas previously the `max_attempts` would be incremented. In either case, this avoids allowing a snooze to exhaust a job's retries; however the new behavior also avoids potential issues with wrapping the `max_attempts` value, and makes it simpler to implement a `RetryPolicy` based on either `attempt` or `max_attempts`. The number of snoozes is also tracked in the job's metadata as `snoozes` for debugging purposes.

  The implementation of the builtin `RetryPolicy` implementations is not changed, so this change should not cause any user-facing breakage unless you're relying on `attempt - len(errors)` for some reason. [PR #730](https://github.com/riverqueue/river/pull/730).

- `ByPeriod` uniqueness is now based off a job's `ScheduledAt` instead of the current time if it has a value. [PR #734](https://github.com/riverqueue/river/pull/734).

[skip ci]