### PR TITLE
Let test workers call `JobCompleteTx` + test work transaction variants

### DIFF
--- a/periodic_job_test.go
+++ b/periodic_job_test.go
@@ -24,7 +24,7 @@ func TestNeverSchedule(t *testing.T) {
 		require.False(t, next.Before(now))
 		// use an arbitrary duration to check that
 		// the next schedule is far in the future
-		require.True(t, next.Year()-now.Year() > 1000)
+		require.Greater(t, next.Year()-now.Year(), 1000)
 	})
 }
 


### PR DESCRIPTION
Follows up #753 to make it possible to call `JobCompleteTx` inside test
worker implementations. The test worker tries to update an equivalent
job in the database's state to `running` so `JobCompleteTx` will be able
to find it when called (it only considers jobs in `running` state).

We also augment the API so that it's workable for users who want to use
test transactions in their tests (which is hopefully the vast majority
of users) by adding transaction variants `WorkTx` and `WorkJobTx`.