### PR TITLE
improve driver test coverage for InsertFastMany, fix databasesql unique key issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix error message on unsuccessful client subscribe that erroneously referred to "Workers" not configured. [PR #771](https://github.com/riverqueue/river/pull/771).
+- Fix an issue with encoding unique keys in riverdatabasesql driver. [PR #777](https://github.com/riverqueue/river/pull/777).
 
 ## [0.17.0] - 2025-02-16
 

--- a/riverdriver/riverdatabasesql/internal/pgtypealias/null_bytea.go
+++ b/riverdriver/riverdatabasesql/internal/pgtypealias/null_bytea.go
@@ -2,6 +2,7 @@ package pgtypealias
 
 import (
 	"database/sql/driver"
+	"encoding/hex"
 	"fmt"
 )
 
@@ -21,7 +22,13 @@ func (nb NullBytea) Value() (driver.Value, error) {
 	if len(nb) == 0 {
 		return nil, nil //nolint:nilnil
 	}
-	return []byte(nb), nil
+
+	// Encode the byte slice as a hex format string with \x prefix:
+	result := make([]byte, 2+hex.EncodedLen(len(nb)))
+	result[0] = '\\'
+	result[1] = 'x'
+	hex.Encode(result[2:], nb)
+	return result, nil
 }
 
 // Scan implements the sql.Scanner interface.

--- a/riverdriver/riverdatabasesql/internal/pgtypealias/null_bytea.go
+++ b/riverdriver/riverdatabasesql/internal/pgtypealias/null_bytea.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// NullBytea is a custom type for PostgreSQL bytea that returns SQL NULL when
+// NullBytea is a custom type for Postgres bytea that returns SQL NULL when
 // the underlying slice is nil or empty. This override takes over for the base
 // type `bytea`, so that when sqlc generates code for arrays of bytea, each
 // element is a NullBytea and properly handles nil values. This is in contrast


### PR DESCRIPTION
When the unique key was a binary non-UTF8 []byte, it was generating an encoding error in the `database/sql` driver. The fix is to encode it, similar to what pq does. I couldn't find a way to do this via pq or pgx without reimplementing this code block, but would love a way to do that if possible.

Also improve test coverage to make sure we are explicitly testing both intentionally set unique key + unique states, as well as intentionally omitted.

Fixes #779.