### PR TITLE
Fix error message on unsuccessful client subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Finally, the implementation was refactored so that it uses the _real_ `river.Client` insert path, and also uses the same job execution path as real execution. This minimizes the potential for differences in behavior between testing and real execution.
   [PR #766](https://github.com/riverqueue/river/pull/766).
 
+### Fixed
+
+- Fix error message on unsuccessful client subscribe that erroneously referred to "Workers" not configured. [PR #771](https://github.com/riverqueue/river/pull/771).
+
 ## [0.17.0] - 2025-02-16
 
 ### Added

--- a/client.go
+++ b/client.go
@@ -966,7 +966,7 @@ type SubscribeConfig struct {
 // Special internal variant that lets us inject an overridden size.
 func (c *Client[TTx]) SubscribeConfig(config *SubscribeConfig) (<-chan *Event, func()) {
 	if c.subscriptionManager == nil {
-		panic("created a subscription on a client that will never work jobs (Workers not configured)")
+		panic("created a subscription on a client that will never work jobs (Queues not configured)")
 	}
 
 	return c.subscriptionManager.SubscribeConfig(config)

--- a/client_test.go
+++ b/client_test.go
@@ -4293,7 +4293,7 @@ func Test_Client_Subscribe(t *testing.T) {
 
 		client := newTestClient(t, dbPool, &Config{})
 
-		require.PanicsWithValue(t, "created a subscription on a client that will never work jobs (Workers not configured)", func() {
+		require.PanicsWithValue(t, "created a subscription on a client that will never work jobs (Queues not configured)", func() {
 			_, _ = client.Subscribe(EventKindJobCompleted)
 		})
 	})


### PR DESCRIPTION
Fix a bad error message that I just happened to notice while working on
something else. The message says that the subscribe failed because
`Workers` are not configured, but it's actually contingent on `Queues`
not being configured.

You get the error if `subscriptionManager` is nil:

    if c.subscriptionManager == nil {
        panic("created a subscription on a client that will never work jobs (Workers not configured)")
    }

`subscriptionManager is non-nil if `config.willExecuteJobs`:

    if config.willExecuteJobs() {
        if !driver.HasPool() {
                return nil, errMissingDatabasePoolWithQueues
        }

        client.completer = jobcompleter.NewBatchCompleter(archetype, driver.GetExecutor(), client.pilot, nil)
        client.subscriptionManager = newSubscriptionManager(archetype, nil)

And `config.willExecuteJobs` is true if `Queues` is non-empty:

    func (c *Config) willExecuteJobs() bool {
            return len(c.Queues) > 0
    }