### PR TITLE
Prepare release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2025-03-16
+
 ⚠️ Version 0.19.0 has minor breaking changes for the `Worker.Middleware`, introduced fairly recently in 0.17.0 that has a worker's `Middleware` function now taking a non-generic `JobRow` parameter instead of a generic `Job[T]`. We tried not to make this change, but found the existing middleware interface insufficient to provide the necessary range of functionality we wanted, and this is a secondary middleware facility that won't be in use for many users, so it seemed worthwhile.
 
 ### Added

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -1,16 +1,17 @@
 module github.com/riverqueue/river/cmd/river
 
 go 1.22.0
+
 toolchain go1.23.5
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/lmittmann/tint v1.0.7
-	github.com/riverqueue/river v0.18.0
-	github.com/riverqueue/river/riverdriver v0.18.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.18.0
-	github.com/riverqueue/river/rivershared v0.18.0
-	github.com/riverqueue/river/rivertype v0.18.0
+	github.com/riverqueue/river v0.19.0
+	github.com/riverqueue/river/riverdriver v0.19.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.19.0
+	github.com/riverqueue/river/rivershared v0.19.0
+	github.com/riverqueue/river/rivertype v0.19.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,18 @@
 module github.com/riverqueue/river
 
 go 1.22.0
+
 toolchain go1.23.5
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.18.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.18.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.18.0
-	github.com/riverqueue/river/rivershared v0.18.0
-	github.com/riverqueue/river/rivertype v0.18.0
+	github.com/riverqueue/river/riverdriver v0.19.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.19.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.19.0
+	github.com/riverqueue/river/rivershared v0.19.0
+	github.com/riverqueue/river/rivertype v0.19.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.23.5
 
 require (
-	github.com/riverqueue/river/rivertype v0.18.0
+	github.com/riverqueue/river/rivertype v0.19.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.5
 require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.18.0
-	github.com/riverqueue/river/riverdriver v0.18.0
-	github.com/riverqueue/river/rivershared v0.18.0
-	github.com/riverqueue/river/rivertype v0.18.0
+	github.com/riverqueue/river v0.19.0
+	github.com/riverqueue/river/riverdriver v0.19.0
+	github.com/riverqueue/river/rivershared v0.19.0
+	github.com/riverqueue/river/rivertype v0.19.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,10 +7,10 @@ toolchain go1.23.5
 require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river v0.18.0
-	github.com/riverqueue/river/riverdriver v0.18.0
-	github.com/riverqueue/river/rivershared v0.18.0
-	github.com/riverqueue/river/rivertype v0.18.0
+	github.com/riverqueue/river v0.19.0
+	github.com/riverqueue/river/riverdriver v0.19.0
+	github.com/riverqueue/river/rivershared v0.19.0
+	github.com/riverqueue/river/rivertype v0.19.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -1,12 +1,13 @@
 module github.com/riverqueue/river/rivershared
 
 go 1.22.0
+
 toolchain go1.23.5
 
 require (
-	github.com/riverqueue/river v0.18.0
-	github.com/riverqueue/river/riverdriver v0.18.0
-	github.com/riverqueue/river/rivertype v0.18.0
+	github.com/riverqueue/river v0.19.0
+	github.com/riverqueue/river/riverdriver v0.19.0
+	github.com/riverqueue/river/rivertype v0.19.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.24.0


### PR DESCRIPTION
It's been a while since the last release, and it'd be nice to get a new
release out including some middleware changes and the addition of hooks
so that we can do a fast follow with additions like the upcoming
OpenTelemetry middleware.

[skip ci]