### PR TITLE
Log job retries as warnings instead of errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Errors returned from retryable jobs are now logged with warning logs instead of error logs. Error logs are still used for jobs that error after reaching `max_attempts`. [PR #743](https://github.com/riverqueue/river/pull/743).
+
 ### Fixed
 
 - `riverdatabasesql` driver: properly handle `nil` values in `bytea[]` inputs. This fixes the driver's handling of empty unique keys on insert for non-unique jobs with the newer unique jobs implementation. [PR #739](https://github.com/riverqueue/river/pull/739).

--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -169,5 +169,5 @@ func Example_gracefulShutdown() {
 	// Received SIGINT/SIGTERM; initiating soft stop (try to wait for jobs to finish)
 	// Received SIGINT/SIGTERM again; initiating hard stop (cancel everything)
 	// Job cancelled
-	// jobExecutor: Job errored
+	// jobExecutor: Job errored; retrying
 }

--- a/job_executor.go
+++ b/job_executor.go
@@ -336,7 +336,11 @@ func (e *jobExecutor) reportError(ctx context.Context, res *jobExecutorResult) {
 		cancelJob = true
 		e.Logger.DebugContext(ctx, e.Name+": Job cancelled explicitly", logAttrs...)
 	case res.Err != nil:
-		e.Logger.ErrorContext(ctx, e.Name+": Job errored", logAttrs...)
+		if e.JobRow.Attempt >= e.JobRow.MaxAttempts {
+			e.Logger.ErrorContext(ctx, e.Name+": Job errored", logAttrs...)
+		} else {
+			e.Logger.WarnContext(ctx, e.Name+": Job errored; retrying", logAttrs...)
+		}
 	case res.PanicVal != nil:
 		e.Logger.ErrorContext(ctx, e.Name+": Job panicked", logAttrs...)
 	}


### PR DESCRIPTION
First of all, thank you for building River, it's a wonderful library!

This PR changes the error reporting to log retryable errors at `warn` level, reserving the `error` level for jobs that fail after reaching `MaxAttempts`.

This is desirable for my use case because I consider `error`-level logs as requiring human inspection/intervention, which is only needed for jobs that fail even after retrying. However I realize this may not be a practice everyone shares, so please let me know if you would prefer another approach here.