### PR TITLE
feat(river_type): add `GetMetadata` and `MustGetMetadata` methods to `river_type` types

### DIFF
--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -306,11 +306,7 @@ type JobInsertMiddleware interface {
 	//
 	// Returning an error from this function will fail the overarching insert
 	// operation, even if the inner insertion originally succeeded.
-	InsertMany(
-		ctx context.Context,
-		manyParams []*JobInsertParams,
-		doInner func(context.Context) ([]*JobInsertResult, error),
-	) ([]*JobInsertResult, error)
+	InsertMany(ctx context.Context, manyParams []*JobInsertParams, doInner func(context.Context) ([]*JobInsertResult, error)) ([]*JobInsertResult, error)
 }
 
 type WorkerMiddleware interface {

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -5,6 +5,7 @@ package rivertype
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 )
@@ -136,6 +137,27 @@ type JobRow struct {
 	UniqueStates []JobState
 }
 
+// GetMetadata unmarshals the JSON blob in the Metadata field into a map[string]interface{}.
+// If the JSON is invalid, an error is returned.
+func (j *JobRow) GetMetadata() (map[string]interface{}, error) {
+	unmarshalled := make(map[string]interface{})
+	err := json.Unmarshal(j.Metadata, &unmarshalled)
+
+	return unmarshalled, err
+}
+
+// MustGetMetadata unmarshals the JSON blob in the Metadata field into a map[string]interface{}.
+// If the JSON is invalid, this function panics.
+func (j *JobRow) MustGetMetadata() map[string]interface{} {
+	unmarshalled := make(map[string]interface{})
+	err := json.Unmarshal(j.Metadata, &unmarshalled)
+	if err != nil {
+		panic(err)
+	}
+
+	return unmarshalled
+}
+
 // JobState is the state of a job. Jobs start their lifecycle as either
 // JobStateAvailable or JobStateScheduled, and if all goes well, transition to
 // JobStateCompleted after they're worked.
@@ -250,6 +272,27 @@ type JobInsertParams struct {
 	UniqueStates byte
 }
 
+// GetMetadata unmarshals the JSON blob in the Metadata field into a map[string]interface{}.
+// If the JSON is invalid, an error is returned.
+func (j *JobInsertParams) GetMetadata() (map[string]interface{}, error) {
+	unmarshalled := make(map[string]interface{})
+	err := json.Unmarshal(j.Metadata, &unmarshalled)
+
+	return unmarshalled, err
+}
+
+// MustGetMetadata unmarshals the JSON blob in the Metadata field into a map[string]interface{}.
+// If the JSON is invalid, this function panics.
+func (j *JobInsertParams) MustGetMetadata() map[string]interface{} {
+	unmarshalled := make(map[string]interface{})
+	err := json.Unmarshal(j.Metadata, &unmarshalled)
+	if err != nil {
+		panic(err)
+	}
+
+	return unmarshalled
+}
+
 // JobInsertMiddleware provides an interface for middleware that integrations can
 // use to encapsulate common logic around job insertion.
 //
@@ -263,7 +306,11 @@ type JobInsertMiddleware interface {
 	//
 	// Returning an error from this function will fail the overarching insert
 	// operation, even if the inner insertion originally succeeded.
-	InsertMany(ctx context.Context, manyParams []*JobInsertParams, doInner func(context.Context) ([]*JobInsertResult, error)) ([]*JobInsertResult, error)
+	InsertMany(
+		ctx context.Context,
+		manyParams []*JobInsertParams,
+		doInner func(context.Context) ([]*JobInsertResult, error),
+	) ([]*JobInsertResult, error)
 }
 
 type WorkerMiddleware interface {
@@ -306,6 +353,27 @@ type Queue struct {
 	// If UpdatedAt has not been updated for awhile, the queue record will be
 	// deleted from the table by a maintenance process.
 	UpdatedAt time.Time
+}
+
+// GetMetadata unmarshals the JSON blob in the Metadata field into a map[string]interface{}.
+// If the JSON is invalid, an error is returned.
+func (q *Queue) GetMetadata() (map[string]interface{}, error) {
+	unmarshalled := make(map[string]interface{})
+	err := json.Unmarshal(q.Metadata, &unmarshalled)
+
+	return unmarshalled, err
+}
+
+// MustGetMetadata unmarshals the JSON blob in the Metadata field into a map[string]interface{}.
+// If the JSON is invalid, this function panics.
+func (q *Queue) MustGetMetadata() map[string]interface{} {
+	unmarshalled := make(map[string]interface{})
+	err := json.Unmarshal(q.Metadata, &unmarshalled)
+	if err != nil {
+		panic(err)
+	}
+
+	return unmarshalled
 }
 
 // UniqueOptsByStateDefault is the set of job states that are used to determine

--- a/rivertype/river_type_test.go
+++ b/rivertype/river_type_test.go
@@ -30,11 +30,13 @@ func TestJobStates(t *testing.T) {
 }
 
 func TestMetadataGetters(t *testing.T) {
+	metaValid := "{ \"foo\": \"bar\" }"
+	metaInvalid := "{ \"foo\": \"bar\""
+	want := map[string]interface{}{"foo": "bar"}
+
 	t.Run("JobRowGet", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\" }"
-		want := map[string]interface{}{"foo": "bar"}
 		jobRow := rivertype.JobRow{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaValid),
 		}
 
 		got, err := jobRow.GetMetadata()
@@ -42,28 +44,24 @@ func TestMetadataGetters(t *testing.T) {
 		require.Equal(t, want, got)
 	})
 	t.Run("JobRowGetInvalid", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\""
 		jobRow := rivertype.JobRow{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaInvalid),
 		}
 
 		_, err := jobRow.GetMetadata()
 		require.Error(t, err)
 	})
 	t.Run("JobRowMustGet", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\" }"
-		want := map[string]interface{}{"foo": "bar"}
 		jobRow := rivertype.JobRow{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaValid),
 		}
 
 		got := jobRow.MustGetMetadata()
 		require.Equal(t, want, got)
 	})
 	t.Run("JobRowMustGetInvalid", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\""
 		jobRow := rivertype.JobRow{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaInvalid),
 		}
 
 		require.Panics(t, func() {
@@ -72,10 +70,8 @@ func TestMetadataGetters(t *testing.T) {
 	})
 
 	t.Run("JobInsertParamsGet", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\" }"
-		want := map[string]interface{}{"foo": "bar"}
 		jobInsertParams := rivertype.JobInsertParams{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaValid),
 		}
 
 		got, err := jobInsertParams.GetMetadata()
@@ -83,28 +79,24 @@ func TestMetadataGetters(t *testing.T) {
 		require.Equal(t, want, got)
 	})
 	t.Run("JobInsertParamsGetInvalid", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\""
 		jobInsertParams := rivertype.JobInsertParams{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaInvalid),
 		}
 
 		_, err := jobInsertParams.GetMetadata()
 		require.Error(t, err)
 	})
 	t.Run("JobInsertParamsMustGet", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\" }"
-		want := map[string]interface{}{"foo": "bar"}
 		jobInsertParams := rivertype.JobInsertParams{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaValid),
 		}
 
 		got := jobInsertParams.MustGetMetadata()
 		require.Equal(t, want, got)
 	})
 	t.Run("JobInsertParamsMustGetInvalid", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\""
 		jobInsertParams := rivertype.JobInsertParams{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaInvalid),
 		}
 
 		require.Panics(t, func() {
@@ -113,10 +105,8 @@ func TestMetadataGetters(t *testing.T) {
 	})
 
 	t.Run("QueueGet", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\" }"
-		want := map[string]interface{}{"foo": "bar"}
 		queue := rivertype.Queue{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaValid),
 		}
 
 		got, err := queue.GetMetadata()
@@ -124,28 +114,24 @@ func TestMetadataGetters(t *testing.T) {
 		require.Equal(t, want, got)
 	})
 	t.Run("QueueGetInvalid", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\""
 		queue := rivertype.Queue{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaInvalid),
 		}
 
 		_, err := queue.GetMetadata()
 		require.Error(t, err)
 	})
 	t.Run("QueueMustGet", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\" }"
-		want := map[string]interface{}{"foo": "bar"}
 		queue := rivertype.Queue{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaValid),
 		}
 
 		got := queue.MustGetMetadata()
 		require.Equal(t, want, got)
 	})
 	t.Run("QueueMustGetInvalid", func(t *testing.T) {
-		meta := "{ \"foo\": \"bar\""
 		queue := rivertype.Queue{
-			Metadata: []byte(meta),
+			Metadata: []byte(metaInvalid),
 		}
 
 		require.Panics(t, func() {

--- a/rivertype/river_type_test.go
+++ b/rivertype/river_type_test.go
@@ -29,6 +29,131 @@ func TestJobStates(t *testing.T) {
 	}
 }
 
+func TestMetadataGetters(t *testing.T) {
+	t.Run("JobRowGet", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\" }"
+		want := map[string]interface{}{"foo": "bar"}
+		jobRow := rivertype.JobRow{
+			Metadata: []byte(meta),
+		}
+
+		got, err := jobRow.GetMetadata()
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+	t.Run("JobRowGetInvalid", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\""
+		jobRow := rivertype.JobRow{
+			Metadata: []byte(meta),
+		}
+
+		_, err := jobRow.GetMetadata()
+		require.Error(t, err)
+	})
+	t.Run("JobRowMustGet", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\" }"
+		want := map[string]interface{}{"foo": "bar"}
+		jobRow := rivertype.JobRow{
+			Metadata: []byte(meta),
+		}
+
+		got := jobRow.MustGetMetadata()
+		require.Equal(t, want, got)
+	})
+	t.Run("JobRowMustGetInvalid", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\""
+		jobRow := rivertype.JobRow{
+			Metadata: []byte(meta),
+		}
+
+		require.Panics(t, func() {
+			jobRow.MustGetMetadata()
+		})
+	})
+
+	t.Run("JobInsertParamsGet", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\" }"
+		want := map[string]interface{}{"foo": "bar"}
+		jobInsertParams := rivertype.JobInsertParams{
+			Metadata: []byte(meta),
+		}
+
+		got, err := jobInsertParams.GetMetadata()
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+	t.Run("JobInsertParamsGetInvalid", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\""
+		jobInsertParams := rivertype.JobInsertParams{
+			Metadata: []byte(meta),
+		}
+
+		_, err := jobInsertParams.GetMetadata()
+		require.Error(t, err)
+	})
+	t.Run("JobInsertParamsMustGet", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\" }"
+		want := map[string]interface{}{"foo": "bar"}
+		jobInsertParams := rivertype.JobInsertParams{
+			Metadata: []byte(meta),
+		}
+
+		got := jobInsertParams.MustGetMetadata()
+		require.Equal(t, want, got)
+	})
+	t.Run("JobInsertParamsMustGetInvalid", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\""
+		jobInsertParams := rivertype.JobInsertParams{
+			Metadata: []byte(meta),
+		}
+
+		require.Panics(t, func() {
+			jobInsertParams.MustGetMetadata()
+		})
+	})
+
+	t.Run("QueueGet", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\" }"
+		want := map[string]interface{}{"foo": "bar"}
+		queue := rivertype.Queue{
+			Metadata: []byte(meta),
+		}
+
+		got, err := queue.GetMetadata()
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+	t.Run("QueueGetInvalid", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\""
+		queue := rivertype.Queue{
+			Metadata: []byte(meta),
+		}
+
+		_, err := queue.GetMetadata()
+		require.Error(t, err)
+	})
+	t.Run("QueueMustGet", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\" }"
+		want := map[string]interface{}{"foo": "bar"}
+		queue := rivertype.Queue{
+			Metadata: []byte(meta),
+		}
+
+		got := queue.MustGetMetadata()
+		require.Equal(t, want, got)
+	})
+	t.Run("QueueMustGetInvalid", func(t *testing.T) {
+		meta := "{ \"foo\": \"bar\""
+		queue := rivertype.Queue{
+			Metadata: []byte(meta),
+		}
+
+		require.Panics(t, func() {
+			queue.MustGetMetadata()
+		})
+	})
+}
+
 // stringConstantNameAndValue is a name and value for a string constant like
 // `JobStateAvailable` + `available`.
 type stringConstantNameAndValue struct{ Name, Value string }


### PR DESCRIPTION
Helper methods for interacting with the `Metadata` fields returning a `map[string]interface{}` without introducing breaking changes.

Tangentially related to: https://github.com/riverqueue/river/issues/749