### PR TITLE
Job executor: Unmarshal job args late, after middlewares have run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+⚠️ Version 0.19.0 has minor breaking changes for the `Worker.Middleware`, introduced fairly recently in 0.17.0. We tried not to make this change, but found the existing middleware interface insufficient to provide the necessary range of functionality we wanted, and this is a secondary middleware facility that won't be in use for many users, so it seemed worthwhile.
+
+### Changed
+
 - The `river.RecordOutput` function now returns an error if the output is too large. The output is limited to 32MB in size. [PR #782](https://github.com/riverqueue/river/pull/782).
+- **Breaking change:** The `Worker` interface's `Middleware` function now takes a `JobRow` parameter instead of a generic `Job[T]`. This was necessary to expand the potential of what middleware can do: by letting the executor extract a middleware stack from a worker before a job is fully unmarshaled, the middleware can also participate in the unmarshaling process. [PR #783](https://github.com/riverqueue/river/pull/783).
 
 ## [0.18.0] - 2025-02-20
 

--- a/common_test.go
+++ b/common_test.go
@@ -32,7 +32,7 @@ func waitForNJobs(subscribeChan <-chan *river.Event, numJobs int) {
 			}
 
 		case <-time.After(time.Until(deadline)):
-			panic(fmt.Sprintf("WaitOrTimeout timed out after waiting %s (received %d job(s), wanted %d)",
+			panic(fmt.Sprintf("waitForNJobs timed out after waiting %s (received %d job(s), wanted %d)",
 				timeout, len(events), numJobs))
 		}
 	}

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -300,7 +300,7 @@ func (w *wrapperWorkUnit[T]) Timeout() time.Duration         { return w.worker.T
 func (w *wrapperWorkUnit[T]) Work(ctx context.Context) error { return w.worker.Work(ctx, w.job) }
 
 func (w *wrapperWorkUnit[T]) Middleware() []rivertype.WorkerMiddleware {
-	return w.worker.Middleware(w.job)
+	return w.worker.Middleware(w.jobRow)
 }
 
 func (w *wrapperWorkUnit[T]) UnmarshalJob() error {

--- a/work_unit_wrapper.go
+++ b/work_unit_wrapper.go
@@ -30,7 +30,7 @@ func (w *wrapperWorkUnit[T]) Timeout() time.Duration         { return w.worker.T
 func (w *wrapperWorkUnit[T]) Work(ctx context.Context) error { return w.worker.Work(ctx, w.job) }
 
 func (w *wrapperWorkUnit[T]) Middleware() []rivertype.WorkerMiddleware {
-	return w.worker.Middleware(w.job)
+	return w.worker.Middleware(w.jobRow)
 }
 
 func (w *wrapperWorkUnit[T]) UnmarshalJob() error {

--- a/worker.go
+++ b/worker.go
@@ -38,7 +38,7 @@ import (
 // with the client using the AddWorker function.
 type Worker[T JobArgs] interface {
 	// Middleware returns the type-specific middleware for this job.
-	Middleware(job *Job[T]) []rivertype.WorkerMiddleware
+	Middleware(job *rivertype.JobRow) []rivertype.WorkerMiddleware
 
 	// NextRetry calculates when the next retry for a failed job should take
 	// place given when it was last attempted and its number of attempts, or any
@@ -74,7 +74,7 @@ type Worker[T JobArgs] interface {
 // struct to make it fulfill the Worker interface with default values.
 type WorkerDefaults[T JobArgs] struct{}
 
-func (w WorkerDefaults[T]) Middleware(*Job[T]) []rivertype.WorkerMiddleware { return nil }
+func (w WorkerDefaults[T]) Middleware(*rivertype.JobRow) []rivertype.WorkerMiddleware { return nil }
 
 // NextRetry returns an empty time.Time{} to avoid setting any job or
 // Worker-specific overrides on the next retry time. This means that the


### PR DESCRIPTION
Here, modify the job executor so that instead of exclusively invoking a
work unit's `UnmarshalJSON` implementation before starting to execute
the stack of work middleware, invoke it much later from within the
executor's `doInner` implementation. This gives middlewares the
opportunity to modify args before unmarshaling, thereby enabling use
cases like args encryption.

This does have the downside of having to modify the worker interface's
`Middleware` function from taking a generic job:

    type Worker[T JobArgs] interface {
        Middleware(job *Job[T]) []rivertype.WorkerMiddleware

To taking a `JobRow` instead:

    type Worker[T JobArgs] interface {
        Middleware(job *rivertype.JobRow) []rivertype.WorkerMiddleware

Because the full generic `Job[T]` is not yet available by the time we
need to extract a middleware stack.
