### PR TITLE
test a broader CI matrix to isolate potential v1.24 issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
       # This ensures that we're really running the Go version in the CI matrix
       # rather than one that the Go command has upgraded to automatically.
       GOTOOLCHAIN: local
+      RIVER_DEBUG: true
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,12 +30,7 @@ jobs:
         # Run the 4 latest Postgres versions against the latest Go version:
         go-version:
           - "1.24"
-          - "1.23"
         postgres-version: [14, 15, 16, 17]
-        include:
-          # Also run previous Go version against the latest Postgres version:
-          - go-version: "1.22"
-            postgres-version: 17
       fail-fast: false
     timeout-minutes: 5
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,11 @@ jobs:
         # Run the 4 latest Postgres versions against the latest Go version:
         go-version:
           - "1.24"
+          - "1.23"
         postgres-version: [14, 15, 16, 17]
         include:
           # Also run previous Go version against the latest Postgres version:
-          - go-version: "1.23"
+          - go-version: "1.22"
             postgres-version: 17
       fail-fast: false
     timeout-minutes: 5

--- a/internal/cmd/testdbman/main.go
+++ b/internal/cmd/testdbman/main.go
@@ -139,11 +139,7 @@ func createTestDatabases(ctx context.Context, out io.Writer) error {
 		return nil
 	}
 
-	// This is the same default as pgxpool's maximum number of connections
-	// when not specified -- either 4 or the number of CPUs, whichever is
-	// greater. If changing this number, also change the similar value in
-	// `riverinternaltest` where it's duplicated.
-	dbNames := generateTestDBNames(max(4, runtime.NumCPU()))
+	dbNames := generateTestDBNames(runtime.GOMAXPROCS(0))
 
 	for _, dbName := range dbNames {
 		if err := createDBAndMigrate(dbName); err != nil {

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -160,7 +160,8 @@ func DrainContinuously[T any](drainChan <-chan T) func() []T {
 
 // TestDB acquires a dedicated test database for the duration of the test. If an
 // error occurs, the test fails. The test database will be automatically
-// returned to the pool at the end of the test and the pgxpool will be closed.
+// returned to the pool at the end of the test. If the pool was closed, it will
+// be recreated.
 func TestDB(ctx context.Context, tb testing.TB) *pgxpool.Pool {
 	tb.Helper()
 
@@ -172,9 +173,6 @@ func TestDB(ctx context.Context, tb testing.TB) *pgxpool.Pool {
 		tb.Fatalf("Failed to acquire pool for test DB: %v", err)
 	}
 	tb.Cleanup(testPool.Release)
-
-	// Also close the pool just to ensure nothing is still active on it:
-	tb.Cleanup(testPool.Pool().Close)
 
 	return testPool.Pool()
 }

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -287,6 +287,8 @@ func WrapTestMain(m *testing.M) {
 	// NUM_CPU pools, each with NUM_CPU*4 connections, and that's a lot of
 	// connections.
 	poolConfig.MaxConns = 4
+	// Pre-initialize 1 connection per pool.
+	poolConfig.MinConns = 1
 
 	var err error
 	dbManager, err = testdb.NewManager(poolConfig, int32(runtime.GOMAXPROCS(0)), nil, TruncateRiverTables)

--- a/internal/testdb/db_with_pool.go
+++ b/internal/testdb/db_with_pool.go
@@ -29,28 +29,33 @@ func (db *DBWithPool) Release() {
 
 func (db *DBWithPool) release() {
 	db.logger.Debug("DBWithPool: release called", "dbName", db.dbName)
-	// Close and recreate the connection pool for 2 reasons:
-	// 1. ensure tests don't hold on to connections
-	// 2. If a test happens to close the pool as a matter of course (i.e. as part of a defer)
-	//    then we don't reuse a closed pool.
-	db.res.Value().pool.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	newPgxPool, err := pgxpool.NewWithConfig(ctx, db.res.Value().config)
-	if err != nil {
-		db.res.Destroy()
-		return
+	if err := db.res.Value().pool.Ping(ctx); err != nil {
+		// If the pgx pool is already closed, Ping returns puddle.ErrClosedPool.
+		// When this happens, we need to re-create the pool.
+		if err == puddle.ErrClosedPool {
+			db.logger.Debug("DBWithPool: pool is closed, re-creating", "dbName", db.dbName)
+
+			newPgxPool, err := pgxpool.NewWithConfig(ctx, db.res.Value().config)
+			if err != nil {
+				db.res.Destroy()
+				return
+			}
+			db.res.Value().pool = newPgxPool
+		} else {
+			// Log any other ping error but proceed with cleanup.
+			db.logger.Debug("DBWithPool: pool ping returned error", "dbName", db.dbName, "err", err)
+		}
 	}
-	db.res.Value().pool = newPgxPool
 
 	if db.manager.cleanup != nil {
 		db.logger.Debug("DBWithPool: release calling cleanup", "dbName", db.dbName)
-		if err := db.manager.cleanup(ctx, newPgxPool); err != nil {
+		if err := db.manager.cleanup(ctx, db.res.Value().pool); err != nil {
 			db.logger.Error("testdb.DBWithPool: Error during release cleanup", "err", err)
 			db.res.Destroy()
-			return
 		}
 		db.logger.Debug("DBWithPool: release done with cleanup", "dbName", db.dbName)
 	}

--- a/internal/testdb/db_with_pool.go
+++ b/internal/testdb/db_with_pool.go
@@ -28,6 +28,7 @@ func (db *DBWithPool) Release() {
 }
 
 func (db *DBWithPool) release() {
+	db.logger.Debug("DBWithPool: release called", "dbName", db.dbName)
 	// Close and recreate the connection pool for 2 reasons:
 	// 1. ensure tests don't hold on to connections
 	// 2. If a test happens to close the pool as a matter of course (i.e. as part of a defer)
@@ -45,11 +46,13 @@ func (db *DBWithPool) release() {
 	db.res.Value().pool = newPgxPool
 
 	if db.manager.cleanup != nil {
+		db.logger.Debug("DBWithPool: release calling cleanup", "dbName", db.dbName)
 		if err := db.manager.cleanup(ctx, newPgxPool); err != nil {
 			db.logger.Error("testdb.DBWithPool: Error during release cleanup", "err", err)
 			db.res.Destroy()
 			return
 		}
+		db.logger.Debug("DBWithPool: release done with cleanup", "dbName", db.dbName)
 	}
 
 	// Finally this resource is ready to be reused:


### PR DESCRIPTION
I'm seeing if #761 happens to be triggered by Go v1.24. Testing against 1.24 + 1.23 in the matrix here to see if it reveals any differences.