### PR TITLE
Proof out explicit schema injection without `search_path`

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -585,7 +585,7 @@ func Test_Client(t *testing.T) {
 
 		// Cancel an unknown job ID, within a transaction:
 		err = dbutil.WithTx(ctx, client.driver.GetExecutor(), func(ctx context.Context, exec riverdriver.ExecutorTx) error {
-			jobAfter, err := exec.JobCancel(ctx, &riverdriver.JobCancelParams{ID: 0})
+			jobAfter, err := exec.JobCancel(ctx, &riverdriver.JobCancelParams{ID: 0, Schema: client.config.schema})
 			require.ErrorIs(t, err, ErrNotFound)
 			require.Nil(t, jobAfter)
 			return nil
@@ -2020,7 +2020,11 @@ func Test_Client_InsertManyFast(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, count)
 
-		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
+
 		require.NoError(t, err)
 		require.Len(t, jobs, 2, "Expected to find exactly two jobs of kind: "+(noOpArgs{}).Kind())
 	})
@@ -2122,7 +2126,11 @@ func Test_Client_InsertManyFast(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 
-		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
+
 		require.NoError(t, err)
 		require.Len(t, jobs, 1, "Expected to find exactly one job of kind: "+(noOpArgs{}).Kind())
 		jobRow := jobs[0]
@@ -2262,14 +2270,21 @@ func Test_Client_InsertManyFastTx(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 2, count)
 
-		jobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		jobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
+
 		require.NoError(t, err)
 		require.Len(t, jobs, 2, "Expected to find exactly two jobs of kind: "+(noOpArgs{}).Kind())
 
 		require.NoError(t, bundle.tx.Commit(ctx))
 
 		// Ensure the jobs are visible outside the transaction:
-		jobs, err = client.driver.GetExecutor().JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		jobs, err = client.driver.GetExecutor().JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, jobs, 2, "Expected to find exactly two jobs of kind: "+(noOpArgs{}).Kind())
 	})
@@ -2282,7 +2297,10 @@ func Test_Client_InsertManyFastTx(t *testing.T) {
 		_, err := client.InsertManyFastTx(ctx, bundle.tx, []InsertManyParams{{noOpArgs{}, nil}})
 		require.NoError(t, err)
 
-		insertedJobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		insertedJobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, insertedJobs, 1)
 		require.Equal(t, rivertype.JobStateAvailable, insertedJobs[0].State)
@@ -2300,7 +2318,10 @@ func Test_Client_InsertManyFastTx(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, count)
 
-		insertedJobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		insertedJobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, insertedJobs, 1)
 		require.Equal(t, rivertype.JobStateScheduled, insertedJobs[0].State)
@@ -2466,7 +2487,10 @@ func Test_Client_InsertMany(t *testing.T) {
 
 		require.NotEqual(t, results[0].Job.ID, results[1].Job.ID)
 
-		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, jobs, 2, "Expected to find exactly two jobs of kind: "+(noOpArgs{}).Kind())
 	})
@@ -2568,7 +2592,10 @@ func Test_Client_InsertMany(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, results, 1)
 
-		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		jobs, err := client.driver.GetExecutor().JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, jobs, 1, "Expected to find exactly one job of kind: "+(noOpArgs{}).Kind())
 		jobRow := jobs[0]
@@ -2752,7 +2779,10 @@ func Test_Client_InsertManyTx(t *testing.T) {
 
 		require.NotEqual(t, results[0].Job.ID, results[1].Job.ID)
 
-		jobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		jobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, jobs, 2, "Expected to find exactly two jobs of kind: "+(noOpArgs{}).Kind())
 	})
@@ -2769,7 +2799,10 @@ func Test_Client_InsertManyTx(t *testing.T) {
 		require.Equal(t, rivertype.JobStateAvailable, results[0].Job.State)
 		require.WithinDuration(t, time.Now(), results[0].Job.ScheduledAt, 2*time.Second)
 
-		insertedJobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, []string{(noOpArgs{}).Kind()})
+		insertedJobs, err := client.driver.UnwrapExecutor(bundle.tx).JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(noOpArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, insertedJobs, 1)
 		require.Equal(t, rivertype.JobStateAvailable, insertedJobs[0].State)
@@ -3444,7 +3477,10 @@ func Test_Client_ErrorHandler(t *testing.T) {
 		// unknown job.
 		insertParams, err := insertParamsFromConfigArgsAndOptions(&client.baseService.Archetype, config, unregisteredJobArgs{}, nil)
 		require.NoError(t, err)
-		_, err = client.driver.GetExecutor().JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{(*riverdriver.JobInsertFastParams)(insertParams)})
+		_, err = client.driver.GetExecutor().JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+			Jobs:   []*riverdriver.JobInsertFastParams{(*riverdriver.JobInsertFastParams)(insertParams)},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 
 		riversharedtest.WaitOrTimeout(t, bundle.SubscribeChan)
@@ -3605,7 +3641,7 @@ func Test_Client_Maintenance(t *testing.T) {
 
 		requireJobHasState := func(jobID int64, state rivertype.JobState) {
 			t.Helper()
-			job, err := bundle.exec.JobGetByID(ctx, jobID)
+			job, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: jobID, Schema: ""})
 			require.NoError(t, err)
 			require.Equal(t, state, job.State)
 		}
@@ -3702,7 +3738,10 @@ func Test_Client_Maintenance(t *testing.T) {
 		svc := maintenance.GetService[*maintenance.PeriodicJobEnqueuer](client.queueMaintainer)
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 
-		jobs, err := bundle.exec.JobGetByKindMany(ctx, []string{(periodicJobArgs{}).Kind()})
+		jobs, err := bundle.exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(periodicJobArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, jobs, 1, "Expected to find exactly one job of kind: "+(periodicJobArgs{}).Kind())
 	})
@@ -3728,7 +3767,10 @@ func Test_Client_Maintenance(t *testing.T) {
 		svc.TestSignals.EnteredLoop.WaitOrTimeout()
 
 		// No jobs yet because the RunOnStart option was not specified.
-		jobs, err := bundle.exec.JobGetByKindMany(ctx, []string{(periodicJobArgs{}).Kind()})
+		jobs, err := bundle.exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(periodicJobArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Empty(t, jobs)
 	})
@@ -3755,7 +3797,10 @@ func Test_Client_Maintenance(t *testing.T) {
 		svc := maintenance.GetService[*maintenance.PeriodicJobEnqueuer](client.queueMaintainer)
 		svc.TestSignals.SkippedJob.WaitOrTimeout()
 
-		jobs, err := bundle.exec.JobGetByKindMany(ctx, []string{(periodicJobArgs{}).Kind()})
+		jobs, err := bundle.exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(periodicJobArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Empty(t, jobs, "Expected to find zero jobs of kind: "+(periodicJobArgs{}).Kind())
 	})
@@ -3789,7 +3834,10 @@ func Test_Client_Maintenance(t *testing.T) {
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 
 		// We get a queued job because RunOnStart was specified.
-		jobs, err := exec.JobGetByKindMany(ctx, []string{(periodicJobArgs{}).Kind()})
+		jobs, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(periodicJobArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, jobs, 1)
 	})
@@ -3839,12 +3887,18 @@ func Test_Client_Maintenance(t *testing.T) {
 		// periodic job was inserted also due to RunOnStart, but only after the
 		// first was removed.
 		{
-			jobs, err := exec.JobGetByKindMany(ctx, []string{(periodicJobArgs{}).Kind()})
+			jobs, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+				Kind:   []string{(periodicJobArgs{}).Kind()},
+				Schema: client.config.schema,
+			})
 			require.NoError(t, err)
 			require.Len(t, jobs, 1)
 		}
 		{
-			jobs, err := exec.JobGetByKindMany(ctx, []string{(OtherPeriodicArgs{}).Kind()})
+			jobs, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+				Kind:   []string{(OtherPeriodicArgs{}).Kind()},
+				Schema: client.config.schema,
+			})
 			require.NoError(t, err)
 			require.Len(t, jobs, 1)
 		}
@@ -3878,7 +3932,10 @@ func Test_Client_Maintenance(t *testing.T) {
 		svc := maintenance.GetService[*maintenance.PeriodicJobEnqueuer](client.queueMaintainer)
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 
-		jobs, err := bundle.exec.JobGetByKindMany(ctx, []string{(periodicJobArgs{}).Kind()})
+		jobs, err := bundle.exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{(periodicJobArgs{}).Kind()},
+			Schema: client.config.schema,
+		})
 		require.NoError(t, err)
 		require.Len(t, jobs, 1, "Expected to find exactly one job of kind: "+(periodicJobArgs{}).Kind())
 	})
@@ -4371,8 +4428,10 @@ func Test_Client_RetryPolicy(t *testing.T) {
 			_ = riversharedtest.WaitOrTimeout(t, subscribeChan)
 		}
 
-		finishedJobs, err := client.driver.GetExecutor().JobGetByIDMany(ctx,
-			sliceutil.Map(originalJobs, func(m *rivertype.JobRow) int64 { return m.ID }))
+		finishedJobs, err := client.driver.GetExecutor().JobGetByIDMany(ctx, &riverdriver.JobGetByIDManyParams{
+			ID:     sliceutil.Map(originalJobs, func(m *rivertype.JobRow) int64 { return m.ID }),
+			Schema: "",
+		})
 		require.NoError(t, err)
 
 		// Jobs aren't guaranteed to come back out of the queue in the same
@@ -4799,7 +4858,10 @@ func Test_Client_SubscribeConfig(t *testing.T) {
 			}
 		}
 
-		_, err := client.driver.GetExecutor().JobInsertFastMany(ctx, insertParams)
+		_, err := client.driver.GetExecutor().JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+			Jobs:   insertParams,
+			Schema: "",
+		})
 		require.NoError(t, err)
 
 		// Need to start waiting on events before running the client or the
@@ -5232,7 +5294,10 @@ func Test_Client_UnknownJobKindErrorsTheJob(t *testing.T) {
 
 	insertParams, err := insertParamsFromConfigArgsAndOptions(&client.baseService.Archetype, config, unregisteredJobArgs{}, nil)
 	require.NoError(err)
-	insertedResults, err := client.driver.GetExecutor().JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{(*riverdriver.JobInsertFastParams)(insertParams)})
+	insertedResults, err := client.driver.GetExecutor().JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+		Jobs:   []*riverdriver.JobInsertFastParams{(*riverdriver.JobInsertFastParams)(insertParams)},
+		Schema: client.config.schema,
+	})
 	require.NoError(err)
 
 	insertedResult := insertedResults[0]

--- a/cmd/river/rivercli/command.go
+++ b/cmd/river/rivercli/command.go
@@ -55,6 +55,7 @@ type CommandBase struct {
 	DriverProcurer DriverProcurer
 	Logger         *slog.Logger
 	Out            io.Writer
+	Schema         string
 
 	GetBenchmarker func() BenchmarkerInterface
 	GetMigrator    func(config *rivermigrate.Config) (MigratorInterface, error)
@@ -75,6 +76,7 @@ type RunCommandBundle struct {
 	DriverProcurer DriverProcurer
 	Logger         *slog.Logger
 	OutStd         io.Writer
+	Schema         string
 }
 
 // RunCommand bootstraps and runs a River CLI subcommand.
@@ -88,6 +90,7 @@ func RunCommand[TOpts CommandOpts](ctx context.Context, bundle *RunCommandBundle
 			DriverProcurer: bundle.DriverProcurer,
 			Logger:         bundle.Logger,
 			Out:            bundle.OutStd,
+			Schema:         bundle.Schema,
 		}
 
 		var databaseURL *string
@@ -124,7 +127,9 @@ func RunCommand[TOpts CommandOpts](ctx context.Context, bundle *RunCommandBundle
 
 			driver := bundle.DriverProcurer.ProcurePgxV5(dbPool)
 
-			commandBase.GetBenchmarker = func() BenchmarkerInterface { return riverbench.NewBenchmarker(driver, commandBase.Logger) }
+			commandBase.GetBenchmarker = func() BenchmarkerInterface {
+				return riverbench.NewBenchmarker(driver, commandBase.Logger, commandBase.Schema)
+			}
 			commandBase.GetMigrator = func(config *rivermigrate.Config) (MigratorInterface, error) { return rivermigrate.New(driver, config) }
 		}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -98,17 +98,20 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 		return driver.UnwrapExecutor(tx), &testBundle{}
 	}
 
-	makeInsertParams := func() []*riverdriver.JobInsertFastParams {
-		return []*riverdriver.JobInsertFastParams{{
-			EncodedArgs: []byte(`{}`),
-			Kind:        "fake_job",
-			MaxAttempts: rivercommon.MaxAttemptsDefault,
-			Metadata:    []byte(`{}`),
-			Priority:    rivercommon.PriorityDefault,
-			Queue:       rivercommon.QueueDefault,
-			ScheduledAt: nil,
-			State:       rivertype.JobStateAvailable,
-		}}
+	makeInsertParams := func() *riverdriver.JobInsertFastManyParams {
+		return &riverdriver.JobInsertFastManyParams{
+			Jobs: []*riverdriver.JobInsertFastParams{{
+				EncodedArgs: []byte(`{}`),
+				Kind:        "fake_job",
+				MaxAttempts: rivercommon.MaxAttemptsDefault,
+				Metadata:    []byte(`{}`),
+				Priority:    rivercommon.PriorityDefault,
+				Queue:       rivercommon.QueueDefault,
+				ScheduledAt: nil,
+				State:       rivertype.JobStateAvailable,
+			}},
+			Schema: "",
+		}
 	}
 
 	b.Run("JobInsert_Sequential", func(b *testing.B) {
@@ -222,14 +225,16 @@ func BenchmarkDriverRiverPgxV5Insert(b *testing.B) {
 		_, bundle := setup(b)
 
 		for range b.N {
-			_, err := bundle.exec.JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{{
-				EncodedArgs: []byte(`{"encoded": "args"}`),
-				Kind:        "test_kind",
-				MaxAttempts: rivercommon.MaxAttemptsDefault,
-				Priority:    rivercommon.PriorityDefault,
-				Queue:       rivercommon.QueueDefault,
-				State:       rivertype.JobStateAvailable,
-			}})
+			_, err := bundle.exec.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+				Jobs: []*riverdriver.JobInsertFastParams{{
+					EncodedArgs: []byte(`{"encoded": "args"}`),
+					Kind:        "test_kind",
+					MaxAttempts: rivercommon.MaxAttemptsDefault,
+					Priority:    rivercommon.PriorityDefault,
+					Queue:       rivercommon.QueueDefault,
+					State:       rivertype.JobStateAvailable,
+				}},
+			})
 			require.NoError(b, err)
 		}
 	})
@@ -238,16 +243,18 @@ func BenchmarkDriverRiverPgxV5Insert(b *testing.B) {
 		_, bundle := setup(b)
 
 		for i := range b.N {
-			_, err := bundle.exec.JobInsertFastMany(ctx, []*riverdriver.JobInsertFastParams{{
-				EncodedArgs:  []byte(`{"encoded": "args"}`),
-				Kind:         "test_kind",
-				MaxAttempts:  rivercommon.MaxAttemptsDefault,
-				Priority:     rivercommon.PriorityDefault,
-				Queue:        rivercommon.QueueDefault,
-				State:        rivertype.JobStateAvailable,
-				UniqueKey:    []byte("test_unique_key_" + strconv.Itoa(i)),
-				UniqueStates: 0xFB,
-			}})
+			_, err := bundle.exec.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+				Jobs: []*riverdriver.JobInsertFastParams{{
+					EncodedArgs:  []byte(`{"encoded": "args"}`),
+					Kind:         "test_kind",
+					MaxAttempts:  rivercommon.MaxAttemptsDefault,
+					Priority:     rivercommon.PriorityDefault,
+					Queue:        rivercommon.QueueDefault,
+					State:        rivertype.JobStateAvailable,
+					UniqueKey:    []byte("test_unique_key_" + strconv.Itoa(i)),
+					UniqueStates: 0xFB,
+				}},
+			})
 			require.NoError(b, err)
 		}
 	})

--- a/internal/jobcompleter/job_completer_test.go
+++ b/internal/jobcompleter/job_completer_test.go
@@ -519,7 +519,7 @@ func testCompleter[TCompleter JobCompleter](
 	requireJob := func(t *testing.T, exec riverdriver.Executor, jobID int64) *rivertype.JobRow {
 		t.Helper()
 
-		job, err := exec.JobGetByID(ctx, jobID)
+		job, err := exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: jobID, Schema: ""})
 		require.NoError(t, err)
 		return job
 	}
@@ -590,10 +590,16 @@ func testCompleter[TCompleter JobCompleter](
 			}
 		}
 
-		_, err := bundle.exec.JobInsertFastMany(ctx, insertParams)
+		_, err := bundle.exec.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+			Jobs:   insertParams,
+			Schema: "",
+		})
 		require.NoError(t, err)
 
-		jobs, err := bundle.exec.JobGetByKindMany(ctx, []string{kind})
+		jobs, err := bundle.exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{kind},
+			Schema: "",
+		})
 		require.NoError(t, err)
 
 		t.Cleanup(riverinternaltest.DiscardContinuously(bundle.subscribeCh))
@@ -604,7 +610,10 @@ func testCompleter[TCompleter JobCompleter](
 
 		completer.Stop()
 
-		updatedJobs, err := bundle.exec.JobGetByKindMany(ctx, []string{kind})
+		updatedJobs, err := bundle.exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{kind},
+			Schema: "",
+		})
 		require.NoError(t, err)
 		for i := range updatedJobs {
 			require.Equal(t, rivertype.JobStateCompleted, updatedJobs[i].State)
@@ -633,7 +642,9 @@ func testCompleter[TCompleter JobCompleter](
 
 		require.Positive(t, numInserted)
 
-		numCompleted, err := bundle.exec.JobCountByState(ctx, rivertype.JobStateCompleted)
+		numCompleted, err := bundle.exec.JobCountByState(ctx, &riverdriver.JobCountByStateParams{
+			State: rivertype.JobStateCompleted,
+		})
 		require.NoError(t, err)
 		t.Logf("Counted %d jobs as completed", numCompleted)
 		require.Positive(t, numCompleted)
@@ -658,7 +669,9 @@ func testCompleter[TCompleter JobCompleter](
 
 		require.Positive(t, numInserted)
 
-		numCompleted, err := bundle.exec.JobCountByState(ctx, rivertype.JobStateCompleted)
+		numCompleted, err := bundle.exec.JobCountByState(ctx, &riverdriver.JobCountByStateParams{
+			State: rivertype.JobStateCompleted,
+		})
 		require.NoError(t, err)
 		t.Logf("Counted %d jobs as completed", numCompleted)
 		require.Positive(t, numCompleted)
@@ -943,10 +956,16 @@ func benchmarkCompleter(
 			}
 		}
 
-		_, err := exec.JobInsertFastMany(ctx, insertParams)
+		_, err := exec.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+			Jobs:   insertParams,
+			Schema: "",
+		})
 		require.NoError(b, err)
 
-		jobs, err := exec.JobGetByKindMany(ctx, []string{"benchmark_kind"})
+		jobs, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{"benchmark_kind"},
+			Schema: "",
+		})
 		require.NoError(b, err)
 
 		return completer, &testBundle{

--- a/internal/jobexecutor/job_executor.go
+++ b/internal/jobexecutor/job_executor.go
@@ -116,6 +116,8 @@ type JobExecutor struct {
 	JobRow                   *rivertype.JobRow
 	MiddlewareLookupGlobal   middlewarelookup.MiddlewareLookupInterface
 	SchedulerInterval        time.Duration
+	Schema                   string
+	WorkerMiddleware         []rivertype.WorkerMiddleware
 	WorkUnit                 workunit.WorkUnit
 
 	// Meant to be used from within the job executor only.

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -50,6 +50,10 @@ type JobCleanerConfig struct {
 	// Interval is the amount of time to wait between runs of the cleaner.
 	Interval time.Duration
 
+	// Schema where River tables are located. Empty string omits schema, causing
+	// Postgres to default to `search_path`.
+	Schema string
+
 	// Timeout of the individual queries in the job cleaner.
 	Timeout time.Duration
 }
@@ -163,6 +167,7 @@ func (s *JobCleaner) runOnce(ctx context.Context) (*jobCleanerRunOnceResult, err
 				CompletedFinalizedAtHorizon: time.Now().Add(-s.Config.CompletedJobRetentionPeriod),
 				DiscardedFinalizedAtHorizon: time.Now().Add(-s.Config.DiscardedJobRetentionPeriod),
 				Max:                         s.batchSize,
+				Schema:                      s.Config.Schema,
 			})
 			if err != nil {
 				return 0, fmt.Errorf("error deleting completed jobs: %w", err)

--- a/internal/maintenance/job_cleaner_test.go
+++ b/internal/maintenance/job_cleaner_test.go
@@ -105,32 +105,32 @@ func TestJobCleaner(t *testing.T) {
 		cleaner.TestSignals.DeletedBatch.WaitOrTimeout()
 
 		var err error
-		_, err = bundle.exec.JobGetByID(ctx, job1.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job1.ID, Schema: cleaner.Config.Schema})
 		require.NotErrorIs(t, err, rivertype.ErrNotFound) // still there
-		_, err = bundle.exec.JobGetByID(ctx, job2.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job2.ID, Schema: cleaner.Config.Schema})
 		require.NotErrorIs(t, err, rivertype.ErrNotFound) // still there
-		_, err = bundle.exec.JobGetByID(ctx, job3.ID)
-		require.NotErrorIs(t, err, rivertype.ErrNotFound) // still there
-
-		_, err = bundle.exec.JobGetByID(ctx, cancelledJob1.ID)
-		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.JobGetByID(ctx, cancelledJob2.ID)
-		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.JobGetByID(ctx, cancelledJob3.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job3.ID, Schema: cleaner.Config.Schema})
 		require.NotErrorIs(t, err, rivertype.ErrNotFound) // still there
 
-		_, err = bundle.exec.JobGetByID(ctx, completedJob1.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: cancelledJob1.ID, Schema: cleaner.Config.Schema})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.JobGetByID(ctx, completedJob2.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: cancelledJob2.ID, Schema: cleaner.Config.Schema})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.JobGetByID(ctx, completedJob3.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: cancelledJob3.ID, Schema: cleaner.Config.Schema})
 		require.NotErrorIs(t, err, rivertype.ErrNotFound) // still there
 
-		_, err = bundle.exec.JobGetByID(ctx, discardedJob1.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: completedJob1.ID, Schema: cleaner.Config.Schema})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.JobGetByID(ctx, discardedJob2.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: completedJob2.ID, Schema: cleaner.Config.Schema})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.JobGetByID(ctx, discardedJob3.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: completedJob3.ID, Schema: cleaner.Config.Schema})
+		require.NotErrorIs(t, err, rivertype.ErrNotFound) // still there
+
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: discardedJob1.ID, Schema: cleaner.Config.Schema})
+		require.ErrorIs(t, err, rivertype.ErrNotFound)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: discardedJob2.ID, Schema: cleaner.Config.Schema})
+		require.ErrorIs(t, err, rivertype.ErrNotFound)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: discardedJob3.ID, Schema: cleaner.Config.Schema})
 		require.NotErrorIs(t, err, rivertype.ErrNotFound) // still there
 	})
 
@@ -158,7 +158,7 @@ func TestJobCleaner(t *testing.T) {
 		cleaner.TestSignals.DeletedBatch.WaitOrTimeout()
 
 		for _, job := range jobs {
-			_, err := bundle.exec.JobGetByID(ctx, job.ID)
+			_, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job.ID, Schema: cleaner.Config.Schema})
 			require.ErrorIs(t, err, rivertype.ErrNotFound)
 		}
 	})
@@ -228,9 +228,9 @@ func TestJobCleaner(t *testing.T) {
 		cleaner.TestSignals.DeletedBatch.WaitOrTimeout()
 
 		var err error
-		_, err = bundle.exec.JobGetByID(ctx, job1.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job1.ID, Schema: cleaner.Config.Schema})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.JobGetByID(ctx, job2.ID)
+		_, err = bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job2.ID, Schema: cleaner.Config.Schema})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
 	})
 }

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -50,6 +50,10 @@ type JobRescuerConfig struct {
 	// considered stuck and should be rescued.
 	RescueAfter time.Duration
 
+	// Schema where River tables are located. Empty string omits schema, causing
+	// Postgres to default to `search_path`.
+	Schema string
+
 	WorkUnitFactoryFunc func(kind string) workunit.WorkUnitFactory
 }
 
@@ -169,6 +173,7 @@ func (s *JobRescuer) runOnce(ctx context.Context) (*rescuerRunOnceResult, error)
 			Error:       make([][]byte, 0, len(stuckJobs)),
 			FinalizedAt: make([]time.Time, 0, len(stuckJobs)),
 			ScheduledAt: make([]time.Time, 0, len(stuckJobs)),
+			Schema:      s.Config.Schema,
 			State:       make([]string, 0, len(stuckJobs)),
 		}
 
@@ -247,6 +252,7 @@ func (s *JobRescuer) getStuckJobs(ctx context.Context) ([]*rivertype.JobRow, err
 
 	return s.exec.JobGetStuck(ctx, &riverdriver.JobGetStuckParams{
 		Max:          s.batchSize,
+		Schema:       s.Config.Schema,
 		StuckHorizon: stuckHorizon,
 	})
 }

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -136,7 +136,7 @@ func TestJobRescuer(t *testing.T) {
 		t.Parallel()
 		require := require.New(t)
 
-		cleaner, bundle := setup(t)
+		rescuer, bundle := setup(t)
 
 		stuckToRetryJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
 		stuckToRetryJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)})
@@ -163,13 +163,13 @@ func TestJobRescuer(t *testing.T) {
 		longTimeOutJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKindLongTimeout), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)})
 		longTimeOutJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKindLongTimeout), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-6 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)})
 
-		require.NoError(cleaner.Start(ctx))
+		require.NoError(rescuer.Start(ctx))
 
-		cleaner.TestSignals.FetchedBatch.WaitOrTimeout()
-		cleaner.TestSignals.UpdatedBatch.WaitOrTimeout()
+		rescuer.TestSignals.FetchedBatch.WaitOrTimeout()
+		rescuer.TestSignals.UpdatedBatch.WaitOrTimeout()
 
 		confirmRetried := func(jobBefore *rivertype.JobRow) {
-			jobAfter, err := bundle.exec.JobGetByID(ctx, jobBefore.ID)
+			jobAfter, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: jobBefore.ID, Schema: rescuer.Config.Schema})
 			require.NoError(err)
 			require.Equal(rivertype.JobStateRetryable, jobAfter.State)
 		}
@@ -177,46 +177,47 @@ func TestJobRescuer(t *testing.T) {
 		var err error
 		confirmRetried(stuckToRetryJob1)
 		confirmRetried(stuckToRetryJob2)
-		job3After, err := bundle.exec.JobGetByID(ctx, stuckToRetryJob3.ID)
+
+		job3After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: stuckToRetryJob3.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(stuckToRetryJob3.State, job3After.State) // not rescued
 
-		discardJob1After, err := bundle.exec.JobGetByID(ctx, stuckToDiscardJob1.ID)
+		discardJob1After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: stuckToDiscardJob1.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(rivertype.JobStateDiscarded, discardJob1After.State)
 		require.WithinDuration(time.Now(), *discardJob1After.FinalizedAt, 5*time.Second)
 		require.Len(discardJob1After.Errors, 1)
 
-		discardJob2After, err := bundle.exec.JobGetByID(ctx, stuckToDiscardJob2.ID)
+		discardJob2After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: stuckToDiscardJob2.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(rivertype.JobStateRunning, discardJob2After.State)
 		require.Nil(discardJob2After.FinalizedAt)
 
-		cancelJob1After, err := bundle.exec.JobGetByID(ctx, stuckToCancelJob1.ID)
+		cancelJob1After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: stuckToCancelJob1.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(rivertype.JobStateCancelled, cancelJob1After.State)
 		require.WithinDuration(time.Now(), *cancelJob1After.FinalizedAt, 5*time.Second)
 		require.Len(cancelJob1After.Errors, 1)
 
-		cancelJob2After, err := bundle.exec.JobGetByID(ctx, stuckToCancelJob2.ID)
+		cancelJob2After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: stuckToCancelJob2.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(rivertype.JobStateRunning, cancelJob2After.State)
 		require.Nil(cancelJob2After.FinalizedAt)
 
-		notRunningJob1After, err := bundle.exec.JobGetByID(ctx, notRunningJob1.ID)
+		notRunningJob1After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: notRunningJob1.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(notRunningJob1.State, notRunningJob1After.State)
-		notRunningJob2After, err := bundle.exec.JobGetByID(ctx, notRunningJob2.ID)
+		notRunningJob2After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: notRunningJob2.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(notRunningJob2.State, notRunningJob2After.State)
-		notRunningJob3After, err := bundle.exec.JobGetByID(ctx, notRunningJob3.ID)
+		notRunningJob3After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: notRunningJob3.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(notRunningJob3.State, notRunningJob3After.State)
 
-		notTimedOutJob1After, err := bundle.exec.JobGetByID(ctx, longTimeOutJob1.ID)
+		notTimedOutJob1After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: longTimeOutJob1.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(rivertype.JobStateRunning, notTimedOutJob1After.State)
-		notTimedOutJob2After, err := bundle.exec.JobGetByID(ctx, longTimeOutJob2.ID)
+		notTimedOutJob2After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: longTimeOutJob2.ID, Schema: rescuer.Config.Schema})
 		require.NoError(err)
 		require.Equal(rivertype.JobStateRetryable, notTimedOutJob2After.State)
 	})
@@ -224,12 +225,12 @@ func TestJobRescuer(t *testing.T) {
 	t.Run("RescuesInBatches", func(t *testing.T) {
 		t.Parallel()
 
-		cleaner, bundle := setup(t)
-		cleaner.batchSize = 10 // reduced size for test speed
+		rescuer, bundle := setup(t)
+		rescuer.batchSize = 10 // reduced size for test speed
 
 		// Add one to our chosen batch size to get one extra job and therefore
 		// one extra batch, ensuring that we've tested working multiple.
-		numJobs := cleaner.batchSize + 1
+		numJobs := rescuer.batchSize + 1
 
 		jobs := make([]*rivertype.JobRow, numJobs)
 
@@ -238,16 +239,16 @@ func TestJobRescuer(t *testing.T) {
 			jobs[i] = job
 		}
 
-		require.NoError(t, cleaner.Start(ctx))
+		require.NoError(t, rescuer.Start(ctx))
 
 		// See comment above. Exactly two batches are expected.
-		cleaner.TestSignals.FetchedBatch.WaitOrTimeout()
-		cleaner.TestSignals.UpdatedBatch.WaitOrTimeout()
-		cleaner.TestSignals.FetchedBatch.WaitOrTimeout()
-		cleaner.TestSignals.UpdatedBatch.WaitOrTimeout() // need to wait until after this for the conn to be free
+		rescuer.TestSignals.FetchedBatch.WaitOrTimeout()
+		rescuer.TestSignals.UpdatedBatch.WaitOrTimeout()
+		rescuer.TestSignals.FetchedBatch.WaitOrTimeout()
+		rescuer.TestSignals.UpdatedBatch.WaitOrTimeout() // need to wait until after this for the conn to be free
 
 		for _, job := range jobs {
-			jobUpdated, err := bundle.exec.JobGetByID(ctx, job.ID)
+			jobUpdated, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job.ID, Schema: rescuer.Config.Schema})
 			require.NoError(t, err)
 			require.Equal(t, rivertype.JobStateRetryable, jobUpdated.State)
 		}
@@ -319,10 +320,10 @@ func TestJobRescuer(t *testing.T) {
 		rescuer.TestSignals.FetchedBatch.WaitOrTimeout()
 		rescuer.TestSignals.UpdatedBatch.WaitOrTimeout()
 
-		job1After, err := bundle.exec.JobGetByID(ctx, job1.ID)
+		job1After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job1.ID, Schema: rescuer.Config.Schema})
 		require.NoError(t, err)
 		require.Equal(t, rivertype.JobStateDiscarded, job1After.State)
-		job2After, err := bundle.exec.JobGetByID(ctx, job2.ID)
+		job2After, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: job2.ID, Schema: rescuer.Config.Schema})
 		require.NoError(t, err)
 		require.Equal(t, rivertype.JobStateDiscarded, job2After.State)
 	})

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -52,6 +52,10 @@ type JobSchedulerConfig struct {
 	// NotifyInsert is a function to call to emit notifications for queues
 	// where jobs were scheduled.
 	NotifyInsert NotifyInsertFunc
+
+	// Schema where River tables are located. Empty string omits schema, causing
+	// Postgres to default to `search_path`.
+	Schema string
 }
 
 func (c *JobSchedulerConfig) mustValidate() *JobSchedulerConfig {
@@ -155,8 +159,9 @@ func (s *JobScheduler) runOnce(ctx context.Context) (*schedulerRunOnceResult, er
 			nowWithLookAhead := now.Add(s.config.Interval)
 
 			scheduledJobResults, err := tx.JobSchedule(ctx, &riverdriver.JobScheduleParams{
-				Max: s.config.Limit,
-				Now: nowWithLookAhead,
+				Max:    s.config.Limit,
+				Now:    nowWithLookAhead,
+				Schema: s.config.Schema,
 			})
 			if err != nil {
 				return 0, fmt.Errorf("error scheduling jobs: %w", err)

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -82,7 +82,10 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		finalInsertParams := sliceutil.Map(insertParams, func(params *rivertype.JobInsertParams) *riverdriver.JobInsertFastParams {
 			return (*riverdriver.JobInsertFastParams)(params)
 		})
-		results, err := tx.JobInsertFastMany(ctx, finalInsertParams)
+		results, err := tx.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+			Jobs:   finalInsertParams,
+			Schema: "",
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -109,12 +112,15 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		return svc, bundle
 	}
 
-	requireNJobs := func(t *testing.T, exec riverdriver.Executor, kind string, n int) []*rivertype.JobRow {
+	requireNJobs := func(t *testing.T, exec riverdriver.Executor, kind string, expectedNumJobs int) []*rivertype.JobRow {
 		t.Helper()
 
-		jobs, err := exec.JobGetByKindMany(ctx, []string{kind})
+		jobs, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+			Kind:   []string{kind},
+			Schema: "",
+		})
 		require.NoError(t, err)
-		require.Len(t, jobs, n, "Expected to find exactly %d job(s) of kind: %s, but found %d", n, kind, len(jobs))
+		require.Len(t, jobs, expectedNumJobs, "Expected to find exactly %d job(s) of kind: %s, but found %d", expectedNumJobs, kind, len(jobs))
 
 		return jobs
 	}

--- a/internal/maintenance/queue_cleaner.go
+++ b/internal/maintenance/queue_cleaner.go
@@ -35,9 +35,14 @@ func (ts *QueueCleanerTestSignals) Init() {
 type QueueCleanerConfig struct {
 	// Interval is the amount of time to wait between runs of the cleaner.
 	Interval time.Duration
+
 	// RetentionPeriod is the amount of time to keep queues around before they're
 	// removed.
 	RetentionPeriod time.Duration
+
+	// Schema where River tables are located. Empty string omits schema, causing
+	// Postgres to default to `search_path`.
+	Schema string
 }
 
 func (c *QueueCleanerConfig) mustValidate() *QueueCleanerConfig {
@@ -134,6 +139,7 @@ func (s *QueueCleaner) runOnce(ctx context.Context) (*queueCleanerRunOnceResult,
 
 			queuesDeleted, err := s.exec.QueueDeleteExpired(ctx, &riverdriver.QueueDeleteExpiredParams{
 				Max:              s.batchSize,
+				Schema:           s.Config.Schema,
 				UpdatedAtHorizon: time.Now().Add(-s.Config.RetentionPeriod),
 			})
 			if err != nil {

--- a/internal/maintenance/queue_cleaner_test.go
+++ b/internal/maintenance/queue_cleaner_test.go
@@ -90,16 +90,31 @@ func TestQueueCleaner(t *testing.T) {
 		cleaner.TestSignals.DeletedBatch.WaitOrTimeout()
 
 		var err error
-		_, err = bundle.exec.QueueGet(ctx, queue1.Name)
+		_, err = bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+			Name:   queue1.Name,
+			Schema: cleaner.Config.Schema,
+		})
 		require.NoError(t, err) // still there
-		_, err = bundle.exec.QueueGet(ctx, queue2.Name)
+		_, err = bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+			Name:   queue2.Name,
+			Schema: cleaner.Config.Schema,
+		})
 		require.NoError(t, err) // still there
 
-		_, err = bundle.exec.QueueGet(ctx, queue3.Name)
+		_, err = bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+			Name:   queue3.Name,
+			Schema: cleaner.Config.Schema,
+		})
 		require.ErrorIs(t, err, rivertype.ErrNotFound) // still there
-		_, err = bundle.exec.QueueGet(ctx, queue4.Name)
+		_, err = bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+			Name:   queue4.Name,
+			Schema: cleaner.Config.Schema,
+		})
 		require.ErrorIs(t, err, rivertype.ErrNotFound) // still there
-		_, err = bundle.exec.QueueGet(ctx, queue5.Name)
+		_, err = bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+			Name:   queue5.Name,
+			Schema: cleaner.Config.Schema,
+		})
 		require.ErrorIs(t, err, rivertype.ErrNotFound) // still there
 	})
 
@@ -130,7 +145,10 @@ func TestQueueCleaner(t *testing.T) {
 		cleaner.TestSignals.DeletedBatch.WaitOrTimeout()
 
 		for _, queue := range queues {
-			_, err := bundle.exec.QueueGet(ctx, queue.Name)
+			_, err := bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+				Name:   queue.Name,
+				Schema: cleaner.Config.Schema,
+			})
 			require.ErrorIs(t, err, rivertype.ErrNotFound)
 		}
 	})
@@ -200,9 +218,15 @@ func TestQueueCleaner(t *testing.T) {
 		cleaner.TestSignals.DeletedBatch.WaitOrTimeout()
 
 		var err error
-		_, err = bundle.exec.QueueGet(ctx, queue1.Name)
+		_, err = bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+			Name:   queue1.Name,
+			Schema: cleaner.Config.Schema,
+		})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
-		_, err = bundle.exec.QueueGet(ctx, queue2.Name)
+		_, err = bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
+			Name:   queue2.Name,
+			Schema: cleaner.Config.Schema,
+		})
 		require.ErrorIs(t, err, rivertype.ErrNotFound)
 	})
 }

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -43,7 +43,8 @@ func TestNotifier(t *testing.T) {
 		var (
 			dbPool   = riverinternaltest.TestDB(ctx, t)
 			driver   = riverpgxv5.New(dbPool)
-			listener = driver.GetListener()
+			schema   = "" // try to make tests schema-based rather than database-based in the future
+			listener = driver.GetListener(schema)
 		)
 
 		notifier := New(riversharedtest.BaseServiceArchetype(t), listener)
@@ -599,5 +600,5 @@ func sendNotification(ctx context.Context, t *testing.T, exec riverdriver.Execut
 	t.Helper()
 
 	t.Logf("Sending notification on %q: %s", topic, payload)
-	require.NoError(t, exec.NotifyMany(ctx, &riverdriver.NotifyManyParams{Payload: []string{payload}, Topic: topic}))
+	require.NoError(t, exec.NotifyMany(ctx, &riverdriver.NotifyManyParams{Payload: []string{payload}, Schema: "", Topic: topic}))
 }

--- a/job_complete_tx_test.go
+++ b/job_complete_tx_test.go
@@ -66,7 +66,10 @@ func TestJobCompleteTx(t *testing.T) {
 		require.Equal(t, rivertype.JobStateCompleted, completedJob.State)
 		require.WithinDuration(t, time.Now(), *completedJob.FinalizedAt, 2*time.Second)
 
-		updatedJob, err := bundle.exec.JobGetByID(ctx, job.ID)
+		updatedJob, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{
+			ID:     job.ID,
+			Schema: "",
+		})
 		require.NoError(t, err)
 		require.Equal(t, rivertype.JobStateCompleted, updatedJob.State)
 	})
@@ -88,7 +91,10 @@ func TestJobCompleteTx(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, rivertype.JobStateCompleted, completedJob.State)
 
-		updatedJob, err := bundle.exec.JobGetByID(ctx, job.ID)
+		updatedJob, err := bundle.exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{
+			ID:     job.ID,
+			Schema: "",
+		})
 		require.NoError(t, err)
 		require.Equal(t, rivertype.JobStateCompleted, updatedJob.State)
 	})
@@ -130,7 +136,7 @@ func TestJobCompleteTx(t *testing.T) {
 		})
 
 		// delete the job
-		_, err := bundle.exec.JobDelete(ctx, job.ID)
+		_, err := bundle.exec.JobDelete(ctx, &riverdriver.JobDeleteParams{ID: job.ID})
 		require.NoError(t, err)
 
 		// fake the job's state to work around the check:

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -53,7 +53,7 @@ type Driver[TTx any] interface {
 	// GetListener gets a listener for purposes of receiving notifications.
 	//
 	// API is not stable. DO NOT USE.
-	GetListener() Listener
+	GetListener(schema string) Listener
 
 	// GetMigrationFS gets a filesystem containing migrations for the driver.
 	//
@@ -100,76 +100,75 @@ type Executor interface {
 
 	// ColumnExists checks whether a column for a particular table exists for
 	// the schema in the current search schema.
-	ColumnExists(ctx context.Context, tableName, columnName string) (bool, error)
+	ColumnExists(ctx context.Context, params *ColumnExistsParams) (bool, error)
 
 	// Exec executes raw SQL. Used for migrations.
 	Exec(ctx context.Context, sql string) (struct{}, error)
 
 	JobCancel(ctx context.Context, params *JobCancelParams) (*rivertype.JobRow, error)
-	JobCountByState(ctx context.Context, state rivertype.JobState) (int, error)
-	JobDelete(ctx context.Context, id int64) (*rivertype.JobRow, error)
+	JobCountByState(ctx context.Context, params *JobCountByStateParams) (int, error)
+	JobDelete(ctx context.Context, params *JobDeleteParams) (*rivertype.JobRow, error)
 	JobDeleteBefore(ctx context.Context, params *JobDeleteBeforeParams) (int, error)
 	JobGetAvailable(ctx context.Context, params *JobGetAvailableParams) ([]*rivertype.JobRow, error)
-	JobGetByID(ctx context.Context, id int64) (*rivertype.JobRow, error)
-	JobGetByIDMany(ctx context.Context, id []int64) ([]*rivertype.JobRow, error)
-	JobGetByKindAndUniqueProperties(ctx context.Context, params *JobGetByKindAndUniquePropertiesParams) (*rivertype.JobRow, error)
-	JobGetByKindMany(ctx context.Context, kind []string) ([]*rivertype.JobRow, error)
+	JobGetByID(ctx context.Context, params *JobGetByIDParams) (*rivertype.JobRow, error)
+	JobGetByIDMany(ctx context.Context, params *JobGetByIDManyParams) ([]*rivertype.JobRow, error)
+	JobGetByKindMany(ctx context.Context, params *JobGetByKindManyParams) ([]*rivertype.JobRow, error)
 	JobGetStuck(ctx context.Context, params *JobGetStuckParams) ([]*rivertype.JobRow, error)
-	JobInsertFastMany(ctx context.Context, params []*JobInsertFastParams) ([]*JobInsertFastResult, error)
-	JobInsertFastManyNoReturning(ctx context.Context, params []*JobInsertFastParams) (int, error)
+	JobInsertFastMany(ctx context.Context, params *JobInsertFastManyParams) ([]*JobInsertFastResult, error)
+	JobInsertFastManyNoReturning(ctx context.Context, params *JobInsertFastManyParams) (int, error)
 	JobInsertFull(ctx context.Context, params *JobInsertFullParams) (*rivertype.JobRow, error)
 	JobList(ctx context.Context, params *JobListParams) ([]*rivertype.JobRow, error)
 	JobRescueMany(ctx context.Context, params *JobRescueManyParams) (*struct{}, error)
-	JobRetry(ctx context.Context, id int64) (*rivertype.JobRow, error)
+	JobRetry(ctx context.Context, params *JobRetryParams) (*rivertype.JobRow, error)
 	JobSchedule(ctx context.Context, params *JobScheduleParams) ([]*JobScheduleResult, error)
 	JobSetStateIfRunningMany(ctx context.Context, params *JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error)
 	JobUpdate(ctx context.Context, params *JobUpdateParams) (*rivertype.JobRow, error)
 	LeaderAttemptElect(ctx context.Context, params *LeaderElectParams) (bool, error)
 	LeaderAttemptReelect(ctx context.Context, params *LeaderElectParams) (bool, error)
-	LeaderDeleteExpired(ctx context.Context) (int, error)
-	LeaderGetElectedLeader(ctx context.Context) (*Leader, error)
+	LeaderDeleteExpired(ctx context.Context, params *LeaderDeleteExpiredParams) (int, error)
+	LeaderGetElectedLeader(ctx context.Context, params *LeaderGetElectedLeaderParams) (*Leader, error)
 	LeaderInsert(ctx context.Context, params *LeaderInsertParams) (*Leader, error)
 	LeaderResign(ctx context.Context, params *LeaderResignParams) (bool, error)
 
 	// MigrationDeleteAssumingMainMany deletes many migrations assuming
 	// everything is on the main line. This is suitable for use in databases on
 	// a version before the `line` column exists.
-	MigrationDeleteAssumingMainMany(ctx context.Context, versions []int) ([]*Migration, error)
+	MigrationDeleteAssumingMainMany(ctx context.Context, params *MigrationDeleteAssumingMainManyParams) ([]*Migration, error)
 
 	// MigrationDeleteByLineAndVersionMany deletes many migration versions on a
 	// particular line.
-	MigrationDeleteByLineAndVersionMany(ctx context.Context, line string, versions []int) ([]*Migration, error)
+	MigrationDeleteByLineAndVersionMany(ctx context.Context, params *MigrationDeleteByLineAndVersionManyParams) ([]*Migration, error)
 
 	// MigrationGetAllAssumingMain gets all migrations assuming everything is on
 	// the main line. This is suitable for use in databases on a version before
 	// the `line` column exists.
-	MigrationGetAllAssumingMain(ctx context.Context) ([]*Migration, error)
+	MigrationGetAllAssumingMain(ctx context.Context, params *MigrationGetAllAssumingMainParams) ([]*Migration, error)
 
 	// MigrationGetByLine gets all currently applied migrations.
-	MigrationGetByLine(ctx context.Context, line string) ([]*Migration, error)
+	MigrationGetByLine(ctx context.Context, params *MigrationGetByLineParams) ([]*Migration, error)
 
 	// MigrationInsertMany inserts many migration versions.
-	MigrationInsertMany(ctx context.Context, line string, versions []int) ([]*Migration, error)
+	MigrationInsertMany(ctx context.Context, params *MigrationInsertManyParams) ([]*Migration, error)
 
 	// MigrationInsertManyAssumingMain inserts many migrations, assuming they're
 	// on the main line. This operation is necessary for compatibility before
 	// the `line` column was added to the migrations table.
-	MigrationInsertManyAssumingMain(ctx context.Context, versions []int) ([]*Migration, error)
+	MigrationInsertManyAssumingMain(ctx context.Context, params *MigrationInsertManyAssumingMainParams) ([]*Migration, error)
 
 	NotifyMany(ctx context.Context, params *NotifyManyParams) error
 	PGAdvisoryXactLock(ctx context.Context, key int64) (*struct{}, error)
 
 	QueueCreateOrSetUpdatedAt(ctx context.Context, params *QueueCreateOrSetUpdatedAtParams) (*rivertype.Queue, error)
 	QueueDeleteExpired(ctx context.Context, params *QueueDeleteExpiredParams) ([]string, error)
-	QueueGet(ctx context.Context, name string) (*rivertype.Queue, error)
-	QueueList(ctx context.Context, limit int) ([]*rivertype.Queue, error)
-	QueuePause(ctx context.Context, name string) error
-	QueueResume(ctx context.Context, name string) error
+	QueueGet(ctx context.Context, params *QueueGetParams) (*rivertype.Queue, error)
+	QueueList(ctx context.Context, params *QueueListParams) ([]*rivertype.Queue, error)
+	QueuePause(ctx context.Context, params *QueuePauseParams) error
+	QueueResume(ctx context.Context, params *QueueResumeParams) error
 	QueueUpdate(ctx context.Context, params *QueueUpdateParams) (*rivertype.Queue, error)
 
 	// TableExists checks whether a table exists for the schema in the current
 	// search schema.
-	TableExists(ctx context.Context, tableName string) (bool, error)
+	TableExists(ctx context.Context, params *TableExistsParams) (bool, error)
 }
 
 // ExecutorTx is an executor which is a transaction. In addition to standard
@@ -199,6 +198,7 @@ type Listener interface {
 	Connect(ctx context.Context) error
 	Listen(ctx context.Context, topic string) error
 	Ping(ctx context.Context) error
+	Schema() string
 	Unlisten(ctx context.Context, topic string) error
 	WaitForNotification(ctx context.Context) (*Notification, error)
 }
@@ -208,10 +208,27 @@ type Notification struct {
 	Topic   string
 }
 
+type ColumnExistsParams struct {
+	Column string
+	Schema string
+	Table  string
+}
+
 type JobCancelParams struct {
+	ID                int64
 	CancelAttemptedAt time.Time
 	ControlTopic      string
-	ID                int64
+	Schema            string
+}
+
+type JobCountByStateParams struct {
+	Schema string
+	State  rivertype.JobState
+}
+
+type JobDeleteParams struct {
+	ID     int64
+	Schema string
 }
 
 type JobDeleteBeforeParams struct {
@@ -219,31 +236,36 @@ type JobDeleteBeforeParams struct {
 	CompletedFinalizedAtHorizon time.Time
 	DiscardedFinalizedAtHorizon time.Time
 	Max                         int
+	Schema                      string
 }
 
 type JobGetAvailableParams struct {
 	ClientID   string
 	Max        int
 	Now        *time.Time
-	Queue      string
 	ProducerID int64
+	Queue      string
+	Schema     string
 }
 
-type JobGetByKindAndUniquePropertiesParams struct {
-	Kind           string
-	ByArgs         bool
-	Args           []byte
-	ByCreatedAt    bool
-	CreatedAtBegin time.Time
-	CreatedAtEnd   time.Time
-	ByQueue        bool
-	Queue          string
-	ByState        bool
-	State          []string
+type JobGetByIDParams struct {
+	ID     int64
+	Schema string
+}
+
+type JobGetByIDManyParams struct {
+	ID     []int64
+	Schema string
+}
+
+type JobGetByKindManyParams struct {
+	Kind   []string
+	Schema string
 }
 
 type JobGetStuckParams struct {
 	Max          int
+	Schema       string
 	StuckHorizon time.Time
 }
 
@@ -266,6 +288,11 @@ type JobInsertFastParams struct {
 	UniqueStates byte
 }
 
+type JobInsertFastManyParams struct {
+	Jobs   []*JobInsertFastParams
+	Schema string
+}
+
 type JobInsertFastResult struct {
 	Job                      *rivertype.JobRow
 	UniqueSkippedAsDuplicate bool
@@ -285,6 +312,7 @@ type JobInsertFullParams struct {
 	Priority     int
 	Queue        string
 	ScheduledAt  *time.Time
+	Schema       string
 	State        rivertype.JobState
 	Tags         []string
 	UniqueKey    []byte
@@ -295,6 +323,7 @@ type JobListParams struct {
 	Max           int32
 	NamedArgs     map[string]any
 	OrderByClause string
+	Schema        string
 	WhereClause   string
 }
 
@@ -303,12 +332,19 @@ type JobRescueManyParams struct {
 	Error       [][]byte
 	FinalizedAt []time.Time
 	ScheduledAt []time.Time
+	Schema      string
 	State       []string
 }
 
+type JobRetryParams struct {
+	ID     int64
+	Schema string
+}
+
 type JobScheduleParams struct {
-	Max int
-	Now time.Time
+	Max    int
+	Now    time.Time
+	Schema string
 }
 
 type JobScheduleResult struct {
@@ -417,6 +453,7 @@ type JobSetStateIfRunningManyParams struct {
 	MetadataDoMerge []bool
 	MetadataUpdates [][]byte
 	ScheduledAt     []*time.Time
+	Schema          string
 	State           []rivertype.JobState
 }
 
@@ -432,6 +469,7 @@ type JobUpdateParams struct {
 	Errors              [][]byte
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
+	Schema              string
 	StateDoUpdate       bool
 	State               rivertype.JobState
 	// Deprecated and will be removed when advisory lock unique path is removed.
@@ -449,21 +487,32 @@ type Leader struct {
 	LeaderID  string
 }
 
+type LeaderDeleteExpiredParams struct {
+	Schema string
+}
+
+type LeaderGetElectedLeaderParams struct {
+	Schema string
+}
+
 type LeaderInsertParams struct {
 	ElectedAt *time.Time
 	ExpiresAt *time.Time
 	LeaderID  string
+	Schema    string
 	TTL       time.Duration
 }
 
 type LeaderElectParams struct {
 	LeaderID string
+	Schema   string
 	TTL      time.Duration
 }
 
 type LeaderResignParams struct {
 	LeaderID        string
 	LeadershipTopic string
+	Schema          string
 }
 
 // Migration represents a River migration.
@@ -486,16 +535,49 @@ type Migration struct {
 	Version int
 }
 
+type MigrationDeleteAssumingMainManyParams struct {
+	Schema   string
+	Versions []int
+}
+
+type MigrationDeleteByLineAndVersionManyParams struct {
+	Line     string
+	Schema   string
+	Versions []int
+}
+
+type MigrationGetAllAssumingMainParams struct {
+	Schema string
+}
+
+type MigrationGetByLineParams struct {
+	Line   string
+	Schema string
+}
+
+type MigrationInsertManyParams struct {
+	Line     string
+	Schema   string
+	Versions []int
+}
+
+type MigrationInsertManyAssumingMainParams struct {
+	Schema   string
+	Versions []int
+}
+
 // NotifyManyParams are parameters to issue many pubsub notifications all at
 // once for a single topic.
 type NotifyManyParams struct {
 	Payload []string
 	Topic   string
+	Schema  string
 }
 
 type ProducerKeepAliveParams struct {
 	ID                    int64
 	QueueName             string
+	Schema                string
 	StaleUpdatedAtHorizon time.Time
 }
 
@@ -503,16 +585,44 @@ type QueueCreateOrSetUpdatedAtParams struct {
 	Metadata  []byte
 	Name      string
 	PausedAt  *time.Time
+	Schema    string
 	UpdatedAt *time.Time
 }
 
 type QueueDeleteExpiredParams struct {
 	Max              int
+	Schema           string
 	UpdatedAtHorizon time.Time
+}
+
+type QueueGetParams struct {
+	Name   string
+	Schema string
+}
+
+type QueueListParams struct {
+	Limit  int
+	Schema string
+}
+
+type QueuePauseParams struct {
+	Name   string
+	Schema string
+}
+
+type QueueResumeParams struct {
+	Name   string
+	Schema string
 }
 
 type QueueUpdateParams struct {
 	Metadata         []byte
 	MetadataDoUpdate bool
 	Name             string
+	Schema           string
+}
+
+type TableExistsParams struct {
+	Schema string
+	Table  string
 }

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_client.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_client.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const clientCreateOrSetUpdatedAt = `-- name: ClientCreateOrSetUpdatedAt :one
-INSERT INTO river_client (
+INSERT INTO /* TEMPLATE: schema */river_client (
     id,
     metadata,
     paused_at,

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_client_queue.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_client_queue.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const clientQueueCreateOrSetUpdatedAtMany = `-- name: ClientQueueCreateOrSetUpdatedAtMany :one
-INSERT INTO river_client_queue (
+INSERT INTO /* TEMPLATE: schema */river_client_queue (
     metadata,
     name,
     paused_at,

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
@@ -7,11 +7,12 @@ package dbsqlc
 
 import (
 	"context"
+	"database/sql"
 	"time"
 )
 
 const leaderAttemptElect = `-- name: LeaderAttemptElect :execrows
-INSERT INTO river_leader(leader_id, elected_at, expires_at)
+INSERT INTO /* TEMPLATE: schema */river_leader (leader_id, elected_at, expires_at)
     VALUES ($1, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO NOTHING
@@ -31,7 +32,7 @@ func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAt
 }
 
 const leaderAttemptReelect = `-- name: LeaderAttemptReelect :execrows
-INSERT INTO river_leader(leader_id, elected_at, expires_at)
+INSERT INTO /* TEMPLATE: schema */river_leader (leader_id, elected_at, expires_at)
     VALUES ($1, now(), now() + $2::interval)
 ON CONFLICT (name)
     DO UPDATE SET
@@ -54,7 +55,7 @@ func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg *Leader
 }
 
 const leaderDeleteExpired = `-- name: LeaderDeleteExpired :execrows
-DELETE FROM river_leader
+DELETE FROM /* TEMPLATE: schema */river_leader
 WHERE expires_at < now()
 `
 
@@ -68,7 +69,7 @@ func (q *Queries) LeaderDeleteExpired(ctx context.Context, db DBTX) (int64, erro
 
 const leaderGetElectedLeader = `-- name: LeaderGetElectedLeader :one
 SELECT elected_at, expires_at, leader_id, name
-FROM river_leader
+FROM /* TEMPLATE: schema */river_leader
 `
 
 func (q *Queries) LeaderGetElectedLeader(ctx context.Context, db DBTX) (*RiverLeader, error) {
@@ -84,7 +85,7 @@ func (q *Queries) LeaderGetElectedLeader(ctx context.Context, db DBTX) (*RiverLe
 }
 
 const leaderInsert = `-- name: LeaderInsert :one
-INSERT INTO river_leader(
+INSERT INTO /* TEMPLATE: schema */river_leader(
     elected_at,
     expires_at,
     leader_id
@@ -122,27 +123,28 @@ func (q *Queries) LeaderInsert(ctx context.Context, db DBTX, arg *LeaderInsertPa
 const leaderResign = `-- name: LeaderResign :execrows
 WITH currently_held_leaders AS (
   SELECT elected_at, expires_at, leader_id, name
-  FROM river_leader
+  FROM /* TEMPLATE: schema */river_leader
   WHERE leader_id = $1::text
   FOR UPDATE
 ),
 notified_resignations AS (
     SELECT pg_notify(
-        concat(current_schema(), '.', $2::text),
+        concat(coalesce($2::text, current_schema()), '.', $3::text),
         json_build_object('leader_id', leader_id, 'action', 'resigned')::text
     )
     FROM currently_held_leaders
 )
-DELETE FROM river_leader USING notified_resignations
+DELETE FROM /* TEMPLATE: schema */river_leader USING notified_resignations
 `
 
 type LeaderResignParams struct {
 	LeaderID        string
+	Schema          sql.NullString
 	LeadershipTopic string
 }
 
 func (q *Queries) LeaderResign(ctx context.Context, db DBTX, arg *LeaderResignParams) (int64, error) {
-	result, err := db.ExecContext(ctx, leaderResign, arg.LeaderID, arg.LeadershipTopic)
+	result, err := db.ExecContext(ctx, leaderResign, arg.LeaderID, arg.Schema, arg.LeadershipTopic)
 	if err != nil {
 		return 0, err
 	}

--- a/riverdriver/riverdatabasesql/migration/main/001_create_river_migration.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/001_create_river_migration.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE river_migration;
+DROP TABLE /* TEMPLATE: schema */river_migration;

--- a/riverdriver/riverdatabasesql/migration/main/001_create_river_migration.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/001_create_river_migration.up.sql
@@ -1,8 +1,8 @@
-CREATE TABLE river_migration(
+CREATE TABLE /* TEMPLATE: schema */river_migration(
   id bigserial PRIMARY KEY,
   created_at timestamptz NOT NULL DEFAULT NOW(),
   version bigint NOT NULL,
   CONSTRAINT version CHECK (version >= 1)
 );
 
-CREATE UNIQUE INDEX ON river_migration USING btree(version);
+CREATE UNIQUE INDEX ON /* TEMPLATE: schema */river_migration USING btree(version);

--- a/riverdriver/riverdatabasesql/migration/main/002_initial_schema.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/002_initial_schema.down.sql
@@ -1,5 +1,5 @@
-DROP TABLE river_job;
-DROP FUNCTION river_job_notify;
-DROP TYPE river_job_state;
+DROP TABLE /* TEMPLATE: schema */river_job;
+DROP FUNCTION /* TEMPLATE: schema */river_job_notify;
+DROP TYPE /* TEMPLATE: schema */river_job_state;
 
-DROP TABLE river_leader;
+DROP TABLE /* TEMPLATE: schema */river_leader;

--- a/riverdriver/riverdatabasesql/migration/main/002_initial_schema.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/002_initial_schema.up.sql
@@ -1,4 +1,4 @@
-CREATE TYPE river_job_state AS ENUM(
+CREATE TYPE /* TEMPLATE: schema */river_job_state AS ENUM(
   'available',
   'cancelled',
   'completed',
@@ -8,7 +8,7 @@ CREATE TYPE river_job_state AS ENUM(
   'scheduled'
 );
 
-CREATE TABLE river_job(
+CREATE TABLE /* TEMPLATE: schema */river_job(
   -- 8 bytes
   id bigserial PRIMARY KEY,
 
@@ -49,17 +49,17 @@ CREATE TABLE river_job(
 
 -- We may want to consider adding another property here after `kind` if it seems
 -- like it'd be useful for something.
-CREATE INDEX river_job_kind ON river_job USING btree(kind);
+CREATE INDEX river_job_kind ON /* TEMPLATE: schema */river_job USING btree(kind);
 
-CREATE INDEX river_job_state_and_finalized_at_index ON river_job USING btree(state, finalized_at) WHERE finalized_at IS NOT NULL;
+CREATE INDEX river_job_state_and_finalized_at_index ON /* TEMPLATE: schema */river_job USING btree(state, finalized_at) WHERE finalized_at IS NOT NULL;
 
-CREATE INDEX river_job_prioritized_fetching_index ON river_job USING btree(state, queue, priority, scheduled_at, id);
+CREATE INDEX river_job_prioritized_fetching_index ON /* TEMPLATE: schema */river_job USING btree(state, queue, priority, scheduled_at, id);
 
-CREATE INDEX river_job_args_index ON river_job USING GIN(args);
+CREATE INDEX river_job_args_index ON /* TEMPLATE: schema */river_job USING GIN(args);
 
-CREATE INDEX river_job_metadata_index ON river_job USING GIN(metadata);
+CREATE INDEX river_job_metadata_index ON /* TEMPLATE: schema */river_job USING GIN(metadata);
 
-CREATE OR REPLACE FUNCTION river_job_notify()
+CREATE OR REPLACE FUNCTION /* TEMPLATE: schema */river_job_notify()
   RETURNS TRIGGER
   AS $$
 DECLARE
@@ -78,11 +78,11 @@ $$
 LANGUAGE plpgsql;
 
 CREATE TRIGGER river_notify
-  AFTER INSERT ON river_job
+  AFTER INSERT ON /* TEMPLATE: schema */river_job
   FOR EACH ROW
-  EXECUTE PROCEDURE river_job_notify();
+  EXECUTE PROCEDURE /* TEMPLATE: schema */river_job_notify();
 
-CREATE UNLOGGED TABLE river_leader(
+CREATE UNLOGGED TABLE /* TEMPLATE: schema */river_leader(
   -- 8 bytes each (no alignment needed)
   elected_at timestamptz NOT NULL,
   expires_at timestamptz NOT NULL,

--- a/riverdriver/riverdatabasesql/migration/main/003_river_job_tags_non_null.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/003_river_job_tags_non_null.down.sql
@@ -1,2 +1,3 @@
-ALTER TABLE river_job ALTER COLUMN tags DROP NOT NULL,
-                      ALTER COLUMN tags DROP DEFAULT;
+ALTER TABLE /* TEMPLATE: schema */river_job
+    ALTER COLUMN tags DROP NOT NULL,
+    ALTER COLUMN tags DROP DEFAULT;

--- a/riverdriver/riverdatabasesql/migration/main/003_river_job_tags_non_null.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/003_river_job_tags_non_null.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE river_job ALTER COLUMN tags SET DEFAULT '{}';
-UPDATE river_job SET tags = '{}' WHERE tags IS NULL;
-ALTER TABLE river_job ALTER COLUMN tags SET NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN tags SET DEFAULT '{}';
+UPDATE /* TEMPLATE: schema */river_job SET tags = '{}' WHERE tags IS NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN tags SET NOT NULL;

--- a/riverdriver/riverdatabasesql/migration/main/004_pending_and_more.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/004_pending_and_more.down.sql
@@ -1,17 +1,17 @@
-ALTER TABLE river_job ALTER COLUMN args DROP NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args DROP NOT NULL;
 
-ALTER TABLE river_job ALTER COLUMN metadata DROP NOT NULL;
-ALTER TABLE river_job ALTER COLUMN metadata DROP DEFAULT;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata DROP NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata DROP DEFAULT;
 
 -- It is not possible to safely remove 'pending' from the river_job_state enum,
 -- so leave it in place.
 
-ALTER TABLE river_job DROP CONSTRAINT finalized_or_finalized_at_null;
-ALTER TABLE river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
+ALTER TABLE /* TEMPLATE: schema */river_job DROP CONSTRAINT finalized_or_finalized_at_null;
+ALTER TABLE /* TEMPLATE: schema */river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
   (state IN ('cancelled', 'completed', 'discarded') AND finalized_at IS NOT NULL) OR finalized_at IS NULL
 );
 
-CREATE OR REPLACE FUNCTION river_job_notify()
+CREATE OR REPLACE FUNCTION /* TEMPLATE: schema */river_job_notify()
   RETURNS TRIGGER
   AS $$
 DECLARE
@@ -30,13 +30,13 @@ $$
 LANGUAGE plpgsql;
 
 CREATE TRIGGER river_notify
-  AFTER INSERT ON river_job
+  AFTER INSERT ON /* TEMPLATE: schema */river_job
   FOR EACH ROW
-  EXECUTE PROCEDURE river_job_notify();
+  EXECUTE PROCEDURE /* TEMPLATE: schema */river_job_notify();
 
-DROP TABLE river_queue;
+DROP TABLE /* TEMPLATE: schema */river_queue;
 
-ALTER TABLE river_leader
+ALTER TABLE /* TEMPLATE: schema */river_leader
     ALTER COLUMN name DROP DEFAULT,
     DROP CONSTRAINT name_length,
     ADD CONSTRAINT name_length CHECK (char_length(name) > 0 AND char_length(name) < 128);

--- a/riverdriver/riverdatabasesql/migration/main/004_pending_and_more.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/004_pending_and_more.up.sql
@@ -1,29 +1,29 @@
 -- The args column never had a NOT NULL constraint or default value at the
 -- database level, though we tried to ensure one at the application level.
-ALTER TABLE river_job ALTER COLUMN args SET DEFAULT '{}';
-UPDATE river_job SET args = '{}' WHERE args IS NULL;
-ALTER TABLE river_job ALTER COLUMN args SET NOT NULL;
-ALTER TABLE river_job ALTER COLUMN args DROP DEFAULT;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args SET DEFAULT '{}';
+UPDATE /* TEMPLATE: schema */river_job SET args = '{}' WHERE args IS NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args SET NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args DROP DEFAULT;
 
 -- The metadata column never had a NOT NULL constraint or default value at the
 -- database level, though we tried to ensure one at the application level.
-ALTER TABLE river_job ALTER COLUMN metadata SET DEFAULT '{}';
-UPDATE river_job SET metadata = '{}' WHERE metadata IS NULL;
-ALTER TABLE river_job ALTER COLUMN metadata SET NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata SET DEFAULT '{}';
+UPDATE /* TEMPLATE: schema */river_job SET metadata = '{}' WHERE metadata IS NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata SET NOT NULL;
 
 -- The 'pending' job state will be used for upcoming functionality:
-ALTER TYPE river_job_state ADD VALUE IF NOT EXISTS 'pending' AFTER 'discarded';
+ALTER TYPE /* TEMPLATE: schema */river_job_state ADD VALUE IF NOT EXISTS 'pending' AFTER 'discarded';
 
-ALTER TABLE river_job DROP CONSTRAINT finalized_or_finalized_at_null;
-ALTER TABLE river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
+ALTER TABLE /* TEMPLATE: schema */river_job DROP CONSTRAINT finalized_or_finalized_at_null;
+ALTER TABLE /* TEMPLATE: schema */river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
     (finalized_at IS NULL AND state NOT IN ('cancelled', 'completed', 'discarded')) OR
     (finalized_at IS NOT NULL AND state IN ('cancelled', 'completed', 'discarded'))
 );
 
-DROP TRIGGER river_notify ON river_job;
-DROP FUNCTION river_job_notify;
+DROP TRIGGER river_notify ON /* TEMPLATE: schema */river_job;
+DROP FUNCTION /* TEMPLATE: schema */river_job_notify;
 
-CREATE TABLE river_queue(
+CREATE TABLE /* TEMPLATE: schema */river_queue(
   name text PRIMARY KEY NOT NULL,
   created_at timestamptz NOT NULL DEFAULT NOW(),
   metadata jsonb NOT NULL DEFAULT '{}' ::jsonb,
@@ -31,7 +31,7 @@ CREATE TABLE river_queue(
   updated_at timestamptz NOT NULL
 );
 
-ALTER TABLE river_leader
+ALTER TABLE /* TEMPLATE: schema */river_leader
     ALTER COLUMN name SET DEFAULT 'default',
     DROP CONSTRAINT name_length,
     ADD CONSTRAINT name_length CHECK (name = 'default');

--- a/riverdriver/riverdatabasesql/migration/main/005_migration_unique_client.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/005_migration_unique_client.down.sql
@@ -10,33 +10,33 @@ BEGIN
     -- Tolerate users who may be using their own migration system rather than
     -- River's. If they are, they will have skipped version 001 containing
     -- `CREATE TABLE river_migration`, so this table won't exist.
-    IF (SELECT to_regclass('river_migration') IS NOT NULL) THEN
+    IF (SELECT to_regclass('/* TEMPLATE: schema */river_migration') IS NOT NULL) THEN
         IF EXISTS (
             SELECT *
-            FROM river_migration
+            FROM /* TEMPLATE: schema */river_migration
             WHERE line <> 'main'
         ) THEN
             RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
         END IF;
 
-        ALTER TABLE river_migration
+        ALTER TABLE /* TEMPLATE: schema */river_migration
             RENAME TO river_migration_old;
 
-        CREATE TABLE river_migration(
+        CREATE TABLE /* TEMPLATE: schema */river_migration(
             id bigserial PRIMARY KEY,
             created_at timestamptz NOT NULL DEFAULT NOW(),
             version bigint NOT NULL,
             CONSTRAINT version CHECK (version >= 1)
         );
 
-        CREATE UNIQUE INDEX ON river_migration USING btree(version);
+        CREATE UNIQUE INDEX ON /* TEMPLATE: schema */river_migration USING btree(version);
 
-        INSERT INTO river_migration
+        INSERT INTO /* TEMPLATE: schema */river_migration
             (created_at, version)
         SELECT created_at, version
-        FROM river_migration_old;
+        FROM /* TEMPLATE: schema */river_migration_old;
 
-        DROP TABLE river_migration_old;
+        DROP TABLE /* TEMPLATE: schema */river_migration_old;
     END IF;
 END;
 $body$
@@ -46,12 +46,12 @@ LANGUAGE 'plpgsql';
 -- Drop `river_job.unique_key`.
 --
 
-ALTER TABLE river_job
+ALTER TABLE /* TEMPLATE: schema */river_job
     DROP COLUMN unique_key;
 
 --
 -- Drop `river_client` and derivative.
 --
 
-DROP TABLE river_client_queue;
-DROP TABLE river_client;
+DROP TABLE /* TEMPLATE: schema */river_client_queue;
+DROP TABLE /* TEMPLATE: schema */river_client;

--- a/riverdriver/riverdatabasesql/migration/main/005_migration_unique_client.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/005_migration_unique_client.up.sql
@@ -8,11 +8,11 @@ BEGIN
     -- Tolerate users who may be using their own migration system rather than
     -- River's. If they are, they will have skipped version 001 containing
     -- `CREATE TABLE river_migration`, so this table won't exist.
-    IF (SELECT to_regclass('river_migration') IS NOT NULL) THEN
-        ALTER TABLE river_migration
+    IF (SELECT to_regclass('/* TEMPLATE: schema */river_migration') IS NOT NULL) THEN
+        ALTER TABLE /* TEMPLATE: schema */river_migration
             RENAME TO river_migration_old;
 
-        CREATE TABLE river_migration(
+        CREATE TABLE /* TEMPLATE: schema */river_migration(
             line TEXT NOT NULL,
             version bigint NOT NULL,
             created_at timestamptz NOT NULL DEFAULT NOW(),
@@ -21,12 +21,12 @@ BEGIN
             PRIMARY KEY (line, version)
         );
 
-        INSERT INTO river_migration
+        INSERT INTO /* TEMPLATE: schema */river_migration
             (created_at, line, version)
         SELECT created_at, 'main', version
-        FROM river_migration_old;
+        FROM /* TEMPLATE: schema */river_migration_old;
 
-        DROP TABLE river_migration_old;
+        DROP TABLE /* TEMPLATE: schema */river_migration_old;
     END IF;
 END;
 $body$
@@ -39,10 +39,10 @@ LANGUAGE 'plpgsql';
 -- These statements use `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this
 -- migration, then follow by completing the migration.
-ALTER TABLE river_job
+ALTER TABLE /* TEMPLATE: schema */river_job
     ADD COLUMN IF NOT EXISTS unique_key bytea;
 
-CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON /* TEMPLATE: schema */river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
 
 --
 -- Create `river_client` and derivative.
@@ -52,7 +52,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON river_job (ki
 -- additional migration.
 --
 
-CREATE UNLOGGED TABLE river_client (
+CREATE UNLOGGED TABLE /* TEMPLATE: schema */river_client (
     id text PRIMARY KEY NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),
     metadata jsonb NOT NULL DEFAULT '{}',
@@ -63,7 +63,7 @@ CREATE UNLOGGED TABLE river_client (
 
 -- Differs from `river_queue` in that it tracks the queue state for a particular
 -- active client.
-CREATE UNLOGGED TABLE river_client_queue (
+CREATE UNLOGGED TABLE /* TEMPLATE: schema */river_client_queue (
     river_client_id text NOT NULL REFERENCES river_client (id) ON DELETE CASCADE,
     name text NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),

--- a/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.down.sql
+++ b/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.down.sql
@@ -3,14 +3,14 @@
 -- Drop `river_job.unique_states` and its index.
 --
 
-DROP INDEX river_job_unique_idx;
+DROP INDEX /* TEMPLATE: schema */river_job_unique_idx;
 
-ALTER TABLE river_job
+ALTER TABLE /* TEMPLATE: schema */river_job
     DROP COLUMN unique_states;
 
-CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON /* TEMPLATE: schema */river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
 
 --
 -- Drop `river_job_state_in_bitmask` function.
 --
-DROP FUNCTION river_job_state_in_bitmask;
+DROP FUNCTION /* TEMPLATE: schema */river_job_state_in_bitmask;

--- a/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.up.sql
+++ b/riverdriver/riverdatabasesql/migration/main/006_bulk_unique.up.sql
@@ -1,5 +1,5 @@
 
-CREATE OR REPLACE FUNCTION river_job_state_in_bitmask(bitmask BIT(8), state river_job_state)
+CREATE OR REPLACE FUNCTION /* TEMPLATE: schema */river_job_state_in_bitmask(bitmask BIT(8), state river_job_state)
 RETURNS boolean
 LANGUAGE SQL
 IMMUTABLE
@@ -23,12 +23,12 @@ $$;
 -- This column may exist already if users manually created the column and index
 -- as instructed in the changelog so the index could be created `CONCURRENTLY`.
 --
-ALTER TABLE river_job ADD COLUMN IF NOT EXISTS unique_states BIT(8);
+ALTER TABLE /* TEMPLATE: schema */river_job ADD COLUMN IF NOT EXISTS unique_states BIT(8);
 
 -- This statement uses `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this
 -- migration, then follow by completing the migration.
-CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON river_job (unique_key)
+CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON /* TEMPLATE: schema */river_job (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
       AND river_job_state_in_bitmask(unique_states, state);
@@ -38,4 +38,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON river_job (unique_key)
 -- subsequent migration once all jobs using the old unique system have been
 -- completed (i.e. no more rows with non-null unique_key and null
 -- unique_states).
-DROP INDEX river_job_kind_unique_key_idx;
+DROP INDEX /* TEMPLATE: schema */river_job_kind_unique_key_idx;

--- a/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
@@ -1,6 +1,7 @@
 package riverdatabasesql
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/rivershared/sqlctemplate"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -86,4 +88,46 @@ func TestReplaceNamed(t *testing.T) {
 			require.Equal(t, tt.ExpectedSQL, actualSQL)
 		})
 	}
+}
+
+func TestSchemaTemplateParam(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct{}
+
+	setup := func(t *testing.T) (*sqlctemplate.Replacer, *testBundle) { //nolint:unparam
+		t.Helper()
+
+		return &sqlctemplate.Replacer{}, &testBundle{}
+	}
+
+	t.Run("NoSchema", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		updatedSQL, _, err := replacer.RunSafely(
+			schemaTemplateParam(ctx, ""),
+			"SELECT 1 FROM /* TEMPLATE: schema */river_job",
+			nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1 FROM river_job", updatedSQL)
+	})
+
+	t.Run("WithSchema", func(t *testing.T) {
+		t.Parallel()
+
+		replacer, _ := setup(t)
+
+		updatedSQL, _, err := replacer.RunSafely(
+			schemaTemplateParam(ctx, "custom_schema"),
+			"SELECT 1 FROM /* TEMPLATE: schema */river_job",
+			nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "SELECT 1 FROM custom_schema.river_job", updatedSQL)
+	})
 }

--- a/riverdriver/riverpgxv5/internal/dbsqlc/pg_misc.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/pg_misc.sql
@@ -4,7 +4,7 @@ SELECT pg_advisory_xact_lock(@key);
 -- name: PGNotifyMany :exec
 WITH topic_to_notify AS (
     SELECT
-        concat(current_schema(), '.', @topic::text) AS topic,
+        concat(coalesce(sqlc.narg('schema')::text, current_schema()), '.', @topic::text) AS topic,
         unnest(@payload::text[]) AS payload
 )
 SELECT pg_notify(

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_client.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_client.sql
@@ -8,7 +8,7 @@ CREATE UNLOGGED TABLE river_client (
 );
 
 -- name: ClientCreateOrSetUpdatedAt :one
-INSERT INTO river_client (
+INSERT INTO /* TEMPLATE: schema */river_client (
     id,
     metadata,
     paused_at,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_client.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_client.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const clientCreateOrSetUpdatedAt = `-- name: ClientCreateOrSetUpdatedAt :one
-INSERT INTO river_client (
+INSERT INTO /* TEMPLATE: schema */river_client (
     id,
     metadata,
     paused_at,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_client_queue.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_client_queue.sql
@@ -14,7 +14,7 @@ CREATE UNLOGGED TABLE river_client_queue (
 );
 
 -- name: ClientQueueCreateOrSetUpdatedAtMany :one
-INSERT INTO river_client_queue (
+INSERT INTO /* TEMPLATE: schema */river_client_queue (
     metadata,
     name,
     paused_at,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_client_queue.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_client_queue.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const clientQueueCreateOrSetUpdatedAtMany = `-- name: ClientQueueCreateOrSetUpdatedAtMany :one
-INSERT INTO river_client_queue (
+INSERT INTO /* TEMPLATE: schema */river_client_queue (
     metadata,
     name,
     paused_at,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job_copyfrom.sql
@@ -1,5 +1,5 @@
 -- name: JobInsertFastManyCopyFrom :copyfrom
-INSERT INTO river_job(
+INSERT INTO /* TEMPLATE: schema */river_job(
     args,
     created_at,
     kind,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql
@@ -8,14 +8,14 @@ CREATE TABLE river_migration(
 );
 
 -- name: RiverMigrationDeleteAssumingMainMany :many
-DELETE FROM river_migration
+DELETE FROM /* TEMPLATE: schema */river_migration
 WHERE version = any(@version::bigint[])
 RETURNING
     created_at,
     version;
 
 -- name: RiverMigrationDeleteByLineAndVersionMany :many
-DELETE FROM river_migration
+DELETE FROM /* TEMPLATE: schema */river_migration
 WHERE line = @line
     AND version = any(@version::bigint[])
 RETURNING *;
@@ -30,17 +30,17 @@ RETURNING *;
 SELECT
     created_at,
     version
-FROM river_migration
+FROM /* TEMPLATE: schema */river_migration
 ORDER BY version;
 
 -- name: RiverMigrationGetByLine :many
 SELECT *
-FROM river_migration
+FROM /* TEMPLATE: schema */river_migration
 WHERE line = @line
 ORDER BY version;
 
 -- name: RiverMigrationInsert :one
-INSERT INTO river_migration (
+INSERT INTO /* TEMPLATE: schema */river_migration (
     line,
     version
 ) VALUES (
@@ -49,7 +49,7 @@ INSERT INTO river_migration (
 ) RETURNING *;
 
 -- name: RiverMigrationInsertMany :many
-INSERT INTO river_migration (
+INSERT INTO /* TEMPLATE: schema */river_migration (
     line,
     version
 )
@@ -59,7 +59,7 @@ SELECT
 RETURNING *;
 
 -- name: RiverMigrationInsertManyAssumingMain :many
-INSERT INTO river_migration (
+INSERT INTO /* TEMPLATE: schema */river_migration (
     version
 )
 SELECT
@@ -73,10 +73,10 @@ SELECT EXISTS (
     SELECT column_name
     FROM information_schema.columns 
     WHERE table_name = @table_name::text
-        AND table_schema = CURRENT_SCHEMA
+        AND table_schema = /* TEMPLATE_BEGIN: schema */ CURRENT_SCHEMA /* TEMPLATE_END */
         AND column_name = @column_name::text
 );
 
 -- name: TableExists :one
-SELECT CASE WHEN to_regclass(@table_name) IS NULL THEN false
+SELECT CASE WHEN to_regclass(@schema_and_table) IS NULL THEN false
             ELSE true END;

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_migration.sql.go
@@ -15,7 +15,7 @@ SELECT EXISTS (
     SELECT column_name
     FROM information_schema.columns 
     WHERE table_name = $1::text
-        AND table_schema = CURRENT_SCHEMA
+        AND table_schema = /* TEMPLATE_BEGIN: schema */ CURRENT_SCHEMA /* TEMPLATE_END */
         AND column_name = $2::text
 )
 `
@@ -33,7 +33,7 @@ func (q *Queries) ColumnExists(ctx context.Context, db DBTX, arg *ColumnExistsPa
 }
 
 const riverMigrationDeleteAssumingMainMany = `-- name: RiverMigrationDeleteAssumingMainMany :many
-DELETE FROM river_migration
+DELETE FROM /* TEMPLATE: schema */river_migration
 WHERE version = any($1::bigint[])
 RETURNING
     created_at,
@@ -66,7 +66,7 @@ func (q *Queries) RiverMigrationDeleteAssumingMainMany(ctx context.Context, db D
 }
 
 const riverMigrationDeleteByLineAndVersionMany = `-- name: RiverMigrationDeleteByLineAndVersionMany :many
-DELETE FROM river_migration
+DELETE FROM /* TEMPLATE: schema */river_migration
 WHERE line = $1
     AND version = any($2::bigint[])
 RETURNING line, version, created_at
@@ -101,7 +101,7 @@ const riverMigrationGetAllAssumingMain = `-- name: RiverMigrationGetAllAssumingM
 SELECT
     created_at,
     version
-FROM river_migration
+FROM /* TEMPLATE: schema */river_migration
 ORDER BY version
 `
 
@@ -137,7 +137,7 @@ func (q *Queries) RiverMigrationGetAllAssumingMain(ctx context.Context, db DBTX)
 
 const riverMigrationGetByLine = `-- name: RiverMigrationGetByLine :many
 SELECT line, version, created_at
-FROM river_migration
+FROM /* TEMPLATE: schema */river_migration
 WHERE line = $1
 ORDER BY version
 `
@@ -163,7 +163,7 @@ func (q *Queries) RiverMigrationGetByLine(ctx context.Context, db DBTX, line str
 }
 
 const riverMigrationInsert = `-- name: RiverMigrationInsert :one
-INSERT INTO river_migration (
+INSERT INTO /* TEMPLATE: schema */river_migration (
     line,
     version
 ) VALUES (
@@ -185,7 +185,7 @@ func (q *Queries) RiverMigrationInsert(ctx context.Context, db DBTX, arg *RiverM
 }
 
 const riverMigrationInsertMany = `-- name: RiverMigrationInsertMany :many
-INSERT INTO river_migration (
+INSERT INTO /* TEMPLATE: schema */river_migration (
     line,
     version
 )
@@ -221,7 +221,7 @@ func (q *Queries) RiverMigrationInsertMany(ctx context.Context, db DBTX, arg *Ri
 }
 
 const riverMigrationInsertManyAssumingMain = `-- name: RiverMigrationInsertManyAssumingMain :many
-INSERT INTO river_migration (
+INSERT INTO /* TEMPLATE: schema */river_migration (
     version
 )
 SELECT
@@ -261,8 +261,8 @@ SELECT CASE WHEN to_regclass($1) IS NULL THEN false
             ELSE true END
 `
 
-func (q *Queries) TableExists(ctx context.Context, db DBTX, tableName string) (bool, error) {
-	row := db.QueryRow(ctx, tableExists, tableName)
+func (q *Queries) TableExists(ctx context.Context, db DBTX, schemaAndTable string) (bool, error) {
+	row := db.QueryRow(ctx, tableExists, schemaAndTable)
 	var column_1 bool
 	err := row.Scan(&column_1)
 	return column_1, err

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql
@@ -7,7 +7,7 @@ CREATE TABLE river_queue(
 );
 
 -- name: QueueCreateOrSetUpdatedAt :one
-INSERT INTO river_queue(
+INSERT INTO /* TEMPLATE: schema */river_queue(
     created_at,
     metadata,
     name,
@@ -25,10 +25,10 @@ SET
 RETURNING *;
 
 -- name: QueueDeleteExpired :many
-DELETE FROM river_queue
+DELETE FROM /* TEMPLATE: schema */river_queue
 WHERE name IN (
     SELECT name
-    FROM river_queue
+    FROM /* TEMPLATE: schema */river_queue
     WHERE updated_at < @updated_at_horizon::timestamptz
     ORDER BY name ASC
     LIMIT @max::bigint
@@ -37,24 +37,24 @@ RETURNING *;
 
 -- name: QueueGet :one
 SELECT *
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 WHERE name = @name::text;
 
 -- name: QueueList :many
 SELECT *
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 ORDER BY name ASC
 LIMIT @limit_count::integer;
 
 -- name: QueuePause :execresult
 WITH queue_to_update AS (
     SELECT name, paused_at
-    FROM river_queue
+    FROM /* TEMPLATE: schema */river_queue
     WHERE CASE WHEN @name::text = '*' THEN true ELSE name = @name END
     FOR UPDATE
 ),
 updated_queue AS (
-    UPDATE river_queue
+    UPDATE /* TEMPLATE: schema */river_queue
     SET
         paused_at = now(),
         updated_at = now()
@@ -64,7 +64,7 @@ updated_queue AS (
     RETURNING river_queue.*
 )
 SELECT *
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 WHERE name = @name
     AND name NOT IN (SELECT name FROM updated_queue)
 UNION
@@ -74,12 +74,12 @@ FROM updated_queue;
 -- name: QueueResume :execresult
 WITH queue_to_update AS (
     SELECT name
-    FROM river_queue
+    FROM /* TEMPLATE: schema */river_queue
     WHERE CASE WHEN @name::text = '*' THEN true ELSE river_queue.name = @name::text END
     FOR UPDATE
 ),
 updated_queue AS (
-    UPDATE river_queue
+    UPDATE /* TEMPLATE: schema */river_queue
     SET
         paused_at = NULL,
         updated_at = now()
@@ -88,7 +88,7 @@ updated_queue AS (
     RETURNING river_queue.*
 )
 SELECT *
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 WHERE name = @name
     AND name NOT IN (SELECT name FROM updated_queue)
 UNION
@@ -96,7 +96,7 @@ SELECT *
 FROM updated_queue;
 
 -- name: QueueUpdate :one
-UPDATE river_queue
+UPDATE /* TEMPLATE: schema */river_queue
 SET
     metadata = CASE WHEN @metadata_do_update::boolean THEN @metadata::jsonb ELSE metadata END,
     updated_at = now()

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const queueCreateOrSetUpdatedAt = `-- name: QueueCreateOrSetUpdatedAt :one
-INSERT INTO river_queue(
+INSERT INTO /* TEMPLATE: schema */river_queue(
     created_at,
     metadata,
     name,
@@ -57,10 +57,10 @@ func (q *Queries) QueueCreateOrSetUpdatedAt(ctx context.Context, db DBTX, arg *Q
 }
 
 const queueDeleteExpired = `-- name: QueueDeleteExpired :many
-DELETE FROM river_queue
+DELETE FROM /* TEMPLATE: schema */river_queue
 WHERE name IN (
     SELECT name
-    FROM river_queue
+    FROM /* TEMPLATE: schema */river_queue
     WHERE updated_at < $1::timestamptz
     ORDER BY name ASC
     LIMIT $2::bigint
@@ -101,7 +101,7 @@ func (q *Queries) QueueDeleteExpired(ctx context.Context, db DBTX, arg *QueueDel
 
 const queueGet = `-- name: QueueGet :one
 SELECT name, created_at, metadata, paused_at, updated_at
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 WHERE name = $1::text
 `
 
@@ -120,7 +120,7 @@ func (q *Queries) QueueGet(ctx context.Context, db DBTX, name string) (*RiverQue
 
 const queueList = `-- name: QueueList :many
 SELECT name, created_at, metadata, paused_at, updated_at
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 ORDER BY name ASC
 LIMIT $1::integer
 `
@@ -154,12 +154,12 @@ func (q *Queries) QueueList(ctx context.Context, db DBTX, limitCount int32) ([]*
 const queuePause = `-- name: QueuePause :execresult
 WITH queue_to_update AS (
     SELECT name, paused_at
-    FROM river_queue
+    FROM /* TEMPLATE: schema */river_queue
     WHERE CASE WHEN $1::text = '*' THEN true ELSE name = $1 END
     FOR UPDATE
 ),
 updated_queue AS (
-    UPDATE river_queue
+    UPDATE /* TEMPLATE: schema */river_queue
     SET
         paused_at = now(),
         updated_at = now()
@@ -169,7 +169,7 @@ updated_queue AS (
     RETURNING river_queue.name, river_queue.created_at, river_queue.metadata, river_queue.paused_at, river_queue.updated_at
 )
 SELECT name, created_at, metadata, paused_at, updated_at
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 WHERE name = $1
     AND name NOT IN (SELECT name FROM updated_queue)
 UNION
@@ -184,12 +184,12 @@ func (q *Queries) QueuePause(ctx context.Context, db DBTX, name string) (pgconn.
 const queueResume = `-- name: QueueResume :execresult
 WITH queue_to_update AS (
     SELECT name
-    FROM river_queue
+    FROM /* TEMPLATE: schema */river_queue
     WHERE CASE WHEN $1::text = '*' THEN true ELSE river_queue.name = $1::text END
     FOR UPDATE
 ),
 updated_queue AS (
-    UPDATE river_queue
+    UPDATE /* TEMPLATE: schema */river_queue
     SET
         paused_at = NULL,
         updated_at = now()
@@ -198,7 +198,7 @@ updated_queue AS (
     RETURNING river_queue.name, river_queue.created_at, river_queue.metadata, river_queue.paused_at, river_queue.updated_at
 )
 SELECT name, created_at, metadata, paused_at, updated_at
-FROM river_queue
+FROM /* TEMPLATE: schema */river_queue
 WHERE name = $1
     AND name NOT IN (SELECT name FROM updated_queue)
 UNION
@@ -211,7 +211,7 @@ func (q *Queries) QueueResume(ctx context.Context, db DBTX, name string) (pgconn
 }
 
 const queueUpdate = `-- name: QueueUpdate :one
-UPDATE river_queue
+UPDATE /* TEMPLATE: schema */river_queue
 SET
     metadata = CASE WHEN $1::boolean THEN $2::jsonb ELSE metadata END,
     updated_at = now()

--- a/riverdriver/riverpgxv5/migration/main/001_create_river_migration.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/001_create_river_migration.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE river_migration;
+DROP TABLE /* TEMPLATE: schema */river_migration;

--- a/riverdriver/riverpgxv5/migration/main/001_create_river_migration.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/001_create_river_migration.up.sql
@@ -1,8 +1,8 @@
-CREATE TABLE river_migration(
+CREATE TABLE /* TEMPLATE: schema */river_migration(
   id bigserial PRIMARY KEY,
   created_at timestamptz NOT NULL DEFAULT NOW(),
   version bigint NOT NULL,
   CONSTRAINT version CHECK (version >= 1)
 );
 
-CREATE UNIQUE INDEX ON river_migration USING btree(version);
+CREATE UNIQUE INDEX ON /* TEMPLATE: schema */river_migration USING btree(version);

--- a/riverdriver/riverpgxv5/migration/main/002_initial_schema.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/002_initial_schema.down.sql
@@ -1,5 +1,5 @@
-DROP TABLE river_job;
-DROP FUNCTION river_job_notify;
-DROP TYPE river_job_state;
+DROP TABLE /* TEMPLATE: schema */river_job;
+DROP FUNCTION /* TEMPLATE: schema */river_job_notify;
+DROP TYPE /* TEMPLATE: schema */river_job_state;
 
-DROP TABLE river_leader;
+DROP TABLE /* TEMPLATE: schema */river_leader;

--- a/riverdriver/riverpgxv5/migration/main/002_initial_schema.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/002_initial_schema.up.sql
@@ -1,4 +1,4 @@
-CREATE TYPE river_job_state AS ENUM(
+CREATE TYPE /* TEMPLATE: schema */river_job_state AS ENUM(
   'available',
   'cancelled',
   'completed',
@@ -8,7 +8,7 @@ CREATE TYPE river_job_state AS ENUM(
   'scheduled'
 );
 
-CREATE TABLE river_job(
+CREATE TABLE /* TEMPLATE: schema */river_job(
   -- 8 bytes
   id bigserial PRIMARY KEY,
 
@@ -49,17 +49,17 @@ CREATE TABLE river_job(
 
 -- We may want to consider adding another property here after `kind` if it seems
 -- like it'd be useful for something.
-CREATE INDEX river_job_kind ON river_job USING btree(kind);
+CREATE INDEX river_job_kind ON /* TEMPLATE: schema */river_job USING btree(kind);
 
-CREATE INDEX river_job_state_and_finalized_at_index ON river_job USING btree(state, finalized_at) WHERE finalized_at IS NOT NULL;
+CREATE INDEX river_job_state_and_finalized_at_index ON /* TEMPLATE: schema */river_job USING btree(state, finalized_at) WHERE finalized_at IS NOT NULL;
 
-CREATE INDEX river_job_prioritized_fetching_index ON river_job USING btree(state, queue, priority, scheduled_at, id);
+CREATE INDEX river_job_prioritized_fetching_index ON /* TEMPLATE: schema */river_job USING btree(state, queue, priority, scheduled_at, id);
 
-CREATE INDEX river_job_args_index ON river_job USING GIN(args);
+CREATE INDEX river_job_args_index ON /* TEMPLATE: schema */river_job USING GIN(args);
 
-CREATE INDEX river_job_metadata_index ON river_job USING GIN(metadata);
+CREATE INDEX river_job_metadata_index ON /* TEMPLATE: schema */river_job USING GIN(metadata);
 
-CREATE OR REPLACE FUNCTION river_job_notify()
+CREATE OR REPLACE FUNCTION /* TEMPLATE: schema */river_job_notify()
   RETURNS TRIGGER
   AS $$
 DECLARE
@@ -78,11 +78,11 @@ $$
 LANGUAGE plpgsql;
 
 CREATE TRIGGER river_notify
-  AFTER INSERT ON river_job
+  AFTER INSERT ON /* TEMPLATE: schema */river_job
   FOR EACH ROW
-  EXECUTE PROCEDURE river_job_notify();
+  EXECUTE PROCEDURE /* TEMPLATE: schema */river_job_notify();
 
-CREATE UNLOGGED TABLE river_leader(
+CREATE UNLOGGED TABLE /* TEMPLATE: schema */river_leader(
   -- 8 bytes each (no alignment needed)
   elected_at timestamptz NOT NULL,
   expires_at timestamptz NOT NULL,

--- a/riverdriver/riverpgxv5/migration/main/003_river_job_tags_non_null.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/003_river_job_tags_non_null.down.sql
@@ -1,2 +1,3 @@
-ALTER TABLE river_job ALTER COLUMN tags DROP NOT NULL,
-                      ALTER COLUMN tags DROP DEFAULT;
+ALTER TABLE /* TEMPLATE: schema */river_job
+    ALTER COLUMN tags DROP NOT NULL,
+    ALTER COLUMN tags DROP DEFAULT;

--- a/riverdriver/riverpgxv5/migration/main/003_river_job_tags_non_null.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/003_river_job_tags_non_null.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE river_job ALTER COLUMN tags SET DEFAULT '{}';
-UPDATE river_job SET tags = '{}' WHERE tags IS NULL;
-ALTER TABLE river_job ALTER COLUMN tags SET NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN tags SET DEFAULT '{}';
+UPDATE /* TEMPLATE: schema */river_job SET tags = '{}' WHERE tags IS NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN tags SET NOT NULL;

--- a/riverdriver/riverpgxv5/migration/main/004_pending_and_more.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/004_pending_and_more.down.sql
@@ -1,17 +1,17 @@
-ALTER TABLE river_job ALTER COLUMN args DROP NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args DROP NOT NULL;
 
-ALTER TABLE river_job ALTER COLUMN metadata DROP NOT NULL;
-ALTER TABLE river_job ALTER COLUMN metadata DROP DEFAULT;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata DROP NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata DROP DEFAULT;
 
 -- It is not possible to safely remove 'pending' from the river_job_state enum,
 -- so leave it in place.
 
-ALTER TABLE river_job DROP CONSTRAINT finalized_or_finalized_at_null;
-ALTER TABLE river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
+ALTER TABLE /* TEMPLATE: schema */river_job DROP CONSTRAINT finalized_or_finalized_at_null;
+ALTER TABLE /* TEMPLATE: schema */river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
   (state IN ('cancelled', 'completed', 'discarded') AND finalized_at IS NOT NULL) OR finalized_at IS NULL
 );
 
-CREATE OR REPLACE FUNCTION river_job_notify()
+CREATE OR REPLACE FUNCTION /* TEMPLATE: schema */river_job_notify()
   RETURNS TRIGGER
   AS $$
 DECLARE
@@ -30,13 +30,13 @@ $$
 LANGUAGE plpgsql;
 
 CREATE TRIGGER river_notify
-  AFTER INSERT ON river_job
+  AFTER INSERT ON /* TEMPLATE: schema */river_job
   FOR EACH ROW
-  EXECUTE PROCEDURE river_job_notify();
+  EXECUTE PROCEDURE /* TEMPLATE: schema */river_job_notify();
 
-DROP TABLE river_queue;
+DROP TABLE /* TEMPLATE: schema */river_queue;
 
-ALTER TABLE river_leader
+ALTER TABLE /* TEMPLATE: schema */river_leader
     ALTER COLUMN name DROP DEFAULT,
     DROP CONSTRAINT name_length,
     ADD CONSTRAINT name_length CHECK (char_length(name) > 0 AND char_length(name) < 128);

--- a/riverdriver/riverpgxv5/migration/main/004_pending_and_more.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/004_pending_and_more.up.sql
@@ -1,29 +1,29 @@
 -- The args column never had a NOT NULL constraint or default value at the
 -- database level, though we tried to ensure one at the application level.
-ALTER TABLE river_job ALTER COLUMN args SET DEFAULT '{}';
-UPDATE river_job SET args = '{}' WHERE args IS NULL;
-ALTER TABLE river_job ALTER COLUMN args SET NOT NULL;
-ALTER TABLE river_job ALTER COLUMN args DROP DEFAULT;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args SET DEFAULT '{}';
+UPDATE /* TEMPLATE: schema */river_job SET args = '{}' WHERE args IS NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args SET NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN args DROP DEFAULT;
 
 -- The metadata column never had a NOT NULL constraint or default value at the
 -- database level, though we tried to ensure one at the application level.
-ALTER TABLE river_job ALTER COLUMN metadata SET DEFAULT '{}';
-UPDATE river_job SET metadata = '{}' WHERE metadata IS NULL;
-ALTER TABLE river_job ALTER COLUMN metadata SET NOT NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata SET DEFAULT '{}';
+UPDATE /* TEMPLATE: schema */river_job SET metadata = '{}' WHERE metadata IS NULL;
+ALTER TABLE /* TEMPLATE: schema */river_job ALTER COLUMN metadata SET NOT NULL;
 
 -- The 'pending' job state will be used for upcoming functionality:
-ALTER TYPE river_job_state ADD VALUE IF NOT EXISTS 'pending' AFTER 'discarded';
+ALTER TYPE /* TEMPLATE: schema */river_job_state ADD VALUE IF NOT EXISTS 'pending' AFTER 'discarded';
 
-ALTER TABLE river_job DROP CONSTRAINT finalized_or_finalized_at_null;
-ALTER TABLE river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
+ALTER TABLE /* TEMPLATE: schema */river_job DROP CONSTRAINT finalized_or_finalized_at_null;
+ALTER TABLE /* TEMPLATE: schema */river_job ADD CONSTRAINT finalized_or_finalized_at_null CHECK (
     (finalized_at IS NULL AND state NOT IN ('cancelled', 'completed', 'discarded')) OR
     (finalized_at IS NOT NULL AND state IN ('cancelled', 'completed', 'discarded'))
 );
 
-DROP TRIGGER river_notify ON river_job;
-DROP FUNCTION river_job_notify;
+DROP TRIGGER river_notify ON /* TEMPLATE: schema */river_job;
+DROP FUNCTION /* TEMPLATE: schema */river_job_notify;
 
-CREATE TABLE river_queue(
+CREATE TABLE /* TEMPLATE: schema */river_queue(
   name text PRIMARY KEY NOT NULL,
   created_at timestamptz NOT NULL DEFAULT NOW(),
   metadata jsonb NOT NULL DEFAULT '{}' ::jsonb,
@@ -31,7 +31,7 @@ CREATE TABLE river_queue(
   updated_at timestamptz NOT NULL
 );
 
-ALTER TABLE river_leader
+ALTER TABLE /* TEMPLATE: schema */river_leader
     ALTER COLUMN name SET DEFAULT 'default',
     DROP CONSTRAINT name_length,
     ADD CONSTRAINT name_length CHECK (name = 'default');

--- a/riverdriver/riverpgxv5/migration/main/005_migration_unique_client.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/005_migration_unique_client.down.sql
@@ -10,33 +10,33 @@ BEGIN
     -- Tolerate users who may be using their own migration system rather than
     -- River's. If they are, they will have skipped version 001 containing
     -- `CREATE TABLE river_migration`, so this table won't exist.
-    IF (SELECT to_regclass('river_migration') IS NOT NULL) THEN
+    IF (SELECT to_regclass('/* TEMPLATE: schema */river_migration') IS NOT NULL) THEN
         IF EXISTS (
             SELECT *
-            FROM river_migration
+            FROM /* TEMPLATE: schema */river_migration
             WHERE line <> 'main'
         ) THEN
             RAISE EXCEPTION 'Found non-main migration lines in the database; version 005 migration is irreversible because it would result in loss of migration information.';
         END IF;
 
-        ALTER TABLE river_migration
+        ALTER TABLE /* TEMPLATE: schema */river_migration
             RENAME TO river_migration_old;
 
-        CREATE TABLE river_migration(
+        CREATE TABLE /* TEMPLATE: schema */river_migration(
             id bigserial PRIMARY KEY,
             created_at timestamptz NOT NULL DEFAULT NOW(),
             version bigint NOT NULL,
             CONSTRAINT version CHECK (version >= 1)
         );
 
-        CREATE UNIQUE INDEX ON river_migration USING btree(version);
+        CREATE UNIQUE INDEX ON /* TEMPLATE: schema */river_migration USING btree(version);
 
-        INSERT INTO river_migration
+        INSERT INTO /* TEMPLATE: schema */river_migration
             (created_at, version)
         SELECT created_at, version
-        FROM river_migration_old;
+        FROM /* TEMPLATE: schema */river_migration_old;
 
-        DROP TABLE river_migration_old;
+        DROP TABLE /* TEMPLATE: schema */river_migration_old;
     END IF;
 END;
 $body$
@@ -46,12 +46,12 @@ LANGUAGE 'plpgsql';
 -- Drop `river_job.unique_key`.
 --
 
-ALTER TABLE river_job
+ALTER TABLE /* TEMPLATE: schema */river_job
     DROP COLUMN unique_key;
 
 --
 -- Drop `river_client` and derivative.
 --
 
-DROP TABLE river_client_queue;
-DROP TABLE river_client;
+DROP TABLE /* TEMPLATE: schema */river_client_queue;
+DROP TABLE /* TEMPLATE: schema */river_client;

--- a/riverdriver/riverpgxv5/migration/main/005_migration_unique_client.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/005_migration_unique_client.up.sql
@@ -8,11 +8,11 @@ BEGIN
     -- Tolerate users who may be using their own migration system rather than
     -- River's. If they are, they will have skipped version 001 containing
     -- `CREATE TABLE river_migration`, so this table won't exist.
-    IF (SELECT to_regclass('river_migration') IS NOT NULL) THEN
-        ALTER TABLE river_migration
+    IF (SELECT to_regclass('/* TEMPLATE: schema */river_migration') IS NOT NULL) THEN
+        ALTER TABLE /* TEMPLATE: schema */river_migration
             RENAME TO river_migration_old;
 
-        CREATE TABLE river_migration(
+        CREATE TABLE /* TEMPLATE: schema */river_migration(
             line TEXT NOT NULL,
             version bigint NOT NULL,
             created_at timestamptz NOT NULL DEFAULT NOW(),
@@ -21,12 +21,12 @@ BEGIN
             PRIMARY KEY (line, version)
         );
 
-        INSERT INTO river_migration
+        INSERT INTO /* TEMPLATE: schema */river_migration
             (created_at, line, version)
         SELECT created_at, 'main', version
-        FROM river_migration_old;
+        FROM /* TEMPLATE: schema */river_migration_old;
 
-        DROP TABLE river_migration_old;
+        DROP TABLE /* TEMPLATE: schema */river_migration_old;
     END IF;
 END;
 $body$
@@ -39,10 +39,10 @@ LANGUAGE 'plpgsql';
 -- These statements use `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this
 -- migration, then follow by completing the migration.
-ALTER TABLE river_job
+ALTER TABLE /* TEMPLATE: schema */river_job
     ADD COLUMN IF NOT EXISTS unique_key bytea;
 
-CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON /* TEMPLATE: schema */river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
 
 --
 -- Create `river_client` and derivative.
@@ -52,7 +52,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON river_job (ki
 -- additional migration.
 --
 
-CREATE UNLOGGED TABLE river_client (
+CREATE UNLOGGED TABLE /* TEMPLATE: schema */river_client (
     id text PRIMARY KEY NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),
     metadata jsonb NOT NULL DEFAULT '{}',
@@ -63,7 +63,7 @@ CREATE UNLOGGED TABLE river_client (
 
 -- Differs from `river_queue` in that it tracks the queue state for a particular
 -- active client.
-CREATE UNLOGGED TABLE river_client_queue (
+CREATE UNLOGGED TABLE /* TEMPLATE: schema */river_client_queue (
     river_client_id text NOT NULL REFERENCES river_client (id) ON DELETE CASCADE,
     name text NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),

--- a/riverdriver/riverpgxv5/migration/main/006_bulk_unique.down.sql
+++ b/riverdriver/riverpgxv5/migration/main/006_bulk_unique.down.sql
@@ -3,14 +3,14 @@
 -- Drop `river_job.unique_states` and its index.
 --
 
-DROP INDEX river_job_unique_idx;
+DROP INDEX /* TEMPLATE: schema */river_job_unique_idx;
 
-ALTER TABLE river_job
+ALTER TABLE /* TEMPLATE: schema */river_job
     DROP COLUMN unique_states;
 
-CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS river_job_kind_unique_key_idx ON /* TEMPLATE: schema */river_job (kind, unique_key) WHERE unique_key IS NOT NULL;
 
 --
 -- Drop `river_job_state_in_bitmask` function.
 --
-DROP FUNCTION river_job_state_in_bitmask;
+DROP FUNCTION /* TEMPLATE: schema */river_job_state_in_bitmask;

--- a/riverdriver/riverpgxv5/migration/main/006_bulk_unique.up.sql
+++ b/riverdriver/riverpgxv5/migration/main/006_bulk_unique.up.sql
@@ -1,5 +1,5 @@
 
-CREATE OR REPLACE FUNCTION river_job_state_in_bitmask(bitmask BIT(8), state river_job_state)
+CREATE OR REPLACE FUNCTION /* TEMPLATE: schema */river_job_state_in_bitmask(bitmask BIT(8), state river_job_state)
 RETURNS boolean
 LANGUAGE SQL
 IMMUTABLE
@@ -23,12 +23,12 @@ $$;
 -- This column may exist already if users manually created the column and index
 -- as instructed in the changelog so the index could be created `CONCURRENTLY`.
 --
-ALTER TABLE river_job ADD COLUMN IF NOT EXISTS unique_states BIT(8);
+ALTER TABLE /* TEMPLATE: schema */river_job ADD COLUMN IF NOT EXISTS unique_states BIT(8);
 
 -- This statement uses `IF NOT EXISTS` to allow users with a `river_job` table
 -- of non-trivial size to build the index `CONCURRENTLY` out of band of this
 -- migration, then follow by completing the migration.
-CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON river_job (unique_key)
+CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON /* TEMPLATE: schema */river_job (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
       AND river_job_state_in_bitmask(unique_states, state);
@@ -38,4 +38,4 @@ CREATE UNIQUE INDEX IF NOT EXISTS river_job_unique_idx ON river_job (unique_key)
 -- subsequent migration once all jobs using the old unique system have been
 -- completed (i.e. no more rows with non-null unique_key and null
 -- unique_states).
-DROP INDEX river_job_kind_unique_key_idx;
+DROP INDEX /* TEMPLATE: schema */river_job_kind_unique_key_idx;

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -60,7 +60,11 @@ func New(dbPool *pgxpool.Pool) *Driver {
 func (d *Driver) GetExecutor() riverdriver.Executor {
 	return &Executor{templateReplaceWrapper{d.dbPool, &d.replacer}, d}
 }
-func (d *Driver) GetListener() riverdriver.Listener { return &Listener{dbPool: d.dbPool} }
+
+func (d *Driver) GetListener(schema string) riverdriver.Listener {
+	return &Listener{dbPool: d.dbPool, schema: schema}
+}
+
 func (d *Driver) GetMigrationFS(line string) fs.FS {
 	if line == riverdriver.MigrationLineMain {
 		return migrationFS
@@ -96,10 +100,19 @@ func (e *Executor) Begin(ctx context.Context) (riverdriver.ExecutorTx, error) {
 	return &ExecutorTx{Executor: Executor{templateReplaceWrapper{tx, &e.driver.replacer}, e.driver}, tx: tx}, nil
 }
 
-func (e *Executor) ColumnExists(ctx context.Context, tableName, columnName string) (bool, error) {
+func (e *Executor) ColumnExists(ctx context.Context, params *riverdriver.ColumnExistsParams) (bool, error) {
+	// Schema injection is a bit different on this one because we're querying a table with a schema name.
+	schema := "CURRENT_SCHEMA"
+	if params.Schema != "" {
+		schema = "'" + params.Schema + "'"
+	}
+	ctx = sqlctemplate.WithReplacements(ctx, map[string]sqlctemplate.Replacement{
+		"schema": {Value: schema},
+	}, nil)
+
 	exists, err := dbsqlc.New().ColumnExists(ctx, e.dbtx, &dbsqlc.ColumnExistsParams{
-		ColumnName: columnName,
-		TableName:  tableName,
+		ColumnName: params.Column,
+		TableName:  params.Table,
 	})
 	return exists, interpretError(err)
 }
@@ -115,10 +128,11 @@ func (e *Executor) JobCancel(ctx context.Context, params *riverdriver.JobCancelP
 		return nil, err
 	}
 
-	job, err := dbsqlc.New().JobCancel(ctx, e.dbtx, &dbsqlc.JobCancelParams{
+	job, err := dbsqlc.New().JobCancel(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobCancelParams{
 		ID:                params.ID,
 		CancelAttemptedAt: cancelledAt,
 		ControlTopic:      params.ControlTopic,
+		Schema:            pgtype.Text{String: params.Schema, Valid: params.Schema != ""},
 	})
 	if err != nil {
 		return nil, interpretError(err)
@@ -126,16 +140,16 @@ func (e *Executor) JobCancel(ctx context.Context, params *riverdriver.JobCancelP
 	return jobRowFromInternal(job)
 }
 
-func (e *Executor) JobCountByState(ctx context.Context, state rivertype.JobState) (int, error) {
-	numJobs, err := dbsqlc.New().JobCountByState(ctx, e.dbtx, dbsqlc.RiverJobState(state))
+func (e *Executor) JobCountByState(ctx context.Context, params *riverdriver.JobCountByStateParams) (int, error) {
+	numJobs, err := dbsqlc.New().JobCountByState(schemaTemplateParam(ctx, params.Schema), e.dbtx, dbsqlc.RiverJobState(params.State))
 	if err != nil {
 		return 0, err
 	}
 	return int(numJobs), nil
 }
 
-func (e *Executor) JobDelete(ctx context.Context, id int64) (*rivertype.JobRow, error) {
-	job, err := dbsqlc.New().JobDelete(ctx, e.dbtx, id)
+func (e *Executor) JobDelete(ctx context.Context, params *riverdriver.JobDeleteParams) (*rivertype.JobRow, error) {
+	job, err := dbsqlc.New().JobDelete(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.ID)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -146,7 +160,7 @@ func (e *Executor) JobDelete(ctx context.Context, id int64) (*rivertype.JobRow, 
 }
 
 func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobDeleteBeforeParams) (int, error) {
-	numDeleted, err := dbsqlc.New().JobDeleteBefore(ctx, e.dbtx, &dbsqlc.JobDeleteBeforeParams{
+	numDeleted, err := dbsqlc.New().JobDeleteBefore(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobDeleteBeforeParams{
 		CancelledFinalizedAtHorizon: params.CancelledFinalizedAtHorizon,
 		CompletedFinalizedAtHorizon: params.CompletedFinalizedAtHorizon,
 		DiscardedFinalizedAtHorizon: params.DiscardedFinalizedAtHorizon,
@@ -156,7 +170,7 @@ func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobD
 }
 
 func (e *Executor) JobGetAvailable(ctx context.Context, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
-	jobs, err := dbsqlc.New().JobGetAvailable(ctx, e.dbtx, &dbsqlc.JobGetAvailableParams{
+	jobs, err := dbsqlc.New().JobGetAvailable(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobGetAvailableParams{
 		AttemptedBy: params.ClientID,
 		Max:         int32(min(params.Max, math.MaxInt32)), //nolint:gosec
 		Now:         params.Now,
@@ -168,32 +182,24 @@ func (e *Executor) JobGetAvailable(ctx context.Context, params *riverdriver.JobG
 	return mapSliceError(jobs, jobRowFromInternal)
 }
 
-func (e *Executor) JobGetByID(ctx context.Context, id int64) (*rivertype.JobRow, error) {
-	job, err := dbsqlc.New().JobGetByID(ctx, e.dbtx, id)
+func (e *Executor) JobGetByID(ctx context.Context, params *riverdriver.JobGetByIDParams) (*rivertype.JobRow, error) {
+	job, err := dbsqlc.New().JobGetByID(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.ID)
 	if err != nil {
 		return nil, interpretError(err)
 	}
 	return jobRowFromInternal(job)
 }
 
-func (e *Executor) JobGetByIDMany(ctx context.Context, id []int64) ([]*rivertype.JobRow, error) {
-	jobs, err := dbsqlc.New().JobGetByIDMany(ctx, e.dbtx, id)
+func (e *Executor) JobGetByIDMany(ctx context.Context, params *riverdriver.JobGetByIDManyParams) ([]*rivertype.JobRow, error) {
+	jobs, err := dbsqlc.New().JobGetByIDMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.ID)
 	if err != nil {
 		return nil, interpretError(err)
 	}
 	return mapSliceError(jobs, jobRowFromInternal)
 }
 
-func (e *Executor) JobGetByKindAndUniqueProperties(ctx context.Context, params *riverdriver.JobGetByKindAndUniquePropertiesParams) (*rivertype.JobRow, error) {
-	job, err := dbsqlc.New().JobGetByKindAndUniqueProperties(ctx, e.dbtx, (*dbsqlc.JobGetByKindAndUniquePropertiesParams)(params))
-	if err != nil {
-		return nil, interpretError(err)
-	}
-	return jobRowFromInternal(job)
-}
-
-func (e *Executor) JobGetByKindMany(ctx context.Context, kind []string) ([]*rivertype.JobRow, error) {
-	jobs, err := dbsqlc.New().JobGetByKindMany(ctx, e.dbtx, kind)
+func (e *Executor) JobGetByKindMany(ctx context.Context, params *riverdriver.JobGetByKindManyParams) ([]*rivertype.JobRow, error) {
+	jobs, err := dbsqlc.New().JobGetByKindMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.Kind)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -201,32 +207,32 @@ func (e *Executor) JobGetByKindMany(ctx context.Context, kind []string) ([]*rive
 }
 
 func (e *Executor) JobGetStuck(ctx context.Context, params *riverdriver.JobGetStuckParams) ([]*rivertype.JobRow, error) {
-	jobs, err := dbsqlc.New().JobGetStuck(ctx, e.dbtx, &dbsqlc.JobGetStuckParams{Max: int32(min(params.Max, math.MaxInt32)), StuckHorizon: params.StuckHorizon}) //nolint:gosec
+	jobs, err := dbsqlc.New().JobGetStuck(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobGetStuckParams{Max: int32(min(params.Max, math.MaxInt32)), StuckHorizon: params.StuckHorizon}) //nolint:gosec
 	if err != nil {
 		return nil, interpretError(err)
 	}
 	return mapSliceError(jobs, jobRowFromInternal)
 }
 
-func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.JobInsertFastParams) ([]*riverdriver.JobInsertFastResult, error) {
+func (e *Executor) JobInsertFastMany(ctx context.Context, params *riverdriver.JobInsertFastManyParams) ([]*riverdriver.JobInsertFastResult, error) {
 	insertJobsParams := &dbsqlc.JobInsertFastManyParams{
-		Args:         make([][]byte, len(params)),
-		CreatedAt:    make([]time.Time, len(params)),
-		Kind:         make([]string, len(params)),
-		MaxAttempts:  make([]int16, len(params)),
-		Metadata:     make([][]byte, len(params)),
-		Priority:     make([]int16, len(params)),
-		Queue:        make([]string, len(params)),
-		ScheduledAt:  make([]time.Time, len(params)),
-		State:        make([]string, len(params)),
-		Tags:         make([]string, len(params)),
-		UniqueKey:    make([][]byte, len(params)),
-		UniqueStates: make([]pgtype.Bits, len(params)),
+		Args:         make([][]byte, len(params.Jobs)),
+		CreatedAt:    make([]time.Time, len(params.Jobs)),
+		Kind:         make([]string, len(params.Jobs)),
+		MaxAttempts:  make([]int16, len(params.Jobs)),
+		Metadata:     make([][]byte, len(params.Jobs)),
+		Priority:     make([]int16, len(params.Jobs)),
+		Queue:        make([]string, len(params.Jobs)),
+		ScheduledAt:  make([]time.Time, len(params.Jobs)),
+		State:        make([]string, len(params.Jobs)),
+		Tags:         make([]string, len(params.Jobs)),
+		UniqueKey:    make([][]byte, len(params.Jobs)),
+		UniqueStates: make([]pgtype.Bits, len(params.Jobs)),
 	}
 	now := time.Now().UTC()
 
-	for i := 0; i < len(params); i++ {
-		params := params[i]
+	for i := range len(params.Jobs) {
+		params := params.Jobs[i]
 
 		createdAt := now
 		if params.CreatedAt != nil {
@@ -259,7 +265,7 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 		insertJobsParams.UniqueStates[i] = pgtype.Bits{Bytes: []byte{params.UniqueStates}, Len: 8, Valid: params.UniqueStates != 0}
 	}
 
-	items, err := dbsqlc.New().JobInsertFastMany(ctx, e.dbtx, insertJobsParams)
+	items, err := dbsqlc.New().JobInsertFastMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, insertJobsParams)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -273,12 +279,12 @@ func (e *Executor) JobInsertFastMany(ctx context.Context, params []*riverdriver.
 	})
 }
 
-func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params []*riverdriver.JobInsertFastParams) (int, error) {
-	insertJobsParams := make([]*dbsqlc.JobInsertFastManyCopyFromParams, len(params))
+func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params *riverdriver.JobInsertFastManyParams) (int, error) {
+	insertJobsParams := make([]*dbsqlc.JobInsertFastManyCopyFromParams, len(params.Jobs))
 	now := time.Now().UTC()
 
-	for i := 0; i < len(params); i++ {
-		params := params[i]
+	for i := range len(params.Jobs) {
+		params := params.Jobs[i]
 
 		createdAt := now
 		if params.CreatedAt != nil {
@@ -316,7 +322,7 @@ func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params []*r
 		}
 	}
 
-	numInserted, err := dbsqlc.New().JobInsertFastManyCopyFrom(ctx, e.dbtx, insertJobsParams)
+	numInserted, err := dbsqlc.New().JobInsertFastManyCopyFrom(schemaTemplateParam(ctx, params.Schema), e.dbtx, insertJobsParams)
 	if err != nil {
 		return 0, interpretError(err)
 	}
@@ -325,7 +331,7 @@ func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params []*r
 }
 
 func (e *Executor) JobInsertFull(ctx context.Context, params *riverdriver.JobInsertFullParams) (*rivertype.JobRow, error) {
-	job, err := dbsqlc.New().JobInsertFull(ctx, e.dbtx, &dbsqlc.JobInsertFullParams{
+	job, err := dbsqlc.New().JobInsertFull(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobInsertFullParams{
 		Attempt:      int16(min(params.Attempt, math.MaxInt16)), //nolint:gosec
 		AttemptedAt:  params.AttemptedAt,
 		AttemptedBy:  params.AttemptedBy,
@@ -356,7 +362,7 @@ func (e *Executor) JobList(ctx context.Context, params *riverdriver.JobListParam
 		"where_clause":    {Value: params.WhereClause},
 	}, params.NamedArgs)
 
-	jobs, err := dbsqlc.New().JobList(ctx, e.dbtx, params.Max)
+	jobs, err := dbsqlc.New().JobList(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.Max)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -364,15 +370,21 @@ func (e *Executor) JobList(ctx context.Context, params *riverdriver.JobListParam
 }
 
 func (e *Executor) JobRescueMany(ctx context.Context, params *riverdriver.JobRescueManyParams) (*struct{}, error) {
-	err := dbsqlc.New().JobRescueMany(ctx, e.dbtx, (*dbsqlc.JobRescueManyParams)(params))
+	err := dbsqlc.New().JobRescueMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobRescueManyParams{
+		ID:          params.ID,
+		Error:       params.Error,
+		FinalizedAt: params.FinalizedAt,
+		ScheduledAt: params.ScheduledAt,
+		State:       params.State,
+	})
 	if err != nil {
 		return nil, interpretError(err)
 	}
 	return &struct{}{}, nil
 }
 
-func (e *Executor) JobRetry(ctx context.Context, id int64) (*rivertype.JobRow, error) {
-	job, err := dbsqlc.New().JobRetry(ctx, e.dbtx, id)
+func (e *Executor) JobRetry(ctx context.Context, params *riverdriver.JobRetryParams) (*rivertype.JobRow, error) {
+	job, err := dbsqlc.New().JobRetry(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.ID)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -380,7 +392,7 @@ func (e *Executor) JobRetry(ctx context.Context, id int64) (*rivertype.JobRow, e
 }
 
 func (e *Executor) JobSchedule(ctx context.Context, params *riverdriver.JobScheduleParams) ([]*riverdriver.JobScheduleResult, error) {
-	scheduleResults, err := dbsqlc.New().JobSchedule(ctx, e.dbtx, &dbsqlc.JobScheduleParams{
+	scheduleResults, err := dbsqlc.New().JobSchedule(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobScheduleParams{
 		Max: int64(params.Max),
 		Now: params.Now,
 	})
@@ -435,7 +447,7 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 		setStateParams.State[i] = string(params.State[i])
 	}
 
-	jobs, err := dbsqlc.New().JobSetStateIfRunningMany(ctx, e.dbtx, setStateParams)
+	jobs, err := dbsqlc.New().JobSetStateIfRunningMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, setStateParams)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -443,7 +455,7 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 }
 
 func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateParams) (*rivertype.JobRow, error) {
-	job, err := dbsqlc.New().JobUpdate(ctx, e.dbtx, &dbsqlc.JobUpdateParams{
+	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
 		ID:                  params.ID,
 		AttemptedAtDoUpdate: params.AttemptedAtDoUpdate,
 		Attempt:             int16(min(params.Attempt, math.MaxInt16)), //nolint:gosec
@@ -466,7 +478,7 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 }
 
 func (e *Executor) LeaderAttemptElect(ctx context.Context, params *riverdriver.LeaderElectParams) (bool, error) {
-	numElectionsWon, err := dbsqlc.New().LeaderAttemptElect(ctx, e.dbtx, &dbsqlc.LeaderAttemptElectParams{
+	numElectionsWon, err := dbsqlc.New().LeaderAttemptElect(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.LeaderAttemptElectParams{
 		LeaderID: params.LeaderID,
 		TTL:      params.TTL,
 	})
@@ -477,7 +489,7 @@ func (e *Executor) LeaderAttemptElect(ctx context.Context, params *riverdriver.L
 }
 
 func (e *Executor) LeaderAttemptReelect(ctx context.Context, params *riverdriver.LeaderElectParams) (bool, error) {
-	numElectionsWon, err := dbsqlc.New().LeaderAttemptReelect(ctx, e.dbtx, &dbsqlc.LeaderAttemptReelectParams{
+	numElectionsWon, err := dbsqlc.New().LeaderAttemptReelect(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.LeaderAttemptReelectParams{
 		LeaderID: params.LeaderID,
 		TTL:      params.TTL,
 	})
@@ -487,16 +499,16 @@ func (e *Executor) LeaderAttemptReelect(ctx context.Context, params *riverdriver
 	return numElectionsWon > 0, nil
 }
 
-func (e *Executor) LeaderDeleteExpired(ctx context.Context) (int, error) {
-	numDeleted, err := dbsqlc.New().LeaderDeleteExpired(ctx, e.dbtx)
+func (e *Executor) LeaderDeleteExpired(ctx context.Context, params *riverdriver.LeaderDeleteExpiredParams) (int, error) {
+	numDeleted, err := dbsqlc.New().LeaderDeleteExpired(schemaTemplateParam(ctx, params.Schema), e.dbtx)
 	if err != nil {
 		return 0, interpretError(err)
 	}
 	return int(numDeleted), nil
 }
 
-func (e *Executor) LeaderGetElectedLeader(ctx context.Context) (*riverdriver.Leader, error) {
-	leader, err := dbsqlc.New().LeaderGetElectedLeader(ctx, e.dbtx)
+func (e *Executor) LeaderGetElectedLeader(ctx context.Context, params *riverdriver.LeaderGetElectedLeaderParams) (*riverdriver.Leader, error) {
+	leader, err := dbsqlc.New().LeaderGetElectedLeader(schemaTemplateParam(ctx, params.Schema), e.dbtx)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -504,7 +516,7 @@ func (e *Executor) LeaderGetElectedLeader(ctx context.Context) (*riverdriver.Lea
 }
 
 func (e *Executor) LeaderInsert(ctx context.Context, params *riverdriver.LeaderInsertParams) (*riverdriver.Leader, error) {
-	leader, err := dbsqlc.New().LeaderInsert(ctx, e.dbtx, &dbsqlc.LeaderInsertParams{
+	leader, err := dbsqlc.New().LeaderInsert(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.LeaderInsertParams{
 		ElectedAt: params.ElectedAt,
 		ExpiresAt: params.ExpiresAt,
 		LeaderID:  params.LeaderID,
@@ -517,9 +529,10 @@ func (e *Executor) LeaderInsert(ctx context.Context, params *riverdriver.LeaderI
 }
 
 func (e *Executor) LeaderResign(ctx context.Context, params *riverdriver.LeaderResignParams) (bool, error) {
-	numResigned, err := dbsqlc.New().LeaderResign(ctx, e.dbtx, &dbsqlc.LeaderResignParams{
+	numResigned, err := dbsqlc.New().LeaderResign(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.LeaderResignParams{
 		LeaderID:        params.LeaderID,
 		LeadershipTopic: params.LeadershipTopic,
+		Schema:          pgtype.Text{String: params.Schema, Valid: params.Schema != ""},
 	})
 	if err != nil {
 		return false, interpretError(err)
@@ -527,9 +540,9 @@ func (e *Executor) LeaderResign(ctx context.Context, params *riverdriver.LeaderR
 	return numResigned > 0, nil
 }
 
-func (e *Executor) MigrationDeleteAssumingMainMany(ctx context.Context, versions []int) ([]*riverdriver.Migration, error) {
-	migrations, err := dbsqlc.New().RiverMigrationDeleteAssumingMainMany(ctx, e.dbtx,
-		sliceutil.Map(versions, func(v int) int64 { return int64(v) }))
+func (e *Executor) MigrationDeleteAssumingMainMany(ctx context.Context, params *riverdriver.MigrationDeleteAssumingMainManyParams) ([]*riverdriver.Migration, error) {
+	migrations, err := dbsqlc.New().RiverMigrationDeleteAssumingMainMany(schemaTemplateParam(ctx, params.Schema), e.dbtx,
+		sliceutil.Map(params.Versions, func(v int) int64 { return int64(v) }))
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -542,10 +555,10 @@ func (e *Executor) MigrationDeleteAssumingMainMany(ctx context.Context, versions
 	}), nil
 }
 
-func (e *Executor) MigrationDeleteByLineAndVersionMany(ctx context.Context, line string, versions []int) ([]*riverdriver.Migration, error) {
-	migrations, err := dbsqlc.New().RiverMigrationDeleteByLineAndVersionMany(ctx, e.dbtx, &dbsqlc.RiverMigrationDeleteByLineAndVersionManyParams{
-		Line:    line,
-		Version: sliceutil.Map(versions, func(v int) int64 { return int64(v) }),
+func (e *Executor) MigrationDeleteByLineAndVersionMany(ctx context.Context, params *riverdriver.MigrationDeleteByLineAndVersionManyParams) ([]*riverdriver.Migration, error) {
+	migrations, err := dbsqlc.New().RiverMigrationDeleteByLineAndVersionMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.RiverMigrationDeleteByLineAndVersionManyParams{
+		Line:    params.Line,
+		Version: sliceutil.Map(params.Versions, func(v int) int64 { return int64(v) }),
 	})
 	if err != nil {
 		return nil, interpretError(err)
@@ -553,8 +566,8 @@ func (e *Executor) MigrationDeleteByLineAndVersionMany(ctx context.Context, line
 	return sliceutil.Map(migrations, migrationFromInternal), nil
 }
 
-func (e *Executor) MigrationGetAllAssumingMain(ctx context.Context) ([]*riverdriver.Migration, error) {
-	migrations, err := dbsqlc.New().RiverMigrationGetAllAssumingMain(ctx, e.dbtx)
+func (e *Executor) MigrationGetAllAssumingMain(ctx context.Context, params *riverdriver.MigrationGetAllAssumingMainParams) ([]*riverdriver.Migration, error) {
+	migrations, err := dbsqlc.New().RiverMigrationGetAllAssumingMain(schemaTemplateParam(ctx, params.Schema), e.dbtx)
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -567,18 +580,18 @@ func (e *Executor) MigrationGetAllAssumingMain(ctx context.Context) ([]*riverdri
 	}), nil
 }
 
-func (e *Executor) MigrationGetByLine(ctx context.Context, line string) ([]*riverdriver.Migration, error) {
-	migrations, err := dbsqlc.New().RiverMigrationGetByLine(ctx, e.dbtx, line)
+func (e *Executor) MigrationGetByLine(ctx context.Context, params *riverdriver.MigrationGetByLineParams) ([]*riverdriver.Migration, error) {
+	migrations, err := dbsqlc.New().RiverMigrationGetByLine(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.Line)
 	if err != nil {
 		return nil, interpretError(err)
 	}
 	return sliceutil.Map(migrations, migrationFromInternal), nil
 }
 
-func (e *Executor) MigrationInsertMany(ctx context.Context, line string, versions []int) ([]*riverdriver.Migration, error) {
-	migrations, err := dbsqlc.New().RiverMigrationInsertMany(ctx, e.dbtx, &dbsqlc.RiverMigrationInsertManyParams{
-		Line:    line,
-		Version: sliceutil.Map(versions, func(v int) int64 { return int64(v) }),
+func (e *Executor) MigrationInsertMany(ctx context.Context, params *riverdriver.MigrationInsertManyParams) ([]*riverdriver.Migration, error) {
+	migrations, err := dbsqlc.New().RiverMigrationInsertMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.RiverMigrationInsertManyParams{
+		Line:    params.Line,
+		Version: sliceutil.Map(params.Versions, func(v int) int64 { return int64(v) }),
 	})
 	if err != nil {
 		return nil, interpretError(err)
@@ -586,9 +599,9 @@ func (e *Executor) MigrationInsertMany(ctx context.Context, line string, version
 	return sliceutil.Map(migrations, migrationFromInternal), nil
 }
 
-func (e *Executor) MigrationInsertManyAssumingMain(ctx context.Context, versions []int) ([]*riverdriver.Migration, error) {
-	migrations, err := dbsqlc.New().RiverMigrationInsertManyAssumingMain(ctx, e.dbtx,
-		sliceutil.Map(versions, func(v int) int64 { return int64(v) }),
+func (e *Executor) MigrationInsertManyAssumingMain(ctx context.Context, params *riverdriver.MigrationInsertManyAssumingMainParams) ([]*riverdriver.Migration, error) {
+	migrations, err := dbsqlc.New().RiverMigrationInsertManyAssumingMain(schemaTemplateParam(ctx, params.Schema), e.dbtx,
+		sliceutil.Map(params.Versions, func(v int) int64 { return int64(v) }),
 	)
 	if err != nil {
 		return nil, interpretError(err)
@@ -605,6 +618,7 @@ func (e *Executor) MigrationInsertManyAssumingMain(ctx context.Context, versions
 func (e *Executor) NotifyMany(ctx context.Context, params *riverdriver.NotifyManyParams) error {
 	return dbsqlc.New().PGNotifyMany(ctx, e.dbtx, &dbsqlc.PGNotifyManyParams{
 		Payload: params.Payload,
+		Schema:  pgtype.Text{String: params.Schema, Valid: params.Schema != ""},
 		Topic:   params.Topic,
 	})
 }
@@ -615,7 +629,7 @@ func (e *Executor) PGAdvisoryXactLock(ctx context.Context, key int64) (*struct{}
 }
 
 func (e *Executor) QueueCreateOrSetUpdatedAt(ctx context.Context, params *riverdriver.QueueCreateOrSetUpdatedAtParams) (*rivertype.Queue, error) {
-	queue, err := dbsqlc.New().QueueCreateOrSetUpdatedAt(ctx, e.dbtx, &dbsqlc.QueueCreateOrSetUpdatedAtParams{
+	queue, err := dbsqlc.New().QueueCreateOrSetUpdatedAt(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.QueueCreateOrSetUpdatedAtParams{
 		Metadata:  params.Metadata,
 		Name:      params.Name,
 		PausedAt:  params.PausedAt,
@@ -628,7 +642,7 @@ func (e *Executor) QueueCreateOrSetUpdatedAt(ctx context.Context, params *riverd
 }
 
 func (e *Executor) QueueDeleteExpired(ctx context.Context, params *riverdriver.QueueDeleteExpiredParams) ([]string, error) {
-	queues, err := dbsqlc.New().QueueDeleteExpired(ctx, e.dbtx, &dbsqlc.QueueDeleteExpiredParams{
+	queues, err := dbsqlc.New().QueueDeleteExpired(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.QueueDeleteExpiredParams{
 		Max:              int64(params.Max),
 		UpdatedAtHorizon: params.UpdatedAtHorizon,
 	})
@@ -642,16 +656,16 @@ func (e *Executor) QueueDeleteExpired(ctx context.Context, params *riverdriver.Q
 	return queueNames, nil
 }
 
-func (e *Executor) QueueGet(ctx context.Context, name string) (*rivertype.Queue, error) {
-	queue, err := dbsqlc.New().QueueGet(ctx, e.dbtx, name)
+func (e *Executor) QueueGet(ctx context.Context, params *riverdriver.QueueGetParams) (*rivertype.Queue, error) {
+	queue, err := dbsqlc.New().QueueGet(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.Name)
 	if err != nil {
 		return nil, interpretError(err)
 	}
 	return queueFromInternal(queue), nil
 }
 
-func (e *Executor) QueueList(ctx context.Context, limit int) ([]*rivertype.Queue, error) {
-	internalQueues, err := dbsqlc.New().QueueList(ctx, e.dbtx, int32(min(limit, math.MaxInt32))) //nolint:gosec
+func (e *Executor) QueueList(ctx context.Context, params *riverdriver.QueueListParams) ([]*rivertype.Queue, error) {
+	internalQueues, err := dbsqlc.New().QueueList(schemaTemplateParam(ctx, params.Schema), e.dbtx, int32(min(params.Limit, math.MaxInt32))) //nolint:gosec
 	if err != nil {
 		return nil, interpretError(err)
 	}
@@ -662,30 +676,30 @@ func (e *Executor) QueueList(ctx context.Context, limit int) ([]*rivertype.Queue
 	return queues, nil
 }
 
-func (e *Executor) QueuePause(ctx context.Context, name string) error {
-	res, err := dbsqlc.New().QueuePause(ctx, e.dbtx, name)
+func (e *Executor) QueuePause(ctx context.Context, params *riverdriver.QueuePauseParams) error {
+	res, err := dbsqlc.New().QueuePause(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.Name)
 	if err != nil {
 		return interpretError(err)
 	}
-	if res.RowsAffected() == 0 && name != riverdriver.AllQueuesString {
+	if res.RowsAffected() == 0 && params.Name != riverdriver.AllQueuesString {
 		return rivertype.ErrNotFound
 	}
 	return nil
 }
 
-func (e *Executor) QueueResume(ctx context.Context, name string) error {
-	res, err := dbsqlc.New().QueueResume(ctx, e.dbtx, name)
+func (e *Executor) QueueResume(ctx context.Context, params *riverdriver.QueueResumeParams) error {
+	res, err := dbsqlc.New().QueueResume(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.Name)
 	if err != nil {
 		return interpretError(err)
 	}
-	if res.RowsAffected() == 0 && name != riverdriver.AllQueuesString {
+	if res.RowsAffected() == 0 && params.Name != riverdriver.AllQueuesString {
 		return rivertype.ErrNotFound
 	}
 	return nil
 }
 
 func (e *Executor) QueueUpdate(ctx context.Context, params *riverdriver.QueueUpdateParams) (*rivertype.Queue, error) {
-	queue, err := dbsqlc.New().QueueUpdate(ctx, e.dbtx, &dbsqlc.QueueUpdateParams{
+	queue, err := dbsqlc.New().QueueUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.QueueUpdateParams{
 		Metadata:         params.Metadata,
 		MetadataDoUpdate: params.MetadataDoUpdate,
 		Name:             params.Name,
@@ -696,8 +710,14 @@ func (e *Executor) QueueUpdate(ctx context.Context, params *riverdriver.QueueUpd
 	return queueFromInternal(queue), nil
 }
 
-func (e *Executor) TableExists(ctx context.Context, tableName string) (bool, error) {
-	exists, err := dbsqlc.New().TableExists(ctx, e.dbtx, tableName)
+func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExistsParams) (bool, error) {
+	// Different from other operations because the schemaAndTable name is a parameter.
+	schemaAndTable := params.Table
+	if params.Schema != "" {
+		schemaAndTable = params.Schema + "." + schemaAndTable
+	}
+
+	exists, err := dbsqlc.New().TableExists(ctx, e.dbtx, schemaAndTable)
 	return exists, interpretError(err)
 }
 
@@ -717,8 +737,9 @@ func (t *ExecutorTx) Rollback(ctx context.Context) error {
 type Listener struct {
 	conn   *pgx.Conn
 	dbPool *pgxpool.Pool
-	prefix string
+	prefix string // schema with a dot on the end (very minor optimization)
 	mu     sync.Mutex
+	schema string
 }
 
 func (l *Listener) Close(ctx context.Context) error {
@@ -755,10 +776,15 @@ func (l *Listener) Connect(ctx context.Context) error {
 		return err
 	}
 
-	var schema string
-	if err := poolConn.QueryRow(ctx, "SELECT current_schema();").Scan(&schema); err != nil {
-		poolConn.Release()
-		return err
+	// Use a configured schema if non-empty, otherwise try to select the current
+	// schema based on `search_path`.
+	schema := l.schema
+	if schema == "" {
+		if err := poolConn.QueryRow(ctx, "SELECT current_schema();").Scan(&schema); err != nil {
+			poolConn.Release()
+			return err
+		}
+		l.schema = schema
 	}
 
 	l.prefix = schema + "."
@@ -782,6 +808,13 @@ func (l *Listener) Ping(ctx context.Context) error {
 	defer l.mu.Unlock()
 
 	return l.conn.Ping(ctx)
+}
+
+func (l *Listener) Schema() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.schema
 }
 
 func (l *Listener) Unlisten(ctx context.Context, topic string) error {
@@ -945,4 +978,14 @@ func queueFromInternal(internal *dbsqlc.RiverQueue) *rivertype.Queue {
 		PausedAt:  pausedAt,
 		UpdatedAt: internal.UpdatedAt.UTC(),
 	}
+}
+
+func schemaTemplateParam(ctx context.Context, schema string) context.Context {
+	if schema != "" {
+		schema += "."
+	}
+
+	return sqlctemplate.WithReplacements(ctx, map[string]sqlctemplate.Replacement{
+		"schema": {Value: schema},
+	}, nil)
 }

--- a/rivermigrate/migration/commit_required/001_first.down.sql
+++ b/rivermigrate/migration/commit_required/001_first.down.sql
@@ -1,1 +1,1 @@
-DROP TYPE foobar;
+DROP TYPE /* TEMPLATE: schema */foobar;

--- a/rivermigrate/migration/commit_required/001_first.up.sql
+++ b/rivermigrate/migration/commit_required/001_first.up.sql
@@ -1,2 +1,2 @@
 -- create a foobar enum with values foo, bar:
-CREATE TYPE foobar AS ENUM ('foo', 'bar');
+CREATE TYPE /* TEMPLATE: schema */foobar AS ENUM ('foo', 'bar');

--- a/rivermigrate/migration/commit_required/002_second.down.sql
+++ b/rivermigrate/migration/commit_required/002_second.down.sql
@@ -1,1 +1,3 @@
 -- not truly reversible, can't remove enum values.
+--
+-- here to prevent templating system from throwing here: /* TEMPLATE: schema */

--- a/rivermigrate/migration/commit_required/002_second.up.sql
+++ b/rivermigrate/migration/commit_required/002_second.up.sql
@@ -1,1 +1,1 @@
-ALTER TYPE foobar ADD VALUE 'baz' AFTER 'bar';
+ALTER TYPE /* TEMPLATE: schema */foobar ADD VALUE 'baz' AFTER 'bar';

--- a/rivermigrate/migration/commit_required/003_third.down.sql
+++ b/rivermigrate/migration/commit_required/003_third.down.sql
@@ -1,1 +1,1 @@
-DROP FUNCTION foobar_in_bitmask;
+DROP FUNCTION /* TEMPLATE: schema */foobar_in_bitmask;

--- a/rivermigrate/migration/commit_required/003_third.up.sql
+++ b/rivermigrate/migration/commit_required/003_third.up.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION foobar_in_bitmask(bitmask BIT(8), val foobar)
+CREATE OR REPLACE FUNCTION /* TEMPLATE: schema */foobar_in_bitmask(bitmask BIT(8), val /* TEMPLATE: schema */foobar)
 RETURNS boolean
 LANGUAGE SQL
 IMMUTABLE

--- a/rivershared/riverpilot/pilot.go
+++ b/rivershared/riverpilot/pilot.go
@@ -26,7 +26,7 @@ type Pilot interface {
 	JobInsertMany(
 		ctx context.Context,
 		tx riverdriver.ExecutorTx,
-		params []*riverdriver.JobInsertFastParams,
+		params *riverdriver.JobInsertFastManyParams,
 	) ([]*riverdriver.JobInsertFastResult, error)
 
 	JobSetStateIfRunningMany(ctx context.Context, tx riverdriver.ExecutorTx, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error)
@@ -54,4 +54,5 @@ type ProducerInitParams struct {
 	ProducerID    int64
 	Queue         string
 	QueueMetadata []byte
+	Schema        string
 }

--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -23,7 +23,7 @@ func (p *StandardPilot) JobGetAvailable(ctx context.Context, exec riverdriver.Ex
 func (p *StandardPilot) JobInsertMany(
 	ctx context.Context,
 	tx riverdriver.ExecutorTx,
-	params []*riverdriver.JobInsertFastParams,
+	params *riverdriver.JobInsertFastManyParams,
 ) ([]*riverdriver.JobInsertFastResult, error) {
 	return tx.JobInsertFastMany(ctx, params)
 }

--- a/rivershared/testfactory/test_factory.go
+++ b/rivershared/testfactory/test_factory.go
@@ -118,10 +118,11 @@ type MigrationOpts struct {
 func Migration(ctx context.Context, tb testing.TB, exec riverdriver.Executor, opts *MigrationOpts) *riverdriver.Migration {
 	tb.Helper()
 
-	migration, err := exec.MigrationInsertMany(ctx,
-		ptrutil.ValOrDefault(opts.Line, riverdriver.MigrationLineMain),
-		[]int{ptrutil.ValOrDefaultFunc(opts.Version, nextSeq)},
-	)
+	migration, err := exec.MigrationInsertMany(ctx, &riverdriver.MigrationInsertManyParams{
+		Line:     ptrutil.ValOrDefault(opts.Line, riverdriver.MigrationLineMain),
+		Schema:   "",
+		Versions: []int{ptrutil.ValOrDefaultFunc(opts.Version, nextSeq)},
+	})
 	require.NoError(tb, err)
 	return migration[0]
 }

--- a/rivertest/rivertest.go
+++ b/rivertest/rivertest.go
@@ -146,7 +146,10 @@ func requireInsertedErr[TDriver riverdriver.Driver[TTx], TTx any, TArgs river.Jo
 	t.Helper()
 
 	// Returned ordered by ID.
-	jobRows, err := exec.JobGetByKindMany(ctx, []string{expectedJob.Kind()})
+	jobRows, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+		Kind:   []string{expectedJob.Kind()},
+		Schema: "",
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error querying jobs: %w", err)
 	}
@@ -242,7 +245,10 @@ func requireNotInsertedErr[TDriver riverdriver.Driver[TTx], TTx any, TArgs river
 	t.Helper()
 
 	// Returned ordered by ID.
-	jobRows, err := exec.JobGetByKindMany(ctx, []string{expectedJob.Kind()})
+	jobRows, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+		Kind:   []string{expectedJob.Kind()},
+		Schema: "",
+	})
 	if err != nil {
 		return fmt.Errorf("error querying jobs: %w", err)
 	}
@@ -363,7 +369,10 @@ func requireManyInsertedErr[TDriver riverdriver.Driver[TTx], TTx any](ctx contex
 	expectedArgsKinds := sliceutil.Map(expectedJobs, func(j ExpectedJob) string { return j.Args.Kind() })
 
 	// Returned ordered by ID.
-	jobRows, err := exec.JobGetByKindMany(ctx, expectedArgsKinds)
+	jobRows, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
+		Kind:   expectedArgsKinds,
+		Schema: "",
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error querying jobs: %w", err)
 	}

--- a/rivertest/worker_test.go
+++ b/rivertest/worker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/internal/execution"
 	"github.com/riverqueue/river/internal/riverinternaltest"
+	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
@@ -397,7 +398,7 @@ func TestWorker_WorkJob(t *testing.T) {
 		require.NoError(t, err)
 
 		bundle.workFunc = func(ctx context.Context, job *river.Job[testArgs]) error {
-			updatedJob, err := bundle.driver.UnwrapExecutor(bundle.tx).JobGetByID(ctx, insertRes.Job.ID)
+			updatedJob, err := bundle.driver.UnwrapExecutor(bundle.tx).JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: insertRes.Job.ID, Schema: ""})
 			require.NoError(t, err)
 			require.Equal(t, rivertype.JobStateRunning, updatedJob.State)
 
@@ -411,7 +412,7 @@ func TestWorker_WorkJob(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 
-		updatedJob, err := bundle.driver.UnwrapExecutor(bundle.tx).JobGetByID(ctx, insertRes.Job.ID)
+		updatedJob, err := bundle.driver.UnwrapExecutor(bundle.tx).JobGetByID(ctx, &riverdriver.JobGetByIDParams{ID: insertRes.Job.ID, Schema: ""})
 		require.NoError(t, err)
 		require.Equal(t, rivertype.JobStateCompleted, updatedJob.State)
 	})


### PR DESCRIPTION
Here, follow up #794 to proof out the injection of an explicit schema
into SQL queries so that putting River in a custom schema doesn't
require the use of `search_path`. We use the newly introduced sqlc
template package to prefix table names like so:

    -- name: JobCountByState :one
    SELECT count(*)
    FROM /* TEMPLATE: schema */river_job
    WHERE state = @state;

The main advantage of this approach compared to `search_path` is that
connections no longer require that their `search_path` be set with an
explicit value to work. `search_path` can be set or misset, but because
table names are prefixed with the right schema name already, queries
still go through. This is especially useful in the context of PgBouncer,
where a valid `search_path` setting can't be guaranteed.

Notably, this change doesn't bring in enough new testing to prove that
River really works with explicit schema injection, so for the time being
this setting remains completely internal. What I'd like to try and do is
get some basic infrastructure like this in place first, then prove it
out by starting to move the test suite over to schema-specific tests. By
virtue of doing that we'd be putting the entire load of the River test
suite on the new paths, which should give us high confidence that it's
all working as intended.