### PR TITLE
Iterate over combined hook slices instead of iterating using two loops

### DIFF
--- a/client.go
+++ b/client.go
@@ -1597,17 +1597,10 @@ func (c *Client[TTx]) insertManyShared(
 ) ([]*rivertype.JobInsertResult, error) {
 	doInner := func(ctx context.Context) ([]*rivertype.JobInsertResult, error) {
 		for _, params := range insertParams {
-			// TODO(brandur): This range clause and the one below it are
-			// identical, and it'd be nice to merge them together, but in such a
-			// way that doesn't require array allocation. I think we can do this
-			// using iterators after we drop support for Go 1.22.
-			for _, hook := range c.hookLookupGlobal.ByHookKind(hooklookup.HookKindInsertBegin) {
-				if err := hook.(rivertype.HookInsertBegin).InsertBegin(ctx, params); err != nil { //nolint:forcetypeassert
-					return nil, err
-				}
-			}
-
-			for _, hook := range c.hookLookupByJob.ByJobArgs(params.Args).ByHookKind(hooklookup.HookKindInsertBegin) {
+			for _, hook := range append(
+				c.hookLookupGlobal.ByHookKind(hooklookup.HookKindInsertBegin),
+				c.hookLookupByJob.ByJobArgs(params.Args).ByHookKind(hooklookup.HookKindInsertBegin)...,
+			) {
 				if err := hook.(rivertype.HookInsertBegin).InsertBegin(ctx, params); err != nil { //nolint:forcetypeassert
 					return nil, err
 				}

--- a/internal/jobexecutor/job_executor.go
+++ b/internal/jobexecutor/job_executor.go
@@ -189,17 +189,10 @@ func (e *JobExecutor) execute(ctx context.Context) (res *jobExecutorResult) {
 
 	doInner := execution.Func(func(ctx context.Context) error {
 		{
-			// TODO(brandur): This range clause and the one below it are
-			// identical, and it'd be nice to merge them together, but in such a
-			// way that doesn't require array allocation. I think we can do this
-			// using iterators after we drop support for Go 1.22.
-			for _, hook := range e.HookLookupGlobal.ByHookKind(hooklookup.HookKindWorkBegin) {
-				if err := hook.(rivertype.HookWorkBegin).WorkBegin(ctx, e.JobRow); err != nil { //nolint:forcetypeassert
-					return err
-				}
-			}
-
-			for _, hook := range e.WorkUnit.HookLookup(e.HookLookupByJob).ByHookKind(hooklookup.HookKindWorkBegin) {
+			for _, hook := range append(
+				e.HookLookupGlobal.ByHookKind(hooklookup.HookKindWorkBegin),
+				e.WorkUnit.HookLookup(e.HookLookupByJob).ByHookKind(hooklookup.HookKindWorkBegin)...,
+			) {
 				if err := hook.(rivertype.HookWorkBegin).WorkBegin(ctx, e.JobRow); err != nil { //nolint:forcetypeassert
 					return err
 				}


### PR DESCRIPTION
Clean up some duplicated code in which we were previously iterating over
two sets of hooks and running the same code on both collections, and I'd
left a TODO to investigate the use of sequences instead to avoid a slice
allocation.

I ran the sequences experiment over in #809, and although I'd still
defend it as a worthwhile prototype, it turns out that using sequences
only becomes more efficient than allocating an extra slice once we get
to fairly large slice sizes, and even there the benefit is quite
marginal.

The benchmarks also show that at smaller slice sizes, it's actually a
tiny bit faster allocating a slice to iterate over once instead of using
two for loops. This is convenient because that sure looks a lot nicer
code-wise anyway, so here we switch over to that approach and remove the
TODOs.