### PR TITLE
automatic fixes from golangci-lint

### DIFF
--- a/rivershared/cmd/update-mod-go/main_test.go
+++ b/rivershared/cmd/update-mod-go/main_test.go
@@ -29,7 +29,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 	setup := func(t *testing.T) (string, *testBundle) { //nolint:unparam
 		t.Helper()
 
-		file, err := os.CreateTemp("", "go.mod")
+		file, err := os.CreateTemp(t.TempDir(), "go.mod")
 		require.NoError(t, err)
 		t.Cleanup(func() { os.Remove(file.Name()) })
 

--- a/rivershared/cmd/update-mod-version/main_test.go
+++ b/rivershared/cmd/update-mod-version/main_test.go
@@ -34,7 +34,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 	setup := func(t *testing.T) (string, *testBundle) {
 		t.Helper()
 
-		file, err := os.CreateTemp("", "go.mod")
+		file, err := os.CreateTemp(t.TempDir(), "go.mod")
 		require.NoError(t, err)
 		t.Cleanup(func() { os.Remove(file.Name()) })
 


### PR DESCRIPTION
Automatic fixes from `make lint`. I'm not quite sure why these weren't previously caught by CI upon upgrading the lint version 🤔 