### PR TITLE
Implement job list with sqlc using templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
 ⚠️ Version 0.19.0 has minor breaking changes for the `Worker.Middleware`, introduced fairly recently in 0.17.0. We tried not to make this change, but found the existing middleware interface insufficient to provide the necessary range of functionality we wanted, and this is a secondary middleware facility that won't be in use for many users, so it seemed worthwhile.
 
 ### Changed
 
 - The `river.RecordOutput` function now returns an error if the output is too large. The output is limited to 32MB in size. [PR #782](https://github.com/riverqueue/river/pull/782).
 - **Breaking change:** The `Worker` interface's `Middleware` function now takes a `JobRow` parameter instead of a generic `Job[T]`. This was necessary to expand the potential of what middleware can do: by letting the executor extract a middleware stack from a worker before a job is fully unmarshaled, the middleware can also participate in the unmarshaling process. [PR #783](https://github.com/riverqueue/river/pull/783).
+- `JobList` has been reimplemented to use sqlc. [PR #795](https://github.com/riverqueue/river/pull/795).
 
 ## [0.18.0] - 2025-02-20
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ define test-race-target
 endef
 $(foreach mod,$(submodules),$(eval $(call test-race-target,$(mod))))
 
-
 .PHONY: tidy
 tidy:: ## Run `go mod tidy` for all submodules
 define tidy-target

--- a/internal/dblist/db_list.go
+++ b/internal/dblist/db_list.go
@@ -3,24 +3,12 @@ package dblist
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
-
-const jobList = `-- name: JobList :many
-SELECT
-  %s
-FROM
-  river_job
-%s
-ORDER BY
-  %s
-LIMIT @count::integer
-`
 
 type SortOrder int
 
@@ -47,7 +35,7 @@ type JobListParams struct {
 }
 
 func JobList(ctx context.Context, exec riverdriver.Executor, params *JobListParams) ([]*rivertype.JobRow, error) {
-	var conditionsBuilder strings.Builder
+	var whereBuilder strings.Builder
 
 	orderBy := make([]JobListOrderBy, len(params.OrderBy))
 	for i, o := range params.OrderBy {
@@ -62,41 +50,46 @@ func JobList(ctx context.Context, exec riverdriver.Executor, params *JobListPara
 		namedArgs = make(map[string]any)
 	}
 
-	writeWhereOrAnd := func() {
-		if conditionsBuilder.Len() == 0 {
-			conditionsBuilder.WriteString("WHERE\n	")
-		} else {
-			conditionsBuilder.WriteString("\n  AND ")
+	// Writes an `AND` to connect SQL predicates as long as this isn't the first
+	// predicate.
+	writeAndAfterFirst := func() {
+		if whereBuilder.Len() != 0 {
+			whereBuilder.WriteString("\n  AND ")
 		}
 	}
 
 	if len(params.Kinds) > 0 {
-		writeWhereOrAnd()
-		conditionsBuilder.WriteString("kind = any(@kinds::text[])")
+		writeAndAfterFirst()
+		whereBuilder.WriteString("kind = any(@kinds::text[])")
 		namedArgs["kinds"] = params.Kinds
 	}
 
 	if len(params.Queues) > 0 {
-		writeWhereOrAnd()
-		conditionsBuilder.WriteString("queue = any(@queues::text[])")
+		writeAndAfterFirst()
+		whereBuilder.WriteString("queue = any(@queues::text[])")
 		namedArgs["queues"] = params.Queues
 	}
 
 	if len(params.States) > 0 {
-		writeWhereOrAnd()
-		conditionsBuilder.WriteString("state = any(@states::river_job_state[])")
+		writeAndAfterFirst()
+		whereBuilder.WriteString("state = any(@states::river_job_state[])")
 		namedArgs["states"] = sliceutil.Map(params.States, func(s rivertype.JobState) string { return string(s) })
 	}
 
 	if params.Conditions != "" {
-		writeWhereOrAnd()
-		conditionsBuilder.WriteString(params.Conditions)
+		writeAndAfterFirst()
+		whereBuilder.WriteString(params.Conditions)
+	}
+
+	// A condition of some kind is needed, so given no others write one that'll
+	// always return true.
+	if whereBuilder.Len() < 1 {
+		whereBuilder.WriteString("1")
 	}
 
 	if params.LimitCount < 1 {
 		return nil, errors.New("required parameter 'Count' in JobList must be greater than zero")
 	}
-	namedArgs["count"] = params.LimitCount
 
 	if len(params.OrderBy) == 0 {
 		return nil, errors.New("sort order is required")
@@ -116,7 +109,10 @@ func JobList(ctx context.Context, exec riverdriver.Executor, params *JobListPara
 		}
 	}
 
-	sql := fmt.Sprintf(jobList, exec.JobListFields(), conditionsBuilder.String(), orderByBuilder.String())
-
-	return exec.JobList(ctx, sql, namedArgs)
+	return exec.JobList(ctx, &riverdriver.JobListParams{
+		Max:           params.LimitCount,
+		NamedArgs:     namedArgs,
+		OrderByClause: orderByBuilder.String(),
+		WhereClause:   whereBuilder.String(),
+	})
 }

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -118,8 +118,7 @@ type Executor interface {
 	JobInsertFastMany(ctx context.Context, params []*JobInsertFastParams) ([]*JobInsertFastResult, error)
 	JobInsertFastManyNoReturning(ctx context.Context, params []*JobInsertFastParams) (int, error)
 	JobInsertFull(ctx context.Context, params *JobInsertFullParams) (*rivertype.JobRow, error)
-	JobList(ctx context.Context, query string, namedArgs map[string]any) ([]*rivertype.JobRow, error)
-	JobListFields() string
+	JobList(ctx context.Context, params *JobListParams) ([]*rivertype.JobRow, error)
 	JobRescueMany(ctx context.Context, params *JobRescueManyParams) (*struct{}, error)
 	JobRetry(ctx context.Context, id int64) (*rivertype.JobRow, error)
 	JobSchedule(ctx context.Context, params *JobScheduleParams) ([]*JobScheduleResult, error)
@@ -288,6 +287,13 @@ type JobInsertFullParams struct {
 	Tags         []string
 	UniqueKey    []byte
 	UniqueStates byte
+}
+
+type JobListParams struct {
+	Max           int32
+	NamedArgs     map[string]any
+	OrderByClause string
+	WhereClause   string
 }
 
 type JobRescueManyParams struct {

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -315,6 +315,12 @@ INSERT INTO river_job(
     @unique_states
 ) RETURNING *;
 
+-- name: JobList :many
+SELECT *
+FROM river_job
+WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+LIMIT @max::int;
 
 -- Run by the rescuer to queue for retry or discard depending on job state.
 -- name: JobRescueMany :exec

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -809,6 +809,53 @@ func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFull
 	return &i, err
 }
 
+const jobList = `-- name: JobList :many
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+FROM river_job
+WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+LIMIT $1::int
+`
+
+func (q *Queries) JobList(ctx context.Context, db DBTX, max int32) ([]*RiverJob, error) {
+	rows, err := db.Query(ctx, jobList, max)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			&i.AttemptedBy,
+			&i.CreatedAt,
+			&i.Errors,
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			&i.Tags,
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const jobRescueMany = `-- name: JobRescueMany :exec
 UPDATE river_job
 SET


### PR DESCRIPTION
Here, reimplement the job list API's internals using sqlc using the new
sqlc template system introduced in #794. Admittedly this one isn't quite
as big of a win as we expect the templating to be in some cases, but it
gets rid of a case of SQL code in a raw string, and lets us drop the
`JobListFields` driver interface function.

We don't add tests because the APIs are relatively well tested already,
but make some small modifications to the driver `JobList` test cases so
they're a little more thorough.