### PR TITLE
Minor middleware improvements: Reduce allocations + docs

### DIFF
--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -34,9 +34,12 @@ func MiddlewareChain(global, worker []rivertype.WorkerMiddleware, doInner Func, 
 		return doInner
 	}
 
-	allMiddleware := make([]rivertype.WorkerMiddleware, 0, len(global)+len(worker))
-	allMiddleware = append(allMiddleware, global...)
-	allMiddleware = append(allMiddleware, worker...)
+	// Write this so as to avoid a new slice allocation in cases where there is
+	// no worker specific middleware (which will be the common case).
+	allMiddleware := global
+	if len(worker) > 0 {
+		allMiddleware = append(allMiddleware, worker...)
+	}
 
 	// Wrap middlewares in reverse order so the one defined first is wrapped
 	// as the outermost function and is first to receive the operation.

--- a/middleware_defaults.go
+++ b/middleware_defaults.go
@@ -8,14 +8,18 @@ import (
 
 // JobInsertMiddlewareDefaults is an embeddable struct that provides default
 // implementations for the rivertype.JobInsertMiddleware. Use of this struct is
-// recommended in case rivertype.JobInsertMiddleware is expanded in the future so that
-// existing code isn't unexpectedly broken during an upgrade.
+// recommended in case rivertype.JobInsertMiddleware is expanded in the future
+// so that existing code isn't unexpectedly broken during an upgrade.
 type JobInsertMiddlewareDefaults struct{}
 
 func (d *JobInsertMiddlewareDefaults) InsertMany(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error) {
 	return doInner(ctx)
 }
 
+// WorkerInsertMiddlewareDefaults is an embeddable struct that provides default
+// implementations for the rivertype.WorkerMiddleware. Use of this struct is
+// recommended in case rivertype.WorkerMiddleware is expanded in the future so
+// that existing code isn't unexpectedly broken during an upgrade.
 type WorkerMiddlewareDefaults struct{}
 
 func (d *WorkerMiddlewareDefaults) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {


### PR DESCRIPTION
Just a couple small middleware improvements:

* Retool `MiddlewareChain` so that in case of no worker-specific
  middleware (which should be the overwhelmingly common case), don't
  bother with a new slice allocation. Just use the global middleware
  slice that we already have.

* Add missing docs for `WorkerInsertMiddlewareDefaults`.