### PR TITLE
Add "hooks" interface in addition to middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ⚠️ Version 0.19.0 has minor breaking changes for the `Worker.Middleware`, introduced fairly recently in 0.17.0. We tried not to make this change, but found the existing middleware interface insufficient to provide the necessary range of functionality we wanted, and this is a secondary middleware facility that won't be in use for many users, so it seemed worthwhile.
 
+### Added
+
+- Added a new "hooks" API for tying into River functionality at various points like job inserts or working. Differs from middleware in that it doesn't go on the stack and can't modify context, but in some cases is able to run at a more granular level (e.g. for each job insert rather than each _batch_ of inserts). [PR #789](https://github.com/riverqueue/river/pull/789).
+
 ### Changed
 
 - The `river.RecordOutput` function now returns an error if the output is too large. The output is limited to 32MB in size. [PR #782](https://github.com/riverqueue/river/pull/782).

--- a/hook_defaults_funcs.go
+++ b/hook_defaults_funcs.go
@@ -1,0 +1,34 @@
+package river
+
+import (
+	"context"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+// HookDefaults should be embedded on any hook implementation. It helps
+// guarantee forward compatibility in case additions are necessary to the Hook
+// interface.
+type HookDefaults struct{}
+
+func (d *HookDefaults) IsHook() bool { return true }
+
+// HookInsertBeginFunc is a convenience helper for implementing HookInsertBegin
+// using a simple function instead of a struct.
+type HookInsertBeginFunc func(ctx context.Context, params *rivertype.JobInsertParams) error
+
+func (f HookInsertBeginFunc) InsertBegin(ctx context.Context, params *rivertype.JobInsertParams) error {
+	return f(ctx, params)
+}
+
+func (f HookInsertBeginFunc) IsHook() bool { return true }
+
+// HookWorkBeginFunc is a convenience helper for implementing HookworkBegin
+// using a simple function instead of a struct.
+type HookWorkBeginFunc func(ctx context.Context, job *rivertype.JobRow) error
+
+func (f HookWorkBeginFunc) WorkBegin(ctx context.Context, job *rivertype.JobRow) error {
+	return f(ctx, job)
+}
+
+func (f HookWorkBeginFunc) IsHook() bool { return true }

--- a/hook_defaults_funcs_test.go
+++ b/hook_defaults_funcs_test.go
@@ -1,0 +1,16 @@
+package river
+
+import (
+	"context"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+// Verify interface compliance.
+var (
+	_ rivertype.Hook            = HookInsertBeginFunc(func(ctx context.Context, params *rivertype.JobInsertParams) error { return nil })
+	_ rivertype.HookInsertBegin = HookInsertBeginFunc(func(ctx context.Context, params *rivertype.JobInsertParams) error { return nil })
+
+	_ rivertype.Hook          = HookWorkBeginFunc(func(ctx context.Context, job *rivertype.JobRow) error { return nil })
+	_ rivertype.HookWorkBegin = HookWorkBeginFunc(func(ctx context.Context, job *rivertype.JobRow) error { return nil })
+)

--- a/internal/hooklookup/hook_lookup.go
+++ b/internal/hooklookup/hook_lookup.go
@@ -1,0 +1,152 @@
+package hooklookup
+
+import (
+	"sync"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+//
+// HookKind
+//
+
+type HookKind string
+
+const (
+	HookKindInsertBegin HookKind = "insert_begin"
+	HookKindWorkBegin   HookKind = "work_begin"
+)
+
+//
+// HookLookupInterface
+//
+
+// HookLookupInterface is an interface to look up hooks by hook kind. It's
+// commonly implemented by HookLookup, but may also be EmptyHookLookup as a
+// memory allocation optimization for bundles where no hooks are present.
+type HookLookupInterface interface {
+	ByHookKind(kind HookKind) []rivertype.Hook
+}
+
+// NewHookLookup returns a new hook lookup interface based on the given hooks
+// that satisfies HookLookupInterface. This is often hookLookup, but may be
+// emptyHookLookup as an optimization for the common case of an empty hook
+// bundle.
+func NewHookLookup(hooks []rivertype.Hook) HookLookupInterface {
+	if len(hooks) < 1 {
+		return &emptyHookLookup{}
+	}
+
+	return &hookLookup{
+		hooks:       hooks,
+		hooksByKind: make(map[HookKind][]rivertype.Hook),
+		mu:          &sync.RWMutex{},
+	}
+}
+
+//
+// hookLookup
+//
+
+// hookLookup looks up and caches hooks based on a HookKind, saving work when
+// looking up hooks for specific operations, a common operation that gets
+// repeated over and over again. This struct may be used as a lookup for
+// globally installed hooks or hooks for specific job kinds through the use of
+// JobHookLookup.
+type hookLookup struct {
+	hooks       []rivertype.Hook
+	hooksByKind map[HookKind][]rivertype.Hook
+	mu          *sync.RWMutex
+}
+
+func (c *hookLookup) ByHookKind(kind HookKind) []rivertype.Hook {
+	c.mu.RLock()
+	cache, ok := c.hooksByKind[kind]
+	c.mu.RUnlock()
+	if ok {
+		return cache
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Even if this ends up being empty, make sure there's an entry for the next
+	// time the cache gets invoked for this kind.
+	c.hooksByKind[kind] = nil
+
+	// Rely on exhaustlint to find any missing hook kinds here.
+	switch kind {
+	case HookKindInsertBegin:
+		for _, hook := range c.hooks {
+			if typedHook, ok := hook.(rivertype.HookInsertBegin); ok {
+				c.hooksByKind[kind] = append(c.hooksByKind[kind], typedHook)
+			}
+		}
+	case HookKindWorkBegin:
+		for _, hook := range c.hooks {
+			if typedHook, ok := hook.(rivertype.HookWorkBegin); ok {
+				c.hooksByKind[kind] = append(c.hooksByKind[kind], typedHook)
+			}
+		}
+	}
+
+	return c.hooksByKind[kind]
+}
+
+//
+// emptyHookLookup
+//
+
+// emptyHookLookup is an empty version of HookLookup that's zero allocation. For
+// most applications, most job args won't have hooks, so this prevents us from
+// allocating dozens/hundreds of small HookLookup objects that go unused.
+type emptyHookLookup struct{}
+
+func (c *emptyHookLookup) ByHookKind(kind HookKind) []rivertype.Hook { return nil }
+
+//
+// JobHookLookup
+//
+
+type JobHookLookup struct {
+	hookLookupByKind map[string]HookLookupInterface
+	mu               sync.RWMutex
+}
+
+func NewJobHookLookup() *JobHookLookup {
+	return &JobHookLookup{
+		hookLookupByKind: make(map[string]HookLookupInterface),
+	}
+}
+
+// ByJobArgs returns a HookLookupInterface by job args, which is a HookLookup if
+// the job args had specific hooks (i.e. implements JobArgsWithHooks and returns
+// a non-empty set of hooks), or an EmptyHashLookup otherwise.
+func (c *JobHookLookup) ByJobArgs(args rivertype.JobArgs) HookLookupInterface {
+	kind := args.Kind()
+
+	c.mu.RLock()
+	lookup, ok := c.hookLookupByKind[kind]
+	c.mu.RUnlock()
+	if ok {
+		return lookup
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var hooks []rivertype.Hook
+	if argsWithHooks, ok := args.(jobArgsWithHooks); ok {
+		hooks = argsWithHooks.Hooks()
+	}
+
+	lookup = NewHookLookup(hooks)
+	c.hookLookupByKind[kind] = lookup
+	return lookup
+}
+
+// Same as river.JobArgsWithHooks, but duplicated here so that can still live in
+// the top level package.
+type jobArgsWithHooks interface {
+	Hooks() []rivertype.Hook
+}

--- a/internal/hooklookup/hook_lookup_test.go
+++ b/internal/hooklookup/hook_lookup_test.go
@@ -1,0 +1,244 @@
+package hooklookup
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+func TestHookLookup(t *testing.T) {
+	t.Parallel()
+
+	type testBundle struct{}
+
+	setup := func(t *testing.T) (*hookLookup, *testBundle) { //nolint:unparam
+		t.Helper()
+
+		return NewHookLookup([]rivertype.Hook{ //nolint:forcetypeassert
+			&testHookInsertAndWorkBegin{},
+			&testHookInsertBegin{},
+			&testHookWorkBegin{},
+		}).(*hookLookup), &testBundle{}
+	}
+
+	t.Run("LooksUpHooks", func(t *testing.T) {
+		t.Parallel()
+
+		hookLookup, _ := setup(t)
+
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookInsertBegin{},
+		}, hookLookup.ByHookKind(HookKindInsertBegin))
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookWorkBegin{},
+		}, hookLookup.ByHookKind(HookKindWorkBegin))
+
+		require.Len(t, hookLookup.hooksByKind, 2)
+
+		// Repeat lookups to make sure we get the same result.
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookInsertBegin{},
+		}, hookLookup.ByHookKind(HookKindInsertBegin))
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookWorkBegin{},
+		}, hookLookup.ByHookKind(HookKindWorkBegin))
+	})
+
+	t.Run("Stress", func(t *testing.T) {
+		t.Parallel()
+
+		hookLookup, _ := setup(t)
+
+		var wg sync.WaitGroup
+
+		parallelLookupLoop := func(kind HookKind) {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for range 50 {
+					hookLookup.ByHookKind(kind)
+				}
+			}()
+		}
+
+		parallelLookupLoop(HookKindInsertBegin)
+		parallelLookupLoop(HookKindWorkBegin)
+		parallelLookupLoop(HookKindInsertBegin)
+		parallelLookupLoop(HookKindWorkBegin)
+
+		wg.Wait()
+	})
+}
+
+func TestEmptyHookLookup(t *testing.T) {
+	t.Parallel()
+
+	type testBundle struct{}
+
+	setup := func(t *testing.T) (*emptyHookLookup, *testBundle) {
+		t.Helper()
+
+		return NewHookLookup(nil).(*emptyHookLookup), &testBundle{} //nolint:forcetypeassert
+	}
+
+	t.Run("AlwaysReturnsNil", func(t *testing.T) {
+		t.Parallel()
+
+		hookLookup, _ := setup(t)
+
+		require.Nil(t, hookLookup.ByHookKind(HookKindInsertBegin))
+		require.Nil(t, hookLookup.ByHookKind(HookKindWorkBegin))
+	})
+}
+
+func TestJobHookLookup(t *testing.T) {
+	t.Parallel()
+
+	type testBundle struct{}
+
+	setup := func(t *testing.T) (*JobHookLookup, *testBundle) { //nolint:unparam
+		t.Helper()
+
+		return NewJobHookLookup(), &testBundle{}
+	}
+
+	t.Run("LooksUpHooks", func(t *testing.T) {
+		t.Parallel()
+
+		jobHookLookup, _ := setup(t)
+
+		require.Nil(t, jobHookLookup.ByJobArgs(&jobArgsNoHooks{}).ByHookKind(HookKindInsertBegin))
+		require.Nil(t, jobHookLookup.ByJobArgs(&jobArgsNoHooks{}).ByHookKind(HookKindWorkBegin))
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookInsertBegin{},
+		}, jobHookLookup.ByJobArgs(&jobArgsWithCustomHooks{}).ByHookKind(HookKindInsertBegin))
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookWorkBegin{},
+		}, jobHookLookup.ByJobArgs(&jobArgsWithCustomHooks{}).ByHookKind(HookKindWorkBegin))
+
+		require.Len(t, jobHookLookup.hookLookupByKind, 2)
+
+		// Repeat lookups to make sure we get the same result.
+		require.Nil(t, jobHookLookup.ByJobArgs(&jobArgsNoHooks{}).ByHookKind(HookKindInsertBegin))
+		require.Nil(t, jobHookLookup.ByJobArgs(&jobArgsNoHooks{}).ByHookKind(HookKindWorkBegin))
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookInsertBegin{},
+		}, jobHookLookup.ByJobArgs(&jobArgsWithCustomHooks{}).ByHookKind(HookKindInsertBegin))
+		require.Equal(t, []rivertype.Hook{
+			&testHookInsertAndWorkBegin{},
+			&testHookWorkBegin{},
+		}, jobHookLookup.ByJobArgs(&jobArgsWithCustomHooks{}).ByHookKind(HookKindWorkBegin))
+	})
+
+	t.Run("Stress", func(t *testing.T) {
+		t.Parallel()
+
+		jobHookLookup, _ := setup(t)
+
+		var wg sync.WaitGroup
+
+		parallelLookupLoop := func(args rivertype.JobArgs) {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				for range 50 {
+					jobHookLookup.ByJobArgs(args)
+				}
+			}()
+		}
+
+		parallelLookupLoop(&jobArgsNoHooks{})
+		parallelLookupLoop(&jobArgsWithCustomHooks{})
+		parallelLookupLoop(&jobArgsNoHooks{})
+		parallelLookupLoop(&jobArgsWithCustomHooks{})
+
+		wg.Wait()
+	})
+}
+
+//
+// jobArgsNoHooks
+//
+
+var _ rivertype.JobArgs = &jobArgsNoHooks{}
+
+type jobArgsNoHooks struct{}
+
+func (jobArgsNoHooks) Kind() string { return "no_hooks" }
+
+//
+// jobArgsWithHooks
+//
+
+var (
+	_ rivertype.JobArgs = &jobArgsWithCustomHooks{}
+	_ jobArgsWithHooks  = &jobArgsWithCustomHooks{}
+)
+
+type jobArgsWithCustomHooks struct{}
+
+func (jobArgsWithCustomHooks) Hooks() []rivertype.Hook {
+	return []rivertype.Hook{
+		&testHookInsertAndWorkBegin{},
+		&testHookInsertBegin{},
+		&testHookWorkBegin{},
+	}
+}
+
+func (jobArgsWithCustomHooks) Kind() string { return "with_custom_hooks" }
+
+//
+// testHookInsertAndWorkBegin
+//
+
+var (
+	_ rivertype.HookInsertBegin = &testHookInsertAndWorkBegin{}
+	_ rivertype.HookWorkBegin   = &testHookInsertAndWorkBegin{}
+)
+
+type testHookInsertAndWorkBegin struct{ rivertype.Hook }
+
+func (t *testHookInsertAndWorkBegin) InsertBegin(ctx context.Context, params *rivertype.JobInsertParams) error {
+	return nil
+}
+
+func (t *testHookInsertAndWorkBegin) WorkBegin(ctx context.Context, job *rivertype.JobRow) error {
+	return nil
+}
+
+//
+// testHookInsertBegin
+//
+
+var _ rivertype.HookInsertBegin = &testHookInsertBegin{}
+
+type testHookInsertBegin struct{ rivertype.Hook }
+
+func (t *testHookInsertBegin) InsertBegin(ctx context.Context, params *rivertype.JobInsertParams) error {
+	return nil
+}
+
+//
+// testHookWorkBegin
+//
+
+var _ rivertype.HookWorkBegin = &testHookWorkBegin{}
+
+type testHookWorkBegin struct{ rivertype.Hook }
+
+func (t *testHookWorkBegin) WorkBegin(ctx context.Context, job *rivertype.JobRow) error {
+	return nil
+}

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/riverqueue/river/internal/hooklookup"
 	"github.com/riverqueue/river/internal/riverinternaltest"
 	"github.com/riverqueue/river/internal/workunit"
 	"github.com/riverqueue/river/riverdriver"
@@ -38,6 +39,9 @@ type callbackWorkUnit struct {
 	timeout  time.Duration // defaults to 0, which signals default timeout
 }
 
+func (w *callbackWorkUnit) HookLookup(cache *hooklookup.JobHookLookup) hooklookup.HookLookupInterface {
+	return nil
+}
 func (w *callbackWorkUnit) Middleware() []rivertype.WorkerMiddleware { return nil }
 func (w *callbackWorkUnit) NextRetry() time.Time                     { return time.Now().Add(30 * time.Second) }
 func (w *callbackWorkUnit) Timeout() time.Duration                   { return w.timeout }

--- a/internal/workunit/work_unit.go
+++ b/internal/workunit/work_unit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/riverqueue/river/internal/hooklookup"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -15,6 +16,11 @@ import (
 //
 // Implemented by river.wrapperWorkUnit.
 type WorkUnit interface {
+	// HookLookup procures the a hook lookup bundle for the wrapped job using
+	// the given job hook lookup bundle. Hooks are looked up by job args and
+	// otherwise not available to jobexecutor.
+	HookLookup(lookup *hooklookup.JobHookLookup) hooklookup.HookLookupInterface
+
 	Middleware() []rivertype.WorkerMiddleware
 	NextRetry() time.Time
 	Timeout() time.Duration

--- a/job.go
+++ b/job.go
@@ -24,6 +24,19 @@ type JobArgs interface {
 	Kind() string
 }
 
+type JobArgsWithHooks interface {
+	// Hooks returns specific hooks to run for this job type. These will run
+	// after the global hooks configured on the client.
+	//
+	// Warning: Hooks returned should be based on the job type only and be
+	// invariant of the specific contents of a job. Hooks are extracted by
+	// instantiating a generic instance of the job even when a specific instance
+	// is available, so any conditional logic within will be ignored. This is
+	// done because although specific job information may be available in some
+	// hook contexts like on InsertBegin, it won't be in others like WorkBegin.
+	Hooks() []rivertype.Hook
+}
+
 // JobArgsWithInsertOpts is an extra interface that a job may implement on top
 // of JobArgs to provide insertion-time options for all jobs of this type.
 type JobArgsWithInsertOpts interface {

--- a/producer_test.go
+++ b/producer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/riverqueue/river/internal/hooklookup"
 	"github.com/riverqueue/river/internal/jobcompleter"
 	"github.com/riverqueue/river/internal/maintenance"
 	"github.com/riverqueue/river/internal/notifier"
@@ -90,6 +91,8 @@ func Test_Producer_CanSafelyCompleteJobsWhileFetchingNewOnes(t *testing.T) {
 		// Fetch constantly to more aggressively trigger the potential data race:
 		FetchCooldown:       time.Millisecond,
 		FetchPollInterval:   time.Millisecond,
+		HookLookupByJob:     hooklookup.NewJobHookLookup(),
+		HookLookupGlobal:    hooklookup.NewHookLookup(nil),
 		JobTimeout:          JobTimeoutDefault,
 		MaxWorkers:          1000,
 		Notifier:            notifier,
@@ -176,6 +179,8 @@ func TestProducer_PollOnly(t *testing.T) {
 			ErrorHandler:        newTestErrorHandler(),
 			FetchCooldown:       FetchCooldownDefault,
 			FetchPollInterval:   50 * time.Millisecond, // more aggressive than normal because we have no notifier
+			HookLookupByJob:     hooklookup.NewJobHookLookup(),
+			HookLookupGlobal:    hooklookup.NewHookLookup(nil),
 			JobTimeout:          JobTimeoutDefault,
 			MaxWorkers:          1_000,
 			Notifier:            nil, // no notifier
@@ -222,6 +227,8 @@ func TestProducer_WithNotifier(t *testing.T) {
 			ErrorHandler:        newTestErrorHandler(),
 			FetchCooldown:       FetchCooldownDefault,
 			FetchPollInterval:   50 * time.Millisecond, // more aggressive than normal so in case we miss the event, tests still pass quickly
+			HookLookupByJob:     hooklookup.NewJobHookLookup(),
+			HookLookupGlobal:    hooklookup.NewHookLookup(nil),
 			JobTimeout:          JobTimeoutDefault,
 			MaxWorkers:          1_000,
 			Notifier:            notifier,

--- a/work_unit_wrapper.go
+++ b/work_unit_wrapper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/riverqueue/river/internal/hooklookup"
 	"github.com/riverqueue/river/internal/workunit"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -25,13 +26,17 @@ type wrapperWorkUnit[T JobArgs] struct {
 	worker Worker[T]
 }
 
-func (w *wrapperWorkUnit[T]) NextRetry() time.Time           { return w.worker.NextRetry(w.job) }
-func (w *wrapperWorkUnit[T]) Timeout() time.Duration         { return w.worker.Timeout(w.job) }
-func (w *wrapperWorkUnit[T]) Work(ctx context.Context) error { return w.worker.Work(ctx, w.job) }
+func (w *wrapperWorkUnit[T]) HookLookup(lookup *hooklookup.JobHookLookup) hooklookup.HookLookupInterface {
+	var job T
+	return lookup.ByJobArgs(job)
+}
 
 func (w *wrapperWorkUnit[T]) Middleware() []rivertype.WorkerMiddleware {
 	return w.worker.Middleware(w.jobRow)
 }
+func (w *wrapperWorkUnit[T]) NextRetry() time.Time           { return w.worker.NextRetry(w.job) }
+func (w *wrapperWorkUnit[T]) Timeout() time.Duration         { return w.worker.Timeout(w.job) }
+func (w *wrapperWorkUnit[T]) Work(ctx context.Context) error { return w.worker.Work(ctx, w.job) }
 
 func (w *wrapperWorkUnit[T]) UnmarshalJob() error {
 	w.job = &Job[T]{

--- a/worker.go
+++ b/worker.go
@@ -74,6 +74,8 @@ type Worker[T JobArgs] interface {
 // struct to make it fulfill the Worker interface with default values.
 type WorkerDefaults[T JobArgs] struct{}
 
+func (w WorkerDefaults[T]) Hooks(*rivertype.JobRow) []rivertype.Hook { return nil }
+
 func (w WorkerDefaults[T]) Middleware(*rivertype.JobRow) []rivertype.WorkerMiddleware { return nil }
 
 // NextRetry returns an empty time.Time{} to avoid setting any job or


### PR DESCRIPTION
Here, try an experiment that adds "hooks", a middleware-like concept, but one
which differs in subtle ways, and if done right will unlock functionality that
middleware doesn't make possible, like job-specific actions like encryption.

While experimenting anyway, we also try a variation on middleware configuration
that tries to improve the experience of using hooks to address #788.

The middleware interface is very generic, containing just one sentinel function
so that it's distinct from `interface{}` (and which would make any type
accidentally settable to it):

    type Hook interface {
        // IsAnyHook is a sentinel function to check that a type is implementing
        // Hook on purpose and not by accident (Hook would otherwise be an empty
        // interface). Hooks should embed river.HookDefaults to pick up an
        // implementation for this function automatically.
        IsAnyHook() bool
    }

But from there, we get into specific hook interfaces that run at various phases
in a job's lifecycle. These ones should look familiar from middleware:

    // HookInsertBegin is an interface to a hook that runs before job insertion.
    type HookInsertBegin interface {
        Hook

        InsertBegin(ctx context.Context, params *JobInsertParams) error
    }

    // HookWorkBegin is an interface to a hook that runs after a job has been locked
    // for work and before it's worked.
    type HookWorkBegin interface {
        Hook

        WorkBegin(ctx context.Context, job *JobRow) error
    }

The primary advantage of hooks is that they don't get layered onto the stack,
and especially when inserting rows, don't all need to share a single set of
hooks, letting each job in question run different hooks if desired.

By extension, this also means that unlike middleware, hooks cannot set anything
to context. This is the main practical distinction between the two concepts

By consolidating different phases into a single interface, we let logically
related hooks be configured much more cleanly. Whereas before we needed to
something like this to install a middleware to different lifecycle phases:

    middleware := riverencrypt.NewEncryptMiddleware(riversecretbox.NewSecretboxEncryptor(key))

    config := &river.Config{
        JobInsertMiddleware: []rivertype.JobInsertMiddleware{middleware},
        WorkerMiddleware:    []rivertype.WorkerMiddleware{middleware},
    }

We now get to do this instead:

    config := Config: river.Config{
        Hooks: []rivertype.Hook{
            riverencrypt.NewEncryptHook(riversecretbox.NewSecretboxEncryptor(key)),
        },

This is cleaner code-wise, but it also prevents accidental misuse where say an
encryptor was installed for insertion, but then forgotten for when jobs are
worked.

Similar to `JobArgsWithInsertOpts`, job args can implement `JobArgsWithHooks`
to add hooks for specific job kinds, and which will also tak effect for when
jobs are worked:

    type JobArgsWithHooks interface {
        // Hooks returns specific hooks to run for this job type. These will run
        // after the global hooks configured on the client.
        //
        // Warning: Hooks returned should be based on the job type only and be
        // invariant of the specific contents of a job. Hooks are extract by
        // instantiating a generic instance of the job even when a specific instance
        // is available, so any conditional logic within will be ignored. This is
        // done because although specific job information may be available in some
        // hook contexts like on InsertBegin, it won't be in others like WorkBegin.
        Hooks() []rivertype.Hook
    }