### PR TITLE
Fix intermittent test in `sqlctemplate` relating to arbitrary map sorting

### DIFF
--- a/rivershared/sqlctemplate/sqlc_template.go
+++ b/rivershared/sqlctemplate/sqlc_template.go
@@ -177,12 +177,18 @@ func (r *Replacer) RunSafely(ctx context.Context, sql string, args []any) (strin
 
 	if len(container.NamedArgs) > 0 {
 		placeholderNum := len(args)
-		for arg, val := range container.NamedArgs {
+
+		// For the benefit of the test suite's output being predictable, sort
+		// named args before processing them.
+		sortedNamedArgs := maputil.Keys(container.NamedArgs)
+		slices.Sort(sortedNamedArgs)
+		for _, arg := range sortedNamedArgs {
 			placeholderNum++
 
 			var (
 				symbol      = "@" + arg
 				symbolIndex = strings.Index(updatedSQL, symbol)
+				val         = container.NamedArgs[arg]
 			)
 
 			if symbolIndex == -1 {


### PR DESCRIPTION
Here, fix an intermittent test [1] that's come up _already_ since #795
was merged in. This is a problem that gets me a lot, which is that map
sorting in Go is not guaranteed, despite in tests small maps often
coming out in the order that you're looking for so you don't notice a
problem until later.

Here, when processing named args in a template, walk through them in
alphabetical order. This has no meaningful effect on the rendered SQL,
but provides stability for the test suite.

[1] https://github.com/riverqueue/river/actions/runs/13734150171/job/38415749775?pr=795