### PR TITLE
(Failed) iterator experiment instead of multiple for loops

### DIFF
--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/cmd/river
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 use (
 	.

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/riverqueue/river/rivertype v0.19.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riverdatabasesql
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riverpgxv5
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/rivershared
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/riverqueue/river v0.19.0

--- a/rivershared/util/sliceutil/slice_util.go
+++ b/rivershared/util/sliceutil/slice_util.go
@@ -4,6 +4,8 @@
 // therefore omitted from the utilities in `slices`.
 package sliceutil
 
+import "iter"
+
 // FirstNonEmpty returns the first non-empty slice from the input, or nil if
 // all input slices are empty.
 func FirstNonEmpty[T any](inputs ...[]T) []T {
@@ -27,6 +29,21 @@ func GroupBy[T any, U comparable](collection []T, keyFunc func(T) U) map[U][]T {
 	}
 
 	return result
+}
+
+func IterateCombined[T any](collection1, collection2 []T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for _, item := range collection1 {
+			if !yield(item) {
+				return
+			}
+		}
+		for _, item := range collection2 {
+			if !yield(item) {
+				return
+			}
+		}
+	}
 }
 
 // KeyBy converts a slice into a map using the key/value tuples returned by

--- a/rivershared/util/sliceutil/slice_util_test.go
+++ b/rivershared/util/sliceutil/slice_util_test.go
@@ -89,3 +89,86 @@ func TestMap(t *testing.T) {
 	require.Equal(t, []string{"Hello", "Hello", "Hello", "Hello"}, result1)
 	require.Equal(t, []string{"1", "2", "3", "4"}, result2)
 }
+
+func BenchmarkIterateCombined(b *testing.B) {
+	var (
+		slice1 = []int{1, 2, 3, 4}
+		slice2 = []int{5, 6, 7, 8}
+	)
+
+	b.Run("IterateCombined", func(b *testing.B) {
+		for range b.N {
+			var total int // try to make sure the loop doesn't get optimized away
+			for item := range IterateCombined(slice1, slice2) {
+				total += item * 100
+			}
+			b.Logf("Total: %d", total)
+		}
+	})
+
+	b.Run("SliceAllocation", func(b *testing.B) {
+		for range b.N {
+			var total int // try to make sure the loop doesn't get optimized away
+			for _, item := range append(slice1, slice2...) {
+				total += item * 100
+			}
+			b.Logf("Total: %d", total)
+		}
+	})
+
+	b.Run("TwoForLoops", func(b *testing.B) {
+		for range b.N {
+			var total int // try to make sure the loop doesn't get optimized away
+			for _, item := range slice1 {
+				total += item * 100
+			}
+			for _, item := range slice2 {
+				total += item * 100
+			}
+			b.Logf("Total: %d", total)
+		}
+	})
+
+	var (
+		slice1Long = make([]int, 100)
+		slice2Long = make([]int, 100)
+	)
+
+	for i := range slice1Long {
+		slice1Long[i] = i + 1
+		slice2Long[i] = i + 1 + 100
+	}
+
+	b.Run("IterateCombinedLong", func(b *testing.B) {
+		for range b.N {
+			var total int // try to make sure the loop doesn't get optimized away
+			for item := range IterateCombined(slice1Long, slice2Long) {
+				total += item * 100
+			}
+			b.Logf("Total: %d", total)
+		}
+	})
+
+	b.Run("SliceAllocationLong", func(b *testing.B) {
+		for range b.N {
+			var total int // try to make sure the loop doesn't get optimized away
+			for _, item := range append(slice1Long, slice2Long...) {
+				total += item * 100
+			}
+			b.Logf("Total: %d", total)
+		}
+	})
+
+	b.Run("TwoForLoopsLong", func(b *testing.B) {
+		for range b.N {
+			var total int // try to make sure the loop doesn't get optimized away
+			for _, item := range slice1Long {
+				total += item * 100
+			}
+			for _, item := range slice2Long {
+				total += item * 100
+			}
+			b.Logf("Total: %d", total)
+		}
+	})
+}

--- a/rivertype/go.mod
+++ b/rivertype/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/rivertype
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
Here, experiment with upgrading to Go 1.23 so we can replace a couple
hooks-related TODOs where we have two separate for loops with a single
invocation that uses an iterator to iterate two slices without an
additional slice invocation.

I'm putting this up for the sake of interest, but it unfortunately turns
out to be quite a failed experiment. The iterators work, but using them
is slower than both the previous two `for` loops, and also slower than
just allocating a new slice with the contents of the previous two and
iterating that.

At larger slice sizes, the iterator becomes marginally faster than
allocating a new slice, but only _marginally_. Using two for loops
continues to be bit a bit faster (perhaps unsurprisingly).

Anyway, opened this for general interest, but am going to close it, and
probably just replace the two for loops with a slice allocation, since
it looks nicer and it's the fastest option for small slices sizes (and
we generally expect hooks to be relatively small slices).

    $ go test ./rivershared/util/sliceutil -bench=.
    goos: darwin
    goarch: arm64
    pkg: github.com/riverqueue/river/rivershared/util/sliceutil
    cpu: Apple M4
    BenchmarkIterateCombined/IterateCombined-10              1481770               822.0 ns/op
    BenchmarkIterateCombined/SliceAllocation-10              1617640               754.1 ns/op
    BenchmarkIterateCombined/TwoForLoops-10                  1560508               775.7 ns/op
    BenchmarkIterateCombined/IterateCombinedLong-10          1393824               863.5 ns/op
    BenchmarkIterateCombined/SliceAllocationLong-10          1399813               866.7 ns/op
    BenchmarkIterateCombined/TwoForLoopsLong-10              1445377               835.2 ns/op
    PASS
    ok      github.com/riverqueue/river/rivershared/util/sliceutil  12.272s