### PR TITLE
allow GOMAXPROCS + 2 test DBs to fix CI flakiness

### DIFF
--- a/internal/cmd/testdbman/main.go
+++ b/internal/cmd/testdbman/main.go
@@ -139,8 +139,9 @@ func createTestDatabases(ctx context.Context, out io.Writer) error {
 		return nil
 	}
 
-	dbNames := generateTestDBNames(runtime.GOMAXPROCS(0))
-
+	// Allow up to one database per concurrent test, plus two for overhead:
+	maxTestDBs := runtime.GOMAXPROCS(0) + 2
+	dbNames := generateTestDBNames(maxTestDBs)
 	for _, dbName := range dbNames {
 		if err := createDBAndMigrate(dbName); err != nil {
 			return err

--- a/internal/riverinternaltest/riverinternaltest.go
+++ b/internal/riverinternaltest/riverinternaltest.go
@@ -289,7 +289,9 @@ func WrapTestMain(m *testing.M) {
 	poolConfig.MinConns = 1
 
 	var err error
-	dbManager, err = testdb.NewManager(poolConfig, int32(runtime.GOMAXPROCS(0)), nil, TruncateRiverTables) //nolint:gosec
+	// Allow up to one database per concurrent test, plus two for overhead:
+	maxTestDBs := int32(runtime.GOMAXPROCS(0)) + 2 //nolint:gosec
+	dbManager, err = testdb.NewManager(poolConfig, maxTestDBs, nil, TruncateRiverTables)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
I'm not entirely sure _why_ this is necessary on GitHub Actions when it's not at all needed locally. What we continue to see in CI is that sometimes tests time out on trying to acquire a test DB from the pool of test DBs, which is currently capped at GOMAXPROCS count. This _shouldn't_ happen, because that's the same as the number of parallel tests that should be able to run at once, and so we shouldn't have more than that number of DBs in demand from concurrent tests.

My hunch is that something is stalling the `TRUNCATE` cleanup actions and causing one or more tests to be blocked on a DB that's been released but not yet returned to the pool because it's undergoing cleanup. Simply increasing the number of DBs to provide a little padding appears to completely eliminate the staging CI flakiness, _and_ it further speeds up the `river` package's tests to 20-24 seconds, rather than the 31 seconds we've been seeing since #769 was merged, or the ~40 seconds we were seeing prior to that.

10+ full runs so far and no failures.