### PR TITLE
Set minimum Go version to Go 1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set minimum Go version to Go 1.23. [PR #811](https://github.com/riverqueue/river/pull/811).
+
 ## [0.19.0] - 2025-03-16
 
 ⚠️ Version 0.19.0 has minor breaking changes for the `Worker.Middleware`, introduced fairly recently in 0.17.0 that has a worker's `Middleware` function now taking a non-generic `JobRow` parameter instead of a generic `Job[T]`. We tried not to make this change, but found the existing middleware interface insufficient to provide the necessary range of functionality we wanted, and this is a secondary middleware facility that won't be in use for many users, so it seemed worthwhile.

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/cmd/river
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 use (
 	.

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/riverqueue/river/rivertype v0.19.0

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riverdatabasesql
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riverpgxv5
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.2

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/rivershared
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require (
 	github.com/riverqueue/river v0.19.0

--- a/rivertype/go.mod
+++ b/rivertype/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/rivertype
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.24.1
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
As noted over in [1], it seems that `x/text` has already started
requiring Go 1.23 as its minimum version, meaning the writing's on the
wall for Go 1.22.

Go's official versioning policy is support for the last two minor
versions, and given Go 1.24's been out for some time now, it seems like
not a bad time to let 1.22 ride off into the sunset.

[1] https://github.com/riverqueue/riverui/pull/311#issuecomment-2730760360