### PR TITLE
rivertest.Worker: Use job executor, always insert jobs, require tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+⚠️ Version 0.18.0 has breaking changes for the `rivertest.Worker` type that was just introduced. While attempting to round out some edge cases with its design, we realized some of them simply couldn't be solved adequately without changing the overall design such that all tested jobs are inserted into the database. Given the short duration since it was released (over a weekend) it's unlikely many users have adopted it and it seemed best to rip off the bandaid to fix it before it gets widely used.
+
+### Changed
+
+- **Breaking change:** The `rivertest.Worker` type now requires all jobs to be inserted into the database. The original design allowed workers to be tested without hitting the database at all. Ultimately this design made it hard to correctly simulate features like `JobCompleteTx` and the other potential solutions seemed undesirable.
+
+  As part of this change, the `Work` and `WorkJob` methods now take a transaction argument. The expectation is that a transaction will be opened by the caller and rolled back after test completion. Additionally, the return signature was changed to return a `WorkResult` struct alongside the error. The struct includes the post-execution job row as well as the event kind that occurred, making it easy to inspect the job's state after execution.
+
+  Finally, the implementation was refactored so that it uses the _real_ `river.Client` insert path, and also uses the same job execution path as real execution. This minimizes the potential for differences in behavior between testing and real execution.
+  [PR #766](https://github.com/riverqueue/river/pull/766).
+
 ## [0.17.0] - 2025-02-16
 
 ### Added

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -204,6 +204,7 @@ func (e *Executor) JobGetStuck(ctx context.Context, params *riverdriver.JobGetSt
 func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.JobInsertFastParams) ([]*riverdriver.JobInsertFastResult, error) {
 	insertJobsParams := &dbsqlc.JobInsertFastManyParams{
 		Args:         make([]string, len(params)),
+		CreatedAt:    make([]time.Time, len(params)),
 		Kind:         make([]string, len(params)),
 		MaxAttempts:  make([]int16, len(params)),
 		Metadata:     make([]string, len(params)),
@@ -220,6 +221,11 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 	for i := 0; i < len(params); i++ {
 		params := params[i]
 
+		createdAt := now
+		if params.CreatedAt != nil {
+			createdAt = *params.CreatedAt
+		}
+
 		scheduledAt := now
 		if params.ScheduledAt != nil {
 			scheduledAt = *params.ScheduledAt
@@ -233,6 +239,7 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 		defaultObject := "{}"
 
 		insertJobsParams.Args[i] = valutil.ValOrDefault(string(params.EncodedArgs), defaultObject)
+		insertJobsParams.CreatedAt[i] = createdAt
 		insertJobsParams.Kind[i] = params.Kind
 		insertJobsParams.MaxAttempts[i] = int16(min(params.MaxAttempts, math.MaxInt16)) //nolint:gosec
 		insertJobsParams.Metadata[i] = valutil.ValOrDefault(string(params.Metadata), defaultObject)
@@ -262,6 +269,7 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params []*riverdriver.JobInsertFastParams) (int, error) {
 	insertJobsParams := &dbsqlc.JobInsertFastManyNoReturningParams{
 		Args:         make([]string, len(params)),
+		CreatedAt:    make([]time.Time, len(params)),
 		Kind:         make([]string, len(params)),
 		MaxAttempts:  make([]int16, len(params)),
 		Metadata:     make([]string, len(params)),
@@ -278,6 +286,11 @@ func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params []*r
 	for i := 0; i < len(params); i++ {
 		params := params[i]
 
+		createdAt := now
+		if params.CreatedAt != nil {
+			createdAt = *params.CreatedAt
+		}
+
 		scheduledAt := now
 		if params.ScheduledAt != nil {
 			scheduledAt = *params.ScheduledAt
@@ -291,6 +304,7 @@ func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params []*r
 		defaultObject := "{}"
 
 		insertJobsParams.Args[i] = valutil.ValOrDefault(string(params.EncodedArgs), defaultObject)
+		insertJobsParams.CreatedAt[i] = createdAt
 		insertJobsParams.Kind[i] = params.Kind
 		insertJobsParams.MaxAttempts[i] = int16(min(params.MaxAttempts, math.MaxInt16)) //nolint:gosec
 		insertJobsParams.Metadata[i] = valutil.ValOrDefault(string(params.Metadata), defaultObject)

--- a/riverdriver/riverpgxv5/internal/dbsqlc/copyfrom.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/copyfrom.go
@@ -30,7 +30,7 @@ func (r *iteratorForJobInsertFastManyCopyFrom) Next() bool {
 func (r iteratorForJobInsertFastManyCopyFrom) Values() ([]interface{}, error) {
 	return []interface{}{
 		r.rows[0].Args,
-		r.rows[0].FinalizedAt,
+		r.rows[0].CreatedAt,
 		r.rows[0].Kind,
 		r.rows[0].MaxAttempts,
 		r.rows[0].Metadata,
@@ -49,5 +49,5 @@ func (r iteratorForJobInsertFastManyCopyFrom) Err() error {
 }
 
 func (q *Queries) JobInsertFastManyCopyFrom(ctx context.Context, db DBTX, arg []*JobInsertFastManyCopyFromParams) (int64, error) {
-	return db.CopyFrom(ctx, []string{"river_job"}, []string{"args", "finalized_at", "kind", "max_attempts", "metadata", "priority", "queue", "scheduled_at", "state", "tags", "unique_key", "unique_states"}, &iteratorForJobInsertFastManyCopyFrom{rows: arg})
+	return db.CopyFrom(ctx, []string{"river_job"}, []string{"args", "created_at", "kind", "max_attempts", "metadata", "priority", "queue", "scheduled_at", "state", "tags", "unique_key", "unique_states"}, &iteratorForJobInsertFastManyCopyFrom{rows: arg})
 }

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -197,6 +197,7 @@ LIMIT @max;
 -- name: JobInsertFastMany :many
 INSERT INTO river_job(
     args,
+    created_at,
     kind,
     max_attempts,
     metadata,
@@ -209,6 +210,7 @@ INSERT INTO river_job(
     unique_states
 ) SELECT
     unnest(@args::jsonb[]),
+    unnest(@created_at::timestamptz[]),
     unnest(@kind::text[]),
     unnest(@max_attempts::smallint[]),
     unnest(@metadata::jsonb[]),
@@ -237,6 +239,7 @@ RETURNING sqlc.embed(river_job), (xmax != 0) AS unique_skipped_as_duplicate;
 -- name: JobInsertFastManyNoReturning :execrows
 INSERT INTO river_job(
     args,
+    created_at,
     kind,
     max_attempts,
     metadata,
@@ -249,6 +252,7 @@ INSERT INTO river_job(
     unique_states
 ) SELECT
     unnest(@args::jsonb[]),
+    unnest(@created_at::timestamptz[]),
     unnest(@kind::text[]),
     unnest(@max_attempts::smallint[]),
     unnest(@metadata::jsonb[]),

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -515,6 +515,7 @@ func (q *Queries) JobGetStuck(ctx context.Context, db DBTX, arg *JobGetStuckPara
 const jobInsertFastMany = `-- name: JobInsertFastMany :many
 INSERT INTO river_job(
     args,
+    created_at,
     kind,
     max_attempts,
     metadata,
@@ -527,22 +528,23 @@ INSERT INTO river_job(
     unique_states
 ) SELECT
     unnest($1::jsonb[]),
-    unnest($2::text[]),
-    unnest($3::smallint[]),
-    unnest($4::jsonb[]),
-    unnest($5::smallint[]),
-    unnest($6::text[]),
-    unnest($7::timestamptz[]),
+    unnest($2::timestamptz[]),
+    unnest($3::text[]),
+    unnest($4::smallint[]),
+    unnest($5::jsonb[]),
+    unnest($6::smallint[]),
+    unnest($7::text[]),
+    unnest($8::timestamptz[]),
     -- To avoid requiring pgx users to register the OID of the river_job_state[]
     -- type, we cast the array to text[] and then to river_job_state.
-    unnest($8::text[])::river_job_state,
+    unnest($9::text[])::river_job_state,
     -- Unnest on a multi-dimensional array will fully flatten the array, so we
     -- encode the tag list as a comma-separated string and split it in the
     -- query.
-    string_to_array(unnest($9::text[]), ','),
+    string_to_array(unnest($10::text[]), ','),
 
-    unnest($10::bytea[]),
-    unnest($11::bit(8)[])
+    unnest($11::bytea[]),
+    unnest($12::bit(8)[])
 
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
@@ -555,6 +557,7 @@ RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_a
 
 type JobInsertFastManyParams struct {
 	Args         [][]byte
+	CreatedAt    []time.Time
 	Kind         []string
 	MaxAttempts  []int16
 	Metadata     [][]byte
@@ -575,6 +578,7 @@ type JobInsertFastManyRow struct {
 func (q *Queries) JobInsertFastMany(ctx context.Context, db DBTX, arg *JobInsertFastManyParams) ([]*JobInsertFastManyRow, error) {
 	rows, err := db.Query(ctx, jobInsertFastMany,
 		arg.Args,
+		arg.CreatedAt,
 		arg.Kind,
 		arg.MaxAttempts,
 		arg.Metadata,
@@ -627,6 +631,7 @@ func (q *Queries) JobInsertFastMany(ctx context.Context, db DBTX, arg *JobInsert
 const jobInsertFastManyNoReturning = `-- name: JobInsertFastManyNoReturning :execrows
 INSERT INTO river_job(
     args,
+    created_at,
     kind,
     max_attempts,
     metadata,
@@ -639,22 +644,23 @@ INSERT INTO river_job(
     unique_states
 ) SELECT
     unnest($1::jsonb[]),
-    unnest($2::text[]),
-    unnest($3::smallint[]),
-    unnest($4::jsonb[]),
-    unnest($5::smallint[]),
-    unnest($6::text[]),
-    unnest($7::timestamptz[]),
-    unnest($8::river_job_state[]),
+    unnest($2::timestamptz[]),
+    unnest($3::text[]),
+    unnest($4::smallint[]),
+    unnest($5::jsonb[]),
+    unnest($6::smallint[]),
+    unnest($7::text[]),
+    unnest($8::timestamptz[]),
+    unnest($9::river_job_state[]),
 
     -- lib/pq really, REALLY does not play nicely with multi-dimensional arrays,
     -- so instead we pack each set of tags into a string, send them through,
     -- then unpack them here into an array to put in each row. This isn't
     -- necessary in the Pgx driver where copyfrom is used instead.
-    string_to_array(unnest($9::text[]), ','),
+    string_to_array(unnest($10::text[]), ','),
 
-    unnest($10::bytea[]),
-    unnest($11::bit(8)[])
+    unnest($11::bytea[]),
+    unnest($12::bit(8)[])
 
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
@@ -665,6 +671,7 @@ DO NOTHING
 
 type JobInsertFastManyNoReturningParams struct {
 	Args         [][]byte
+	CreatedAt    []time.Time
 	Kind         []string
 	MaxAttempts  []int16
 	Metadata     [][]byte
@@ -680,6 +687,7 @@ type JobInsertFastManyNoReturningParams struct {
 func (q *Queries) JobInsertFastManyNoReturning(ctx context.Context, db DBTX, arg *JobInsertFastManyNoReturningParams) (int64, error) {
 	result, err := db.Exec(ctx, jobInsertFastManyNoReturning,
 		arg.Args,
+		arg.CreatedAt,
 		arg.Kind,
 		arg.MaxAttempts,
 		arg.Metadata,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql
@@ -1,7 +1,7 @@
 -- name: JobInsertFastManyCopyFrom :copyfrom
 INSERT INTO river_job(
     args,
-    finalized_at,
+    created_at,
     kind,
     max_attempts,
     metadata,
@@ -14,7 +14,7 @@ INSERT INTO river_job(
     unique_states
 ) VALUES (
     @args,
-    @finalized_at,
+    @created_at,
     @kind,
     @max_attempts,
     @metadata,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql.go
@@ -13,7 +13,7 @@ import (
 
 type JobInsertFastManyCopyFromParams struct {
 	Args         []byte
-	FinalizedAt  *time.Time
+	CreatedAt    time.Time
 	Kind         string
 	MaxAttempts  int16
 	Metadata     []byte

--- a/rivertest/worker_test.go
+++ b/rivertest/worker_test.go
@@ -6,15 +6,12 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/internal/execution"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
-	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
 	"github.com/riverqueue/river/rivertype"
@@ -29,11 +26,34 @@ func (testArgs) Kind() string { return "rivertest_work_test" }
 func TestWorker_Work(t *testing.T) {
 	t.Parallel()
 
-	config := &river.Config{}
-	driver := riverpgxv5.New(nil)
+	ctx := context.Background()
+
+	type testBundle struct {
+		config *river.Config
+		driver *riverpgxv5.Driver
+		tx     pgx.Tx
+	}
+
+	setup := func(t *testing.T) *testBundle {
+		t.Helper()
+
+		var (
+			config = &river.Config{}
+			driver = riverpgxv5.New(nil)
+			tx     = riverinternaltest.TestTx(ctx, t)
+		)
+
+		return &testBundle{
+			config: config,
+			driver: driver,
+			tx:     tx,
+		}
+	}
 
 	t.Run("WorkASimpleJob", func(t *testing.T) {
 		t.Parallel()
+
+		bundle := setup(t)
 
 		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
 			require.Equal(t, testArgs{Value: "test"}, job.Args)
@@ -61,48 +81,37 @@ func TestWorker_Work(t *testing.T) {
 
 			return nil
 		})
-		tw := NewWorker(t, driver, config, worker)
-		require.NoError(t, tw.Work(context.Background(), t, testArgs{Value: "test"}, nil))
+		tw := NewWorker(t, bundle.driver, bundle.config, worker)
+		require.NoError(t, tw.Work(context.Background(), t, bundle.tx, testArgs{Value: "test"}, nil))
 	})
 
 	t.Run("Reusable", func(t *testing.T) {
 		t.Parallel()
 
+		bundle := setup(t)
+
 		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
 			return nil
 		})
-		tw := NewWorker(t, driver, config, worker)
-		require.NoError(t, tw.Work(context.Background(), t, testArgs{Value: "test"}, nil))
-		require.NoError(t, tw.Work(context.Background(), t, testArgs{Value: "test2"}, nil))
+		tw := NewWorker(t, bundle.driver, bundle.config, worker)
+		require.NoError(t, tw.Work(context.Background(), t, bundle.tx, testArgs{Value: "test"}, nil))
+		require.NoError(t, tw.Work(context.Background(), t, bundle.tx, testArgs{Value: "test2"}, nil))
 	})
 
 	t.Run("SetsCustomInsertOpts", func(t *testing.T) {
 		t.Parallel()
 
-		uniqueOpts := river.UniqueOpts{ByQueue: true}
-		hourFromNow := time.Now().Add(1 * time.Hour)
-		internalUniqueOpts := (*dbunique.UniqueOpts)(&uniqueOpts)
-		uniqueKey, err := dbunique.UniqueKey(&baseservice.UnStubbableTimeGenerator{}, internalUniqueOpts, &rivertype.JobInsertParams{
-			Args:        testArgs{Value: "test3"},
-			CreatedAt:   &hourFromNow,
-			EncodedArgs: []byte(`{"value": "test3"}`),
-			Kind:        "rivertest_work_test",
-			MaxAttempts: 420,
-			Metadata:    []byte(`{"key": "value"}`),
-			Priority:    3,
-			Queue:       "custom_queue",
-			State:       rivertype.JobStateAvailable,
-			Tags:        []string{"tag1", "tag2"},
-		})
-		require.NoError(t, err)
+		bundle := setup(t)
+
+		hourFromNow := time.Now().UTC().Add(1 * time.Hour)
 
 		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
 			require.Equal(t, testArgs{Value: "test3"}, job.Args)
 			require.Equal(t, 1, job.JobRow.Attempt)
 			require.NotNil(t, job.JobRow.AttemptedAt)
-			require.WithinDuration(t, hourFromNow, *job.JobRow.AttemptedAt, 2*time.Second)
+			require.WithinDuration(t, time.Now().UTC(), *job.JobRow.AttemptedAt, 2*time.Second)
 			require.Equal(t, []string{"worker1"}, job.JobRow.AttemptedBy)
-			require.WithinDuration(t, hourFromNow, job.JobRow.CreatedAt, 2*time.Second)
+			require.WithinDuration(t, time.Now().UTC(), job.JobRow.CreatedAt, 2*time.Second)
 			require.JSONEq(t, `{"value": "test3"}`, string(job.JobRow.EncodedArgs))
 			require.Empty(t, job.JobRow.Errors)
 			require.Nil(t, job.JobRow.FinalizedAt)
@@ -115,14 +124,13 @@ func TestWorker_Work(t *testing.T) {
 			require.WithinDuration(t, hourFromNow, job.JobRow.ScheduledAt, 2*time.Second)
 			require.Equal(t, rivertype.JobStateRunning, job.JobRow.State)
 			require.Equal(t, []string{"tag1", "tag2"}, job.JobRow.Tags)
-			require.Equal(t, uniqueKey, job.JobRow.UniqueKey)
 
 			return nil
 		})
-		tw := NewWorker(t, driver, config, worker)
+		tw := NewWorker(t, bundle.driver, bundle.config, worker)
 
 		// You can also pass in custom insert options:
-		require.NoError(t, tw.Work(context.Background(), t, testArgs{Value: "test3"}, &river.InsertOpts{
+		require.NoError(t, tw.Work(context.Background(), t, bundle.tx, testArgs{Value: "test3"}, &river.InsertOpts{
 			MaxAttempts: 420,
 			Metadata:    []byte(`{"key": "value"}`),
 			Pending:     true, // ignored but added to ensure non-default behavior
@@ -130,38 +138,29 @@ func TestWorker_Work(t *testing.T) {
 			Queue:       "custom_queue",
 			ScheduledAt: hourFromNow,
 			Tags:        []string{"tag1", "tag2"},
-			UniqueOpts:  uniqueOpts,
 		}))
 	})
 
-	t.Run("UniqueOptsByPeriodRespectsCustomStubbedTime", func(t *testing.T) {
+	t.Run("UniqueOptsAreIgnored", func(t *testing.T) {
 		t.Parallel()
+		// UniqueOpts must be ignored because otherwise there's a likelihood of
+		// conflicts with parallel tests inserting jobs with the same unique key.
+
+		bundle := setup(t)
 
 		stubTime := &riversharedtest.TimeStub{}
 		now := time.Now().UTC()
 		stubTime.StubNowUTC(now)
-		config := &river.Config{
-			Test: river.TestConfig{Time: stubTime},
-		}
-
-		uniqueOpts := river.UniqueOpts{ByPeriod: 1 * time.Hour}
-		internalUniqueOpts := (*dbunique.UniqueOpts)(&uniqueOpts)
-		uniqueKey, err := dbunique.UniqueKey(stubTime, internalUniqueOpts, &rivertype.JobInsertParams{
-			Args:        testArgs{Value: "test3"},
-			CreatedAt:   &now,
-			EncodedArgs: []byte(`{"value": "test3"}`),
-			Kind:        "rivertest_work_test",
-		})
-		require.NoError(t, err)
+		bundle.config.Test.Time = stubTime
 
 		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
-			require.Equal(t, uniqueKey, job.JobRow.UniqueKey)
-
+			require.Empty(t, job.JobRow.UniqueKey)
+			require.Empty(t, job.JobRow.UniqueStates)
 			return nil
 		})
-		tw := NewWorker(t, driver, config, worker)
-		require.NoError(t, tw.Work(context.Background(), t, testArgs{Value: "test"}, &river.InsertOpts{
-			UniqueOpts: uniqueOpts,
+		tw := NewWorker(t, bundle.driver, bundle.config, worker)
+		require.NoError(t, tw.Work(context.Background(), t, bundle.tx, testArgs{Value: "test"}, &river.InsertOpts{
+			UniqueOpts: river.UniqueOpts{ByPeriod: 1 * time.Hour},
 		}))
 	})
 }
@@ -224,8 +223,8 @@ func TestWorker_WorkJob(t *testing.T) {
 
 	type testBundle struct {
 		client   *river.Client[pgx.Tx]
-		dbPool   *pgxpool.Pool
 		driver   *riverpgxv5.Driver
+		tx       pgx.Tx
 		workFunc func(ctx context.Context, job *river.Job[testArgs]) error
 	}
 
@@ -234,8 +233,7 @@ func TestWorker_WorkJob(t *testing.T) {
 
 		var (
 			config = &river.Config{}
-			dbPool = riverinternaltest.TestDB(ctx, t)
-			driver = riverpgxv5.New(dbPool)
+			driver = riverpgxv5.New(nil)
 		)
 
 		client, err := river.NewClient(driver, config)
@@ -244,7 +242,7 @@ func TestWorker_WorkJob(t *testing.T) {
 		bundle := &testBundle{
 			client:   client,
 			driver:   driver,
-			dbPool:   dbPool,
+			tx:       riverinternaltest.TestTx(ctx, t),
 			workFunc: func(ctx context.Context, job *river.Job[testArgs]) error { return nil },
 		}
 
@@ -267,7 +265,7 @@ func TestWorker_WorkJob(t *testing.T) {
 		}
 
 		now := time.Now()
-		require.NoError(t, testWorker.WorkJob(ctx, t, makeJobFromFactoryBuild(t, testArgs{}, &testfactory.JobOpts{
+		require.NoError(t, testWorker.WorkJob(ctx, t, bundle.tx, makeJobFromFactoryBuild(t, testArgs{}, &testfactory.JobOpts{
 			AttemptedAt: &now,
 			AttemptedBy: []string{"worker123"},
 			CreatedAt:   &now,
@@ -282,29 +280,23 @@ func TestWorker_WorkJob(t *testing.T) {
 		testWorker, bundle := setup(t)
 
 		args := testArgs{}
-		insertRes, err := bundle.client.Insert(ctx, args, nil)
+		insertRes, err := bundle.client.InsertTx(ctx, bundle.tx, args, nil)
 		require.NoError(t, err)
 
 		bundle.workFunc = func(ctx context.Context, job *river.Job[testArgs]) error {
-			tx, err := bundle.dbPool.Begin(ctx)
-			require.NoError(t, err)
-
-			updatedJob, err := bundle.driver.GetExecutor().JobGetByID(ctx, insertRes.Job.ID)
+			updatedJob, err := bundle.driver.UnwrapExecutor(bundle.tx).JobGetByID(ctx, insertRes.Job.ID)
 			require.NoError(t, err)
 			require.Equal(t, rivertype.JobStateRunning, updatedJob.State)
 
-			_, err = river.JobCompleteTx[*riverpgxv5.Driver](ctx, tx, job)
-			require.NoError(t, err)
-
-			err = tx.Commit(ctx)
+			_, err = river.JobCompleteTx[*riverpgxv5.Driver](ctx, bundle.tx, job)
 			require.NoError(t, err)
 
 			return nil
 		}
 
-		require.NoError(t, testWorker.WorkJob(ctx, t, &river.Job[testArgs]{Args: args, JobRow: insertRes.Job}))
+		require.NoError(t, testWorker.WorkJob(ctx, t, bundle.tx, &river.Job[testArgs]{Args: args, JobRow: insertRes.Job}))
 
-		updatedJob, err := bundle.driver.GetExecutor().JobGetByID(ctx, insertRes.Job.ID)
+		updatedJob, err := bundle.driver.UnwrapExecutor(bundle.tx).JobGetByID(ctx, insertRes.Job.ID)
 		require.NoError(t, err)
 		require.Equal(t, rivertype.JobStateCompleted, updatedJob.State)
 	})


### PR DESCRIPTION
This updates the `rivertest.Worker` type (#753) to leverage the extracted job executor logic from #768 and to avoid some of the downsides with the first pass of that design (partly outlined in #765), particularly the fact that certain database-dependent operations like `JobCompleteTx` couldn't be accurately simulated without hitting the database.

As part of these changes, test jobs are always inserted into the database and the test worker methods always require a transaction to be used for additional operations on that job (such as completions). The return types were also altered so that an extensible result struct is returned in addition to any legitimate worker errors that occur. The struct contains the kind of event that occurred from execution (completion, snoozing, cancellation, etc) so that it's easy to assert against the result, even if a special not-really-an-error like snooze was returned.

To make the tests line up for this, I had to make corrections to the job insert queries to allow them to properly set the created time in a similar fashion to how they were already setting the scheduled time. This allows stub clocks to be used in tests and ensures they're properly respected throughout the execution process.