### PR TITLE
rivertest.Worker fixes: handle nil config, rename Kind/EventKind, log panic trace

### DIFF
--- a/client.go
+++ b/client.go
@@ -279,6 +279,10 @@ type Config struct {
 
 // WithDefaults returns a copy of the Config with all default values applied.
 func (c *Config) WithDefaults() *Config {
+	if c == nil {
+		c = &Config{}
+	}
+
 	// Use the existing logger if set, otherwise create a default one.
 	logger := c.Logger
 	if logger == nil {

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -212,11 +212,11 @@ func (w *Worker[T, TTx]) workJob(ctx context.Context, tb testing.TB, tx TTx, job
 
 // WorkResult is the result of working a job in the test Worker.
 type WorkResult struct {
+	// EventKind is the kind of event that occurred following execution.
+	EventKind river.EventKind
+
 	// Job is the updated job row from the database _after_ it has been worked.
 	Job *rivertype.JobRow
-
-	// Kind is the kind of event that occurred following execution.
-	Kind river.EventKind
 }
 
 func completerResultToWorkResult(tb testing.TB, completerResult jobcompleter.CompleterJobUpdated) WorkResult {
@@ -240,8 +240,8 @@ func completerResultToWorkResult(tb testing.TB, completerResult jobcompleter.Com
 	}
 
 	return WorkResult{
-		Job:  completerResult.Job,
-		Kind: kind,
+		EventKind: kind,
+		Job:       completerResult.Job,
 	}
 }
 

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -181,7 +181,7 @@ func (w *Worker[T, TTx]) workJob(ctx context.Context, tb testing.TB, tx TTx, job
 				return nil
 			},
 			HandlePanicFunc: func(ctx context.Context, job *rivertype.JobRow, panicVal any, trace string) *jobexecutor.ErrorHandlerResult {
-				tb.Fatalf("panic: %v", panicVal)
+				tb.Fatalf("panic: %v\n%s", panicVal, trace)
 				return nil
 			},
 		},

--- a/rivertest/worker_test.go
+++ b/rivertest/worker_test.go
@@ -117,7 +117,7 @@ func TestWorker_Work(t *testing.T) {
 		tw := NewWorker(t, bundle.driver, bundle.config, worker)
 		res, err := tw.Work(ctx, t, bundle.tx, testArgs{Value: "test"}, nil)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 	})
 
 	t.Run("Reusable", func(t *testing.T) {
@@ -131,10 +131,10 @@ func TestWorker_Work(t *testing.T) {
 		tw := NewWorker(t, bundle.driver, bundle.config, worker)
 		res, err := tw.Work(ctx, t, bundle.tx, testArgs{Value: "test"}, nil)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 		res, err = tw.Work(ctx, t, bundle.tx, testArgs{Value: "test2"}, nil)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 	})
 
 	t.Run("SetsCustomInsertOpts", func(t *testing.T) {
@@ -179,7 +179,7 @@ func TestWorker_Work(t *testing.T) {
 			Tags:        []string{"tag1", "tag2"},
 		})
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 	})
 
 	t.Run("UniqueOptsAreIgnored", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestWorker_Work(t *testing.T) {
 			UniqueOpts: river.UniqueOpts{ByPeriod: 1 * time.Hour},
 		})
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 	})
 
 	t.Run("ReturnsASnoozeEventKindWhenSnoozed", func(t *testing.T) {
@@ -220,7 +220,7 @@ func TestWorker_Work(t *testing.T) {
 
 		res, err := tw.Work(ctx, t, bundle.tx, testArgs{Value: "test"}, nil)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobSnoozed, res.Kind)
+		require.Equal(t, river.EventKindJobSnoozed, res.EventKind)
 	})
 
 	t.Run("ReturnsACancelEventKindWhenCancelled", func(t *testing.T) {
@@ -235,7 +235,7 @@ func TestWorker_Work(t *testing.T) {
 
 		res, err := tw.Work(ctx, t, bundle.tx, testArgs{Value: "test"}, nil)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCancelled, res.Kind)
+		require.Equal(t, river.EventKindJobCancelled, res.EventKind)
 	})
 
 	t.Run("UsesACustomClockWhenProvided", func(t *testing.T) {
@@ -257,7 +257,7 @@ func TestWorker_Work(t *testing.T) {
 
 		res, err := tw.Work(ctx, t, bundle.tx, testArgs{Value: "test"}, nil)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 		require.WithinDuration(t, hourFromNow, *res.Job.FinalizedAt, time.Millisecond)
 	})
 }
@@ -318,7 +318,7 @@ func TestWorker_WorkJob(t *testing.T) {
 
 		res, err := testWorker.WorkJob(ctx, t, bundle.tx, insertRes.Job)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 	})
 
 	t.Run("JobCompleteTxWithInsertedJobRow", func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestWorker_WorkJob(t *testing.T) {
 
 		res, err := testWorker.WorkJob(ctx, t, bundle.tx, insertRes.Job)
 		require.NoError(t, err)
-		require.Equal(t, river.EventKindJobCompleted, res.Kind)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 
 		updatedJob, err := bundle.driver.UnwrapExecutor(bundle.tx).JobGetByID(ctx, insertRes.Job.ID)
 		require.NoError(t, err)


### PR DESCRIPTION
I wrote some tests for the demo app using the test worker (#766) and found a few issues:

1. It panics with a `nil` `*river.Config`. I fixed this by making `Config.WithDefaults` handle a nil pointer so no change was necessary in the `rivertest.NewWorker` caller.
2. The `Kind` field in `rivertest.WorkResult` felt unnatural as I was writing assertions for it like `require.Equal(t, river.EventKindJobCompleted, result.Kind)`. I renamed this to `EventKind` which I still don't love but it feels at least a little more appropriate to me.
3. When I accidentally made my worker panic during the course of developing tests, I realized the current output (just the panic value) was not very helpful for debugging. I adjusted this to also log the full trace, which is also how I realized #774 was necessary.

Side note on (3) above: I realized I couldn't actually use `rivertest.Worker` to write a test for a worker that _intentionally_ panics, because its panic handler calls `tb.Fatal`. This is probably not a very likely issue for real users, and it's probably a good _default_ behavior, but I won't be surprised if we feel compelled to add an option to the test worker type so that it avoid calling fatal and instead surface an error or call `tb.Error`. Wanted to run it by you in case you had other thoughts on this. For example, we could just switch it to `tb.Error` because `Fatal` is quite presumptive?
 