### PR TITLE
Deprecate per-operation middleware operation defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set minimum Go version to Go 1.23. [PR #811](https://github.com/riverqueue/river/pull/811).
+- Deprecate `river.JobInsertMiddlewareDefaults` and `river.WorkerMiddlewareDefaults` in favor of the more general `river.MiddlewareDefaults` embeddable struct. The two former structs will be removed in a future version. [PR #815](https://github.com/riverqueue/river/pull/815).
 
 ## [0.19.0] - 2025-03-16
 

--- a/hook_defaults_funcs.go
+++ b/hook_defaults_funcs.go
@@ -6,9 +6,9 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-// HookDefaults should be embedded on any hook implementation. It helps
-// guarantee forward compatibility in case additions are necessary to the Hook
-// interface.
+// HookDefaults should be embedded on any hooks implementation. It helps
+// identify a struct as hooks, and guarantee forward compatibility in case
+// additions are necessary to the rivertype.Hook interface.
 type HookDefaults struct{}
 
 func (d *HookDefaults) IsHook() bool { return true }

--- a/middleware_defaults.go
+++ b/middleware_defaults.go
@@ -6,6 +6,9 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
+// MiddlewareDefaults should be embedded on any middleware implementation. It
+// helps identify a struct as middleware, and guarantees forward compatibility in
+// case additions are necessary to the rivertype.Middleware interface.
 type MiddlewareDefaults struct{}
 
 func (d *MiddlewareDefaults) IsMiddleware() bool { return true }
@@ -14,6 +17,8 @@ func (d *MiddlewareDefaults) IsMiddleware() bool { return true }
 // implementations for the rivertype.JobInsertMiddleware. Use of this struct is
 // recommended in case rivertype.JobInsertMiddleware is expanded in the future
 // so that existing code isn't unexpectedly broken during an upgrade.
+//
+// Deprecated: Prefer embedding the more general MiddlewareDefaults instead.
 type JobInsertMiddlewareDefaults struct{ MiddlewareDefaults }
 
 func (d *JobInsertMiddlewareDefaults) InsertMany(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error) {
@@ -24,6 +29,8 @@ func (d *JobInsertMiddlewareDefaults) InsertMany(ctx context.Context, manyParams
 // implementations for the rivertype.WorkerMiddleware. Use of this struct is
 // recommended in case rivertype.WorkerMiddleware is expanded in the future so
 // that existing code isn't unexpectedly broken during an upgrade.
+//
+// Deprecated: Prefer embedding the more general MiddlewareDefaults instead.
 type WorkerMiddlewareDefaults struct{ MiddlewareDefaults }
 
 func (d *WorkerMiddlewareDefaults) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {


### PR DESCRIPTION
As per #804, middleware has been restructed to look more like the design
of hooks, and I was finding that as I restructuring documentation as
part of [1] it was hard to recommend the use of per-operation middleware
defaults.

Here, deprecate the per-operation defaults in favor of just the single
`river.MiddlewareDefaults` struct. This should also be somewhat more
beneficial in case more middleware operations need to be added in the
future because we'll just have fewer total new types emerge out of it.

[1] https://github.com/riverqueue/homepage/pull/198