### PR TITLE
Add sqlc templates for arbitrary text substitution

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -710,7 +710,7 @@ func Test_Client(t *testing.T) {
 					&overridableJobMiddleware{
 						workFunc: func(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
 							middlewareCalled = true
-							require.Equal(t, `{"name": "inserted name"}`, string(job.EncodedArgs))
+							require.JSONEq(t, `{"name": "inserted name"}`, string(job.EncodedArgs))
 							job.EncodedArgs = []byte(`{"name": "middleware name"}`)
 							return doInner(ctx)
 						},

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -118,8 +118,7 @@ type Executor interface {
 	JobInsertFastMany(ctx context.Context, params []*JobInsertFastParams) ([]*JobInsertFastResult, error)
 	JobInsertFastManyNoReturning(ctx context.Context, params []*JobInsertFastParams) (int, error)
 	JobInsertFull(ctx context.Context, params *JobInsertFullParams) (*rivertype.JobRow, error)
-	JobList(ctx context.Context, query string, namedArgs map[string]any) ([]*rivertype.JobRow, error)
-	JobListFields() string
+	JobList(ctx context.Context, params *JobListParams) ([]*rivertype.JobRow, error)
 	JobRescueMany(ctx context.Context, params *JobRescueManyParams) (*struct{}, error)
 	JobRetry(ctx context.Context, id int64) (*rivertype.JobRow, error)
 	JobSchedule(ctx context.Context, params *JobScheduleParams) ([]*JobScheduleResult, error)
@@ -288,6 +287,13 @@ type JobInsertFullParams struct {
 	Tags         []string
 	UniqueKey    []byte
 	UniqueStates byte
+}
+
+type JobListParams struct {
+	Max           int32
+	NamedArgs     map[string]any
+	OrderByClause string
+	WhereClause   string
 }
 
 type JobRescueManyParams struct {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -91,7 +91,7 @@ func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg *JobCancelParams) 
 
 const jobCountByState = `-- name: JobCountByState :one
 SELECT count(*)
-FROM river_job
+FROM /* TEMPLATE: schema */river_job
 WHERE state = $1
 `
 
@@ -823,6 +823,56 @@ func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFull
 		&i.UniqueStates,
 	)
 	return &i, err
+}
+
+const jobList = `-- name: JobList :many
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+FROM river_job
+WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+LIMIT $1::int
+`
+
+func (q *Queries) JobList(ctx context.Context, db DBTX, max int32) ([]*RiverJob, error) {
+	rows, err := db.QueryContext(ctx, jobList, max)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			pq.Array(&i.AttemptedBy),
+			&i.CreatedAt,
+			pq.Array(&i.Errors),
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			pq.Array(&i.Tags),
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const jobRescueMany = `-- name: JobRescueMany :exec

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -82,7 +82,7 @@ FROM updated_job;
 
 -- name: JobCountByState :one
 SELECT count(*)
-FROM river_job
+FROM /* TEMPLATE: schema */river_job
 WHERE state = @state;
 
 -- name: JobDelete :one
@@ -315,6 +315,12 @@ INSERT INTO river_job(
     @unique_states
 ) RETURNING *;
 
+-- name: JobList :many
+SELECT *
+FROM river_job
+WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+LIMIT @max::int;
 
 -- Run by the rescuer to queue for retry or discard depending on job state.
 -- name: JobRescueMany :exec

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -90,7 +90,7 @@ func (q *Queries) JobCancel(ctx context.Context, db DBTX, arg *JobCancelParams) 
 
 const jobCountByState = `-- name: JobCountByState :one
 SELECT count(*)
-FROM river_job
+FROM /* TEMPLATE: schema */river_job
 WHERE state = $1
 `
 
@@ -807,6 +807,53 @@ func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFull
 		&i.UniqueStates,
 	)
 	return &i, err
+}
+
+const jobList = `-- name: JobList :many
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+FROM river_job
+WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+LIMIT $1::int
+`
+
+func (q *Queries) JobList(ctx context.Context, db DBTX, max int32) ([]*RiverJob, error) {
+	rows, err := db.Query(ctx, jobList, max)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			&i.AttemptedBy,
+			&i.CreatedAt,
+			&i.Errors,
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			&i.Tags,
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const jobRescueMany = `-- name: JobRescueMany :exec

--- a/rivershared/sqlctemplate/sqlc_template.go
+++ b/rivershared/sqlctemplate/sqlc_template.go
@@ -1,0 +1,225 @@
+// Package sqlctemplate provides a way of making arbitrary text replacement in
+// sqlc queries which normally only allow parameters which are in places valid
+// in a prepared statement. For example, it can be used to insert a schema name
+// as a prefix to tables referenced in sqlc, which is otherwise impossible.
+//
+// Replacement is carried out from within invocations of sqlc's generated DBTX
+// interface, after sqlc generated code runs, but before queries are executed.
+// This is accomplished by implementing DBTX, calling Replacer.Run from within
+// them, and injecting parameters in with WithTemplates (which is unfortunately
+// the only way of injecting them).
+//
+// Templates are modeled as SQL comments so that they're still parseable as
+// valid SQL. An example use of the basic /* TEMPLATE ... */ syntax:
+//
+//	-- name: JobCountByState :one
+//	SELECT count(*)
+//	FROM /* TEMPLATE: schema */river_job
+//	WHERE state = @state;
+//
+// An open/close syntax is also available for when SQL is required before
+// processing for the query to be valid. For example, a WHERE or ORDER BY clause
+// can't be empty, so the SQL includes a sentinel value that's parseable which
+// is then replaced later with template values:
+//
+//	-- name: JobList :many
+//	SELECT *
+//	FROM river_job
+//	WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+//	ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+//	LIMIT @max::int;
+//
+// Be careful not to place a template on a line by itself because sqlc will
+// strip any lines that start with a comment. For example, this does NOT work:
+//
+//	-- name: JobList :many
+//	SELECT *
+//	FROM river_job
+//	/* TEMPLATE_BEGIN: where_clause */
+//	LIMIT @max::int;
+package sqlctemplate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/riverqueue/river/rivershared/util/maputil"
+)
+
+type contextContainer struct {
+	NamedArgs map[string]any
+	Templates map[string]Replacement
+}
+
+type contextKey struct{}
+
+// Replacement defines a replacement for a template value in some input SQL.
+type Replacement struct {
+	// Stable is whether the replacement value is expected to be stable for any
+	// number of times Replacer.Run is called with the same given input SQL. If
+	// all replacements are stable, then the output of Replacer.Run is cached so
+	// that it doesn't have to be processed again. Replacements should be not be
+	// stable if they depend on input parameters.
+	Stable bool
+
+	// Value is the value which the template should be replaced with. For a /*
+	// TEMPLATE ... */ tag, replaces template and the comment containing it. For
+	// a /* TEMPLATE_BEGIN ... */ ... /* TEMPLATE_END */ tag pair, replaces both
+	// templates, comments, and the value between them.
+	Value string
+}
+
+// Replacer replaces templates with template values. As an optimization, it
+// contains an internal cache to short circuit SQL that has entirely stable
+// template replacements and whose output is invariant of input parameters.
+type Replacer struct {
+	cache map[string]string
+}
+
+// NewReplacer initializes a new template Replacer.
+func NewReplacer() *Replacer {
+	return &Replacer{
+		cache: make(map[string]string),
+	}
+}
+
+var (
+	templateBeginEndRE = regexp.MustCompile(`/\* TEMPLATE_BEGIN: (.*?) \*/ .*? /\* TEMPLATE_END \*/`)
+	templateRE         = regexp.MustCompile(`/\* TEMPLATE: (.*?) \*/`)
+)
+
+// Run replaces any tempates in input SQL with values from context added via
+// WithTemplates.
+//
+// args aren't used for replacements in the input SQL, but are needed to
+// determine which placeholder number (e.g. $1, $2, $3, ...) we should start
+// with to replace any template named args. The returned args value should then
+// be used as query input as named args from context may have been added to it.
+func (r *Replacer) Run(ctx context.Context, sql string, args []any) (string, []any) {
+	sql, namedArgs, err := r.RunSafely(ctx, sql, args)
+	if err != nil {
+		panic(err)
+	}
+	return sql, namedArgs
+}
+
+// RunSafely is the same as Run, but returns an error in case of missing or
+// extra templates.
+func (r *Replacer) RunSafely(ctx context.Context, sql string, args []any) (string, []any, error) {
+	// If nothing present in context, short circuit quickly.
+	container, ok := ctx.Value(contextKey{}).(*contextContainer)
+	if !ok {
+		return sql, args, nil
+	}
+
+	// If all input templates were stable, the finished SQL will have been
+	if cachedSQL, ok := r.cache[sql]; ok {
+		if len(container.NamedArgs) > 0 {
+			args = append(args, maputil.Values(container.NamedArgs)...)
+		}
+		return cachedSQL, args, nil
+	}
+
+	if !strings.Contains(sql, "/* TEMPLATE") {
+		return sql, args, nil
+	}
+
+	var (
+		templatesExpected = maputil.Keys(container.Templates)
+		templatesMissing  []string // not preallocated because we don't expect any missing parameters in the common case
+	)
+
+	replaceTemplate := func(sql string, templateRE *regexp.Regexp) string {
+		return templateRE.ReplaceAllStringFunc(sql, func(templateStr string) string {
+			// Really dumb, but Go doesn't provide any way to get submatches in a
+			// function, so we have to match twice.
+			//     https://github.com/golang/go/issues/5690
+			matches := templateRE.FindStringSubmatch(templateStr)
+
+			template := matches[1]
+
+			if tmpl, ok := container.Templates[template]; ok {
+				templatesExpected = slices.DeleteFunc(templatesExpected, func(p string) bool { return p == template })
+				return tmpl.Value
+			} else {
+				templatesMissing = append(templatesMissing, template)
+			}
+
+			return templateStr
+		})
+	}
+
+	updatedSQL := sql
+	updatedSQL = replaceTemplate(updatedSQL, templateBeginEndRE)
+	updatedSQL = replaceTemplate(updatedSQL, templateRE)
+
+	if len(templatesExpected) > 0 {
+		return "", nil, errors.New("sqlctemplate params present in context but missing in SQL: " + strings.Join(templatesExpected, ", "))
+	}
+
+	if len(templatesMissing) > 0 {
+		return "", nil, errors.New("sqlctemplate params present in SQL but missing in context: " + strings.Join(templatesMissing, ", "))
+	}
+
+	if len(container.NamedArgs) > 0 {
+		placeholderNum := len(args)
+		for arg, val := range container.NamedArgs {
+			placeholderNum++
+
+			var (
+				symbol      = "@" + arg
+				symbolIndex = strings.Index(updatedSQL, symbol)
+			)
+
+			if symbolIndex == -1 {
+				return "", nil, fmt.Errorf("sqltemplate expected to find named arg %q, but it wasn't present", symbol)
+			}
+
+			// ReplaceAll because an input parameter may appear multiple times.
+			updatedSQL = strings.ReplaceAll(updatedSQL, symbol, "$"+strconv.Itoa(placeholderNum))
+			args = append(args, val)
+		}
+	}
+
+	for _, tmpl := range container.Templates {
+		if !tmpl.Stable {
+			return updatedSQL, args, nil
+		}
+	}
+
+	r.cache[sql] = updatedSQL
+
+	return updatedSQL, args, nil
+}
+
+// WithTemplates adds sqlctemplate templates to the given context (they go in
+// context because it's the only way to get them down into the innards of sqlc).
+// namedArgs can also be passed in to replace arguments found in
+//
+// If sqlctemplate params are already present in context, the two sets are
+// merged, with the new params taking precedent.
+func WithTemplates(ctx context.Context, templates map[string]Replacement, namedArgs map[string]any) context.Context {
+	if container, ok := ctx.Value(contextKey{}).(*contextContainer); ok {
+		for arg, val := range namedArgs {
+			container.NamedArgs[arg] = val
+		}
+		for template, tmpl := range templates {
+			container.Templates[template] = tmpl
+		}
+		return ctx
+	}
+
+	if namedArgs == nil {
+		namedArgs = make(map[string]any)
+	}
+
+	return context.WithValue(ctx, contextKey{}, &contextContainer{
+		NamedArgs: namedArgs,
+		Templates: templates,
+	})
+}

--- a/rivershared/sqlctemplate/sqlc_template_test.go
+++ b/rivershared/sqlctemplate/sqlc_template_test.go
@@ -1,0 +1,245 @@
+package sqlctemplate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplacer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct{}
+
+	setup := func(t *testing.T) (*Replacer, *testBundle) { //nolint:unparam
+		t.Helper()
+
+		return NewReplacer(), &testBundle{}
+	}
+
+	t.Run("BasicTemplate", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"schema": {Value: "test_schema."},
+		}, nil)
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			-- name: JobCountByState :one
+			SELECT count(*)
+			FROM /* TEMPLATE: schema */river_job
+			WHERE state = @state;
+		`, nil)
+		require.NoError(t, err)
+		require.Nil(t, args)
+		require.Equal(t, `
+			-- name: JobCountByState :one
+			SELECT count(*)
+			FROM test_schema.river_job
+			WHERE state = @state;
+		`, updatedSQL)
+	})
+
+	t.Run("BeginEndTemplate", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"order_by_clause": {Value: "kind, id"},
+			"where_clause":    {Value: "kind = 'no_op'"},
+		}, nil)
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			-- name: JobList :many
+			SELECT *
+			FROM river_job
+			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+			ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+			LIMIT @max::int;
+		`, nil)
+		require.NoError(t, err)
+		require.Nil(t, args)
+		require.Equal(t, `
+			-- name: JobList :many
+			SELECT *
+			FROM river_job
+			WHERE kind = 'no_op'
+			ORDER BY kind, id
+			LIMIT @max::int;
+		`, updatedSQL)
+	})
+
+	t.Run("RepeatedTemplate", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"schema": {Value: "test_schema."},
+		}, nil)
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			SELECT count(*)
+			FROM /* TEMPLATE: schema */river_job r1
+				INNER JOIN /* TEMPLATE: schema */river_job r2 ON r1.id = r2.id;
+		`, nil)
+		require.NoError(t, err)
+		require.Nil(t, args)
+		require.Equal(t, `
+			SELECT count(*)
+			FROM test_schema.river_job r1
+				INNER JOIN test_schema.river_job r2 ON r1.id = r2.id;
+		`, updatedSQL)
+	})
+
+	t.Run("AllTemplatesStableCached", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"schema": {Stable: true, Value: "test_schema."},
+		}, nil)
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			SELECT count(*)
+			FROM /* TEMPLATE: schema */river_job;
+		`, nil)
+		require.NoError(t, err)
+		require.Nil(t, args)
+		require.Equal(t, `
+			SELECT count(*)
+			FROM test_schema.river_job;
+		`, updatedSQL)
+
+		require.Len(t, replacer.cache, 1)
+
+		// Invoke again to make sure we get back the same result.
+		updatedSQL, args, err = replacer.RunSafely(ctx, `
+			SELECT count(*)
+			FROM /* TEMPLATE: schema */river_job;
+		`, nil)
+		require.NoError(t, err)
+		require.Nil(t, args)
+		require.Equal(t, `
+			SELECT count(*)
+			FROM test_schema.river_job;
+		`, updatedSQL)
+	})
+
+	t.Run("AnyTemplateNotStableNotCached", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"schema":       {Stable: true, Value: "test_schema."},
+			"where_clause": {Value: "kind = 'no_op'"},
+		}, nil)
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			SELECT count(*)
+			FROM /* TEMPLATE: schema */river_job
+			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */;
+		`, nil)
+		require.NoError(t, err)
+		require.Nil(t, args)
+		require.Equal(t, `
+			SELECT count(*)
+			FROM test_schema.river_job
+			WHERE kind = 'no_op';
+		`, updatedSQL)
+
+		require.Empty(t, replacer.cache)
+	})
+
+	t.Run("NamedArgsNoInitialArgs", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"where_clause": {Value: "kind = @kind"},
+		}, map[string]any{
+			"kind": "no_op",
+		})
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			SELECT count(*)
+			FROM river_job
+			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */;
+		`, nil)
+		require.NoError(t, err)
+		require.Equal(t, []any{"no_op"}, args)
+		require.Equal(t, `
+			SELECT count(*)
+			FROM river_job
+			WHERE kind = $1;
+		`, updatedSQL)
+	})
+
+	t.Run("NamedArgsWithInitialArgs", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"where_clause": {Value: "kind = @kind"},
+		}, map[string]any{
+			"kind": "no_op",
+		})
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			SELECT count(*)
+			FROM river_job
+			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+				AND status = $1;
+		`, []any{"succeeded"})
+		require.NoError(t, err)
+		require.Equal(t, []any{"succeeded", "no_op"}, args)
+		require.Equal(t, `
+			SELECT count(*)
+			FROM river_job
+			WHERE kind = $2
+				AND status = $1;
+		`, updatedSQL)
+	})
+
+	t.Run("MultipleWithTemplatesOverrides", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		ctx := WithTemplates(ctx, map[string]Replacement{
+			"schema":       {Stable: true, Value: "test_schema."},
+			"where_clause": {Value: "kind = @kind"},
+		}, map[string]any{
+			"kind": "no_op",
+		})
+
+		ctx = WithTemplates(ctx, map[string]Replacement{
+			"where_clause": {Value: "kind = @kind AND status = @status"},
+		}, map[string]any{
+			"status": "succeeded",
+		})
+
+		updatedSQL, args, err := replacer.RunSafely(ctx, `
+			SELECT count(*)
+			FROM /* TEMPLATE: schema */river_job
+			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */;
+		`, nil)
+		require.NoError(t, err)
+		require.Equal(t, []any{"no_op", "succeeded"}, args)
+		require.Equal(t, `
+			SELECT count(*)
+			FROM test_schema.river_job
+			WHERE kind = $1 AND status = $2;
+		`, updatedSQL)
+	})
+}


### PR DESCRIPTION
This one aims to give us a workable resolution to one of our most common
problems with sqlc. Namely, that although it allows substitution for
parameters that work with a prepared query, it can't replace arbitrary
parts of a SQL query, leading to operations that aren't possible so that
we either don't do them or end up degrading to raw SQL that's only
checked at runtime.

Here, we add a `sqlctemplate` package that's designed to be run from
inside custom implementations of sqlc's `DBTX` interface so that it it
runs after sqlc's generated code but before the query goes to Postgres.

In sqlc code, templates look like this:

    -- name: JobCountByState :one
    SELECT count(*)
    FROM /* TEMPLATE: schema */river_job
    WHERE state = @state;

The template replacement is modeled as a comment so that it doesn't
interfere with with sqlc's parsing of SQL syntax. The above is valid SQL
with or without the template, but with it, `sqlctemplate` can add an
arbitrary schema name to the queried table.

It also supports a form of syntax where a value is required for SQL to
be valid. For example, `WHERE` and `ORDER BY` clauses both require a
value for them to be valid. Here, a stand in value is provide between
template tags. It's processed by sqlc's parser, but then replace by the
template engine before the SQL is executed:

    -- name: JobList :many
    SELECT *
    FROM river_job
    WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
    ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
    LIMIT @max::int;

Template values are injected via context (don't love this, but there's
no other way in getting information down to a layer below `DBTX`):

    ctx = sqlctemplate.WithTemplates(ctx, map[string]sqlctemplate.Replacement{
        "order_by_clause": {Value: params.OrderByClause},
        "where_clause":    {Value: params.WhereClause},
    }, params.NamedArgs)

    jobs, err := dbsqlc.New().JobList(ctx, e.dbtx, params.Max)

The template engine is written to be root out as many error as possible
by noticing if a template replacement is passed that doesn't have an
equivalent template in SQL, or if a template in SQL is present for which
there's no replacement.

Named args are support in templates similar to how sqlc supports them.
This allows pgx's prepared statement cache to continue to operate as it
did before, thereby keeping everything fast.

Lastly, I should note that templates are meant as a utility of last
resort. All effort should be made to resolve problems via mainstream
sqlc, and only bring in templates when there's no other option.