### PR TITLE
testdb.Manager: try to recreate pool after cleanup error

### DIFF
--- a/internal/testdb/manager.go
+++ b/internal/testdb/manager.go
@@ -104,6 +104,7 @@ func (m *Manager) allocatePool(ctx context.Context) (*poolWithDBName, error) {
 	if m.cleanup != nil {
 		m.logger.Debug("DBManager: allocatePool calling cleanup", "dbName", dbName)
 		if err := m.cleanup(ctx, pgxp); err != nil {
+			m.logger.Error("DBManager: error during allocatePool cleanup", "error", err)
 			pgxp.Close()
 			return nil, fmt.Errorf("error during cleanup: %w", err)
 		}


### PR DESCRIPTION
In recent changes from #769 / fb6b3e9, I inadvertently tweaked the logic of the testdb.Manager to throw away / destroy a resource if it encountered cleanup errors. Destroying the resource has the side effect of causing the manager to try to reallocate a new database with a new number, potentially higher than the number of test databases we've created (see [this test run](https://github.com/riverqueue/river/actions/runs/13418983055/job/37486797646) where that surfaced).

Instead, try to just make a new pool on the same database, and only destroy the resource if that fails.