### PR TITLE
Test DB pool fixes

### DIFF
--- a/internal/cmd/testdbman/main.go
+++ b/internal/cmd/testdbman/main.go
@@ -139,11 +139,7 @@ func createTestDatabases(ctx context.Context, out io.Writer) error {
 		return nil
 	}
 
-	// This is the same default as pgxpool's maximum number of connections
-	// when not specified -- either 4 or the number of CPUs, whichever is
-	// greater. If changing this number, also change the similar value in
-	// `riverinternaltest` where it's duplicated.
-	dbNames := generateTestDBNames(max(4, runtime.NumCPU()))
+	dbNames := generateTestDBNames(runtime.GOMAXPROCS(0))
 
 	for _, dbName := range dbNames {
 		if err := createDBAndMigrate(dbName); err != nil {

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -287,6 +287,8 @@ func WrapTestMain(m *testing.M) {
 	// NUM_CPU pools, each with NUM_CPU connections, and that's a lot of
 	// connections if there are many CPUs.
 	poolConfig.MaxConns = 4
+	// Pre-initialize 1 connection per pool.
+	poolConfig.MinConns = 1
 
 	var err error
 	dbManager, err = testdb.NewManager(poolConfig, int32(runtime.GOMAXPROCS(0)), nil, TruncateRiverTables) //nolint:gosec

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -160,7 +160,8 @@ func DrainContinuously[T any](drainChan <-chan T) func() []T {
 
 // TestDB acquires a dedicated test database for the duration of the test. If an
 // error occurs, the test fails. The test database will be automatically
-// returned to the pool at the end of the test and the pgxpool will be closed.
+// returned to the pool at the end of the test. If the pool was closed, it will
+// be recreated.
 func TestDB(ctx context.Context, tb testing.TB) *pgxpool.Pool {
 	tb.Helper()
 
@@ -172,9 +173,6 @@ func TestDB(ctx context.Context, tb testing.TB) *pgxpool.Pool {
 		tb.Fatalf("Failed to acquire pool for test DB: %v", err)
 	}
 	tb.Cleanup(testPool.Release)
-
-	// Also close the pool just to ensure nothing is still active on it:
-	tb.Cleanup(testPool.Pool().Close)
 
 	return testPool.Pool()
 }

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -282,8 +282,14 @@ func TruncateRiverTables(ctx context.Context, pool *pgxpool.Pool) error {
 // amongst all packages. e.g. Configures a manager for test databases on setup,
 // and checks for no goroutine leaks on teardown.
 func WrapTestMain(m *testing.M) {
+	poolConfig := DatabaseConfig("river_test")
+	// Use a smaller number of conns per pool, because otherwise we could have
+	// NUM_CPU pools, each with NUM_CPU connections, and that's a lot of
+	// connections if there are many CPUs.
+	poolConfig.MaxConns = 4
+
 	var err error
-	dbManager, err = testdb.NewManager(DatabaseConfig("river_test"), dbPoolMaxConns, nil, TruncateRiverTables)
+	dbManager, err = testdb.NewManager(poolConfig, int32(runtime.GOMAXPROCS(0)), nil, TruncateRiverTables) //nolint:gosec
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/testdb/db_with_pool.go
+++ b/internal/testdb/db_with_pool.go
@@ -28,6 +28,7 @@ func (db *DBWithPool) Release() {
 }
 
 func (db *DBWithPool) release() {
+	db.logger.Debug("DBWithPool: release called", "dbName", db.dbName)
 	// Close and recreate the connection pool for 2 reasons:
 	// 1. ensure tests don't hold on to connections
 	// 2. If a test happens to close the pool as a matter of course (i.e. as part of a defer)
@@ -45,11 +46,13 @@ func (db *DBWithPool) release() {
 	db.res.Value().pool = newPgxPool
 
 	if db.manager.cleanup != nil {
+		db.logger.Debug("DBWithPool: release calling cleanup", "dbName", db.dbName)
 		if err := db.manager.cleanup(ctx, newPgxPool); err != nil {
 			db.logger.Error("testdb.DBWithPool: Error during release cleanup", "err", err)
 			db.res.Destroy()
 			return
 		}
+		db.logger.Debug("DBWithPool: release done with cleanup", "dbName", db.dbName)
 	}
 
 	// Finally this resource is ready to be reused:


### PR DESCRIPTION
Tested the heck out of this on #763 until I figured out a few issues:

1. We were allowing `NUM_CPU` conns to be created in _each_ of the pools for the `testdb.Manager`, meaning it was actually `NUM_CPU * NUM_CPU` connections. That's on top of the `NUM_CPU` connections being allocated for the global `TestTx` pool. I reduced this to a fixed limit of 4.
2. We didn't have a minimum set on the pools. There's no reason for any of these pooled test DBs to drop below 1, so I set that as the minimum.
3. We were always closing pools after every use, which is wasteful and inefficient. After digging, we only had a single test where we were intentionally closing the pool (one for the notifier). Rather than always closing the pool after each test, do a ping operation to make sure it's not closed. If it is closed, then it can be recreated.

The combination of these seems to have caused the flakiness issues that got worse with 1.24. Ultimately we were putting a ton of churn on Postgres conns and creating a lot of them at once. With these changes, not only do the tests pass consistently but the time for the `river` package on Actions seems to drop from ~40 seconds to ~31 seconds.