### PR TITLE
Let `update-mod-version` take a `PACKAGE_PREFIX` env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ update-mod-go: ## Update `go`/`toolchain` directives in all submodules to match 
 
 .PHONY: update-mod-version
 update-mod-version: ## Update River packages in all submodules to $VERSION
-	go run ./rivershared/cmd/update-mod-version ./go.work
+	PACKAGE_PREFIX="github.com/riverqueue/river" go run ./rivershared/cmd/update-mod-version ./go.work
 
 .PHONY: verify
 verify: ## Verify generated artifacts

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,7 +25,7 @@ queries. After changing an sqlc `.sql` file, generate Go with:
 
 ## Releasing a new version
 
-1. Fetch changes to the repo and any new tags. Export `VERSION` by incrementing the last tag. Execute `update-submodule-versions` to add it the project's `go.mod` files:
+1. Fetch changes to the repo and any new tags. Export `VERSION` by incrementing the last tag. Execute `update-mod-version` to add it the project's `go.mod` files:
 
     ```shell
     git checkout master && git pull --rebase

--- a/rivershared/cmd/update-mod-version/main.go
+++ b/rivershared/cmd/update-mod-version/main.go
@@ -26,6 +26,13 @@ func main() {
 }
 
 func run() error {
+	// Allows secondary River repositories to make use of this command by
+	// specifying their own prefix.
+	packagePrefix := os.Getenv("PACKAGE_PREFIX")
+	if packagePrefix == "" {
+		return errors.New("expected to find PACKAGE_PREFIX in env")
+	}
+
 	version := os.Getenv("VERSION")
 	if version == "" {
 		return errors.New("expected to find VERSION in env")
@@ -52,14 +59,14 @@ func run() error {
 	}
 
 	for _, workUse := range workFile.Use {
-		if _, err := parseAndUpdateGoModFile("./"+path.Join(workUse.Path, "go.mod"), version); err != nil {
+		if _, err := parseAndUpdateGoModFile("./"+path.Join(workUse.Path, "go.mod"), packagePrefix, version); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func parseAndUpdateGoModFile(filename, version string) (bool, error) {
+func parseAndUpdateGoModFile(filename, packagePrefix, version string) (bool, error) {
 	fileData, err := os.ReadFile(filename)
 	if err != nil {
 		return false, fmt.Errorf("error reading file %q: %w", filename, err)
@@ -75,7 +82,7 @@ func parseAndUpdateGoModFile(filename, version string) (bool, error) {
 	fmt.Printf("%s\n", filename)
 
 	for _, require := range modFile.Require {
-		if !strings.HasPrefix(require.Mod.Path, "github.com/riverqueue/river") {
+		if !strings.HasPrefix(require.Mod.Path, packagePrefix) {
 			continue
 		}
 

--- a/rivershared/cmd/update-mod-version/main_test.go
+++ b/rivershared/cmd/update-mod-version/main_test.go
@@ -50,7 +50,9 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 
 		filename, _ := setup(t)
 
-		anyChanges, err := parseAndUpdateGoModFile(filename, "v0.0.13")
+		const packagePrefix = "github.com/riverqueue/river"
+
+		anyChanges, err := parseAndUpdateGoModFile(filename, packagePrefix, "v0.0.13")
 		require.NoError(t, err)
 		require.True(t, anyChanges)
 
@@ -64,7 +66,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 
 		versions := make([]module.Version, 0, len(modFile.Require))
 		for _, require := range modFile.Require {
-			if !strings.HasPrefix(require.Mod.Path, "github.com/riverqueue/river") {
+			if !strings.HasPrefix(require.Mod.Path, packagePrefix) {
 				continue
 			}
 
@@ -80,7 +82,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 
 		// Running again is allowed and should be idempotent. This time it'll
 		// return that no changes were made.
-		anyChanges, err = parseAndUpdateGoModFile(filename, "v0.0.13")
+		anyChanges, err = parseAndUpdateGoModFile(filename, packagePrefix, "v0.0.13")
 		require.NoError(t, err)
 		require.False(t, anyChanges)
 	})


### PR DESCRIPTION
Here, have `update-mod-version` take a `PACKAGE_PREFIX` env var that
dictates which prefix it'll operate on, defaulting the previous behavior
of `github.com/riverqueue/river`.

The idea here is that we should be able to use reuse this command from
other River repositories like `rivercontrib` to update internal cross
dependencies.