### PR TITLE
Expand pilot APIs for state tracking, queue metadata changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a `QueueUpdate` API to the `Client` which will be used for upcoming functionality. [PR #822](https://github.com/riverqueue/river/pull/822).
+
 ### Changed
 
 - Set minimum Go version to Go 1.23. [PR #811](https://github.com/riverqueue/river/pull/811).

--- a/client.go
+++ b/client.go
@@ -863,7 +863,7 @@ func (c *Client[TTx]) Start(ctx context.Context) error {
 		// We use separate contexts for fetching and working to allow for a graceful
 		// stop. Both inherit from the provided context, so if it's cancelled, a
 		// more aggressive stop will be initiated.
-		workCtx, workCancel := context.WithCancelCause(withClient[TTx](ctx, c))
+		workCtx, workCancel := context.WithCancelCause(withClient(ctx, c))
 
 		if err := startstop.StartAll(fetchCtx, c.services...); err != nil {
 			workCancel(err)

--- a/client.go
+++ b/client.go
@@ -1809,7 +1809,7 @@ func (c *Client[TTx]) notifyQueuePauseOrResume(ctx context.Context, tx riverdriv
 		slog.String("opts", fmt.Sprintf("%+v", opts)),
 	)
 
-	payload, err := json.Marshal(jobControlPayload{Action: action, Queue: queue})
+	payload, err := json.Marshal(controlEventPayload{Action: action, Queue: queue})
 	if err != nil {
 		return err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -5423,14 +5423,14 @@ func Test_NewClient_MissingParameters(t *testing.T) {
 	t.Run("ErrorOnNilConfig", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewClient[pgx.Tx](riverpgxv5.New(nil), nil)
+		_, err := NewClient(riverpgxv5.New(nil), nil)
 		require.ErrorIs(t, err, errMissingConfig)
 	})
 
 	t.Run("ErrorOnDriverWithNoDatabasePoolAndQueues", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewClient[pgx.Tx](riverpgxv5.New(nil), newTestConfig(t, nil))
+		_, err := NewClient(riverpgxv5.New(nil), newTestConfig(t, nil))
 		require.ErrorIs(t, err, errMissingDatabasePoolWithQueues)
 	})
 }

--- a/driver_test.go
+++ b/driver_test.go
@@ -157,9 +157,9 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 
 		for range b.N {
 			if _, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         100,
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      100,
+				Queue:    rivercommon.QueueDefault,
 			}); err != nil {
 				b.Fatal(err)
 			}
@@ -183,9 +183,9 @@ func BenchmarkDriverRiverPgxV5_Executor(b *testing.B) {
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				if _, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-					AttemptedBy: clientID,
-					Max:         100,
-					Queue:       rivercommon.QueueDefault,
+					ClientID: clientID,
+					Max:      100,
+					Queue:    rivercommon.QueueDefault,
 				}); err != nil {
 					b.Fatal(err)
 				}

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -2893,6 +2893,42 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 				require.NoError(t, exec.QueueResume(ctx, rivercommon.AllQueuesString))
 			})
 		})
+
+		t.Run("QueueUpdate", func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("UpdatesFieldsIfDoUpdateIsTrue", func(t *testing.T) {
+				t.Parallel()
+
+				exec, _ := setup(ctx, t)
+
+				queue := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Metadata: []byte(`{"foo": "bar"}`)})
+
+				updatedQueue, err := exec.QueueUpdate(ctx, &riverdriver.QueueUpdateParams{
+					Metadata:         []byte(`{"baz": "qux"}`),
+					MetadataDoUpdate: true,
+					Name:             queue.Name,
+				})
+				require.NoError(t, err)
+				require.Equal(t, []byte(`{"baz": "qux"}`), updatedQueue.Metadata)
+			})
+
+			t.Run("DoesNotUpdateFieldsIfDoUpdateIsFalse", func(t *testing.T) {
+				t.Parallel()
+
+				exec, _ := setup(ctx, t)
+
+				queue := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Metadata: []byte(`{"foo": "bar"}`)})
+
+				updatedQueue, err := exec.QueueUpdate(ctx, &riverdriver.QueueUpdateParams{
+					Metadata:         []byte(`{"baz": "qux"}`),
+					MetadataDoUpdate: false,
+					Name:             queue.Name,
+				})
+				require.NoError(t, err)
+				require.Equal(t, []byte(`{"foo": "bar"}`), updatedQueue.Metadata)
+			})
+		})
 	})
 }
 

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -497,9 +497,9 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{})
 
 			jobRows, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         100,
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      100,
+				Queue:    rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
 			require.Len(t, jobRows, 1)
@@ -518,9 +518,9 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 			// Two rows inserted but only one found because of the added limit.
 			jobRows, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         1,
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      1,
+				Queue:    rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
 			require.Len(t, jobRows, 1)
@@ -537,9 +537,9 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 			// Job is in a non-default queue so it's not found.
 			jobRows, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         100,
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      100,
+				Queue:    rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
 			require.Empty(t, jobRows)
@@ -556,9 +556,9 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 			// Job is scheduled a while from now so it's not found.
 			jobRows, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         100,
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      100,
+				Queue:    rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
 			require.Empty(t, jobRows)
@@ -580,10 +580,10 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			})
 
 			jobRows, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         100,
-				Now:         ptrutil.Ptr(now),
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      100,
+				Now:      ptrutil.Ptr(now),
+				Queue:    rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
 			require.Len(t, jobRows, 1)
@@ -603,9 +603,9 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			}
 
 			jobRows, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         2,
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      2,
+				Queue:    rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
 			require.Len(t, jobRows, 2, "expected to fetch exactly 2 jobs")
@@ -622,9 +622,9 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 			// Should fetch the one remaining job on the next attempt:
 			jobRows, err = exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
-				AttemptedBy: clientID,
-				Max:         1,
-				Queue:       rivercommon.QueueDefault,
+				ClientID: clientID,
+				Max:      1,
+				Queue:    rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
 			require.NoError(t, err)
@@ -2910,7 +2910,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 					Name:             queue.Name,
 				})
 				require.NoError(t, err)
-				require.Equal(t, []byte(`{"baz": "qux"}`), updatedQueue.Metadata)
+				require.JSONEq(t, `{"baz": "qux"}`, string(updatedQueue.Metadata))
 			})
 
 			t.Run("DoesNotUpdateFieldsIfDoUpdateIsFalse", func(t *testing.T) {
@@ -2926,7 +2926,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 					Name:             queue.Name,
 				})
 				require.NoError(t, err)
-				require.Equal(t, []byte(`{"foo": "bar"}`), updatedQueue.Metadata)
+				require.JSONEq(t, `{"foo": "bar"}`, string(updatedQueue.Metadata))
 			})
 		})
 	})

--- a/producer.go
+++ b/producer.go
@@ -409,7 +409,7 @@ const (
 
 type controlEventPayload struct {
 	Action   controlAction `json:"action"`
-	JobID    int64         `json:"job_id"`
+	JobID    int64         `json:"job_id,omitempty"`
 	Metadata []byte        `json:"metadata,omitempty"`
 	Queue    string        `json:"queue"`
 }

--- a/producer.go
+++ b/producer.go
@@ -1,11 +1,14 @@
 package river
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"math"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -19,23 +22,28 @@ import (
 	"github.com/riverqueue/river/internal/workunit"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivershared/riverpilot"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
 const (
-	queuePollIntervalDefault   = 2 * time.Second
-	queueReportIntervalDefault = 10 * time.Minute
+	producerReportIntervalDefault = time.Minute
+	queuePollIntervalDefault      = 2 * time.Second
+	queueReportIntervalDefault    = 10 * time.Minute
 )
 
 // Test-only properties.
 type producerTestSignals struct {
 	DeletedExpiredQueueRecords testsignal.TestSignal[struct{}] // notifies when the producer deletes expired queue records
+	MetadataChanged            testsignal.TestSignal[struct{}] // notifies when the producer detects a metadata change
 	Paused                     testsignal.TestSignal[struct{}] // notifies when the producer is paused
 	PolledQueueConfig          testsignal.TestSignal[struct{}] // notifies when the producer polls for queue settings
+	ReportedProducerStatus     testsignal.TestSignal[struct{}] // notifies when the producer reports its own status
 	ReportedQueueStatus        testsignal.TestSignal[struct{}] // notifies when the producer reports queue status
 	Resumed                    testsignal.TestSignal[struct{}] // notifies when the producer is resumed
 	StartedExecutors           testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
@@ -43,9 +51,11 @@ type producerTestSignals struct {
 
 func (ts *producerTestSignals) Init() {
 	ts.DeletedExpiredQueueRecords.Init()
+	ts.MetadataChanged.Init()
 	ts.Paused.Init()
 	ts.PolledQueueConfig.Init()
 	ts.ReportedQueueStatus.Init()
+	ts.ReportedProducerStatus.Init()
 	ts.Resumed.Init()
 	ts.StartedExecutors.Init()
 }
@@ -75,6 +85,9 @@ type producerConfig struct {
 	// Notifier is a notifier for subscribing to new job inserts and job
 	// control. If nil, the producer will operate in poll-only mode.
 	Notifier *notifier.Notifier
+	// ProducerReportInterval is the amount of time between periodic reports
+	// of the producer status.
+	ProducerReportInterval time.Duration
 
 	Queue string
 	// QueueEventCallback gets called when a queue's config changes (such as
@@ -87,10 +100,11 @@ type producerConfig struct {
 	QueuePollInterval time.Duration
 	// QueueReportInterval is the amount of time between periodic reports
 	// of the queue status.
-	QueueReportInterval time.Duration
-	RetryPolicy         ClientRetryPolicy
-	SchedulerInterval   time.Duration
-	Workers             *Workers
+	QueueReportInterval          time.Duration
+	RetryPolicy                  ClientRetryPolicy
+	SchedulerInterval            time.Duration
+	StaleProducerRetentionPeriod time.Duration
+	Workers                      *Workers
 }
 
 func (c *producerConfig) mustValidate() *producerConfig {
@@ -112,6 +126,9 @@ func (c *producerConfig) mustValidate() *producerConfig {
 	if c.MaxWorkers == 0 {
 		panic("producerConfig.MaxWorkers is required")
 	}
+	if c.ProducerReportInterval == 0 {
+		c.ProducerReportInterval = producerReportIntervalDefault
+	}
 	if c.Queue == "" {
 		panic("producerConfig.Queue is required")
 	}
@@ -132,6 +149,9 @@ func (c *producerConfig) mustValidate() *producerConfig {
 	}
 	if c.SchedulerInterval == 0 {
 		panic("producerConfig.SchedulerInterval is required")
+	}
+	if c.StaleProducerRetentionPeriod <= 0 {
+		panic("producerConfig.StaleProducerRetentionPeriod must be greater than zero")
 	}
 	if c.Workers == nil {
 		panic("producerConfig.Workers is required")
@@ -156,8 +176,11 @@ type producer struct {
 
 	completer    jobcompleter.JobCompleter
 	config       *producerConfig
+	id           int64
 	exec         riverdriver.Executor
 	errorHandler jobexecutor.ErrorHandler
+	state        riverpilot.ProducerState
+	pilot        riverpilot.Pilot
 	workers      *Workers
 
 	// Receives job IDs to cancel. Written by notifier goroutine, only read from
@@ -188,7 +211,7 @@ type producer struct {
 	testSignals    producerTestSignals
 }
 
-func newProducer(archetype *baseservice.Archetype, exec riverdriver.Executor, config *producerConfig) *producer {
+func newProducer(archetype *baseservice.Archetype, exec riverdriver.Executor, pilot riverpilot.Pilot, config *producerConfig) *producer {
 	if archetype == nil {
 		panic("archetype is required")
 	}
@@ -210,6 +233,7 @@ func newProducer(archetype *baseservice.Archetype, exec riverdriver.Executor, co
 		errorHandler:   errorHandler,
 		jobResultCh:    make(chan *rivertype.JobRow, config.MaxWorkers),
 		jobTimeout:     config.JobTimeout,
+		pilot:          pilot,
 		queueControlCh: make(chan *controlEventPayload, 100),
 		retryPolicy:    config.RetryPolicy,
 		workers:        config.Workers,
@@ -228,9 +252,9 @@ func (p *producer) Start(ctx context.Context) error {
 }
 
 func (p *producer) Stop() {
-	p.Logger.Debug(p.Name + ": Stopping")
+	p.Logger.Debug(p.Name+": Stopping", slog.String("queue", p.config.Queue), slog.Int64("id", p.id))
 	p.BaseStartStop.Stop()
-	p.Logger.Debug(p.Name + ": Stop returned")
+	p.Logger.Debug(p.Name+": Stop returned", slog.String("queue", p.config.Queue), slog.Int64("id", p.id))
 }
 
 // Start starts the producer. It backgrounds a goroutine which is stopped when
@@ -246,7 +270,11 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 		return nil
 	}
 
-	queue, err := func() (*rivertype.Queue, error) {
+	isExpectedShutdownError := func(err error) bool {
+		return errors.Is(err, startstop.ErrStop) || strings.HasSuffix(err.Error(), "conn closed") || fetchCtx.Err() != nil
+	}
+
+	fetchedQueue, err := func() (*rivertype.Queue, error) {
 		ctx, cancel := context.WithTimeout(fetchCtx, 10*time.Second)
 		defer cancel()
 
@@ -258,15 +286,33 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 	}()
 	if err != nil {
 		stopped()
-		if errors.Is(err, startstop.ErrStop) || strings.HasSuffix(err.Error(), "conn closed") || fetchCtx.Err() != nil {
-			return nil //nolint:nilerr
+		if isExpectedShutdownError(err) {
+			return nil
 		}
 		p.Logger.ErrorContext(fetchCtx, p.Name+": Error fetching initial queue settings", slog.String("err", err.Error()))
 		return err
 	}
 
-	initiallyPaused := queue != nil && (queue.PausedAt != nil)
+	initiallyPaused := fetchedQueue != nil && (fetchedQueue.PausedAt != nil)
+	initialMetadata := []byte("{}")
+	if fetchedQueue != nil {
+		initialMetadata = fetchedQueue.Metadata
+	}
 	p.paused = initiallyPaused
+
+	p.id, p.state, err = p.pilot.ProducerInit(fetchCtx, p.exec, &riverpilot.ProducerInitParams{
+		ClientID:      p.config.ClientID,
+		Queue:         p.config.Queue,
+		QueueMetadata: initialMetadata,
+	})
+	if err != nil {
+		stopped()
+		if isExpectedShutdownError(err) {
+			return nil
+		}
+		p.Logger.ErrorContext(fetchCtx, p.Name+": Error initializing producer state", slog.String("err", err.Error()))
+		return err
+	}
 
 	// TODO: fetcher should have some jitter in it to avoid stampeding issues.
 	fetchLimiter := chanutil.NewDebouncedChan(fetchCtx, p.config.FetchCooldown, true)
@@ -278,7 +324,7 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 	if p.config.Notifier == nil {
 		p.Logger.DebugContext(fetchCtx, p.Name+": No notifier configured; starting in poll mode", "client_id", p.config.ClientID)
 
-		go p.pollForSettingChanges(fetchCtx, initiallyPaused)
+		go p.pollForSettingChanges(fetchCtx, initiallyPaused, initialMetadata)
 	} else {
 		var err error
 
@@ -330,11 +376,23 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 			defer controlSub.Unlisten(fetchCtx)
 		}
 
-		go p.heartbeatLogLoop(fetchCtx)
-		go p.reportQueueStatusLoop(fetchCtx)
-		p.fetchAndRunLoop(fetchCtx, workCtx, fetchLimiter)
+		var subroutineWg sync.WaitGroup
+		subroutineWg.Add(3)
+		subroutineCtx, cancelSubroutines := context.WithCancelCause(context.WithoutCancel(fetchCtx))
+		go p.heartbeatLogLoop(subroutineCtx, &subroutineWg)
+		go p.reportQueueStatusLoop(subroutineCtx, &subroutineWg)
+		go p.reportProducerStatusLoop(subroutineCtx, &subroutineWg)
 
+		p.fetchAndRunLoop(fetchCtx, workCtx, fetchLimiter)
+		p.Logger.Debug(p.Name+": Entering shutdown loop", slog.String("queue", p.config.Queue), slog.Int64("id", p.id))
 		p.executorShutdownLoop()
+
+		p.Logger.Debug(p.Name+": Shutdown loop exited, awaiting subroutines", slog.String("queue", p.config.Queue), slog.Int64("id", p.id))
+		cancelSubroutines(errors.New("producer stopped"))
+		subroutineWg.Wait()
+		p.Logger.Debug(p.Name+": Shutdown subroutines completed, finalizing", slog.String("queue", p.config.Queue), slog.Int64("id", p.id))
+
+		p.finalizeShutdown(context.WithoutCancel(fetchCtx))
 	}()
 
 	return nil
@@ -343,15 +401,17 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 type controlAction string
 
 const (
-	controlActionCancel controlAction = "cancel"
-	controlActionPause  controlAction = "pause"
-	controlActionResume controlAction = "resume"
+	controlActionCancel          controlAction = "cancel"
+	controlActionMetadataChanged controlAction = "metadata_changed"
+	controlActionPause           controlAction = "pause"
+	controlActionResume          controlAction = "resume"
 )
 
 type controlEventPayload struct {
-	Action controlAction `json:"action"`
-	JobID  int64         `json:"job_id"`
-	Queue  string        `json:"queue"`
+	Action   controlAction `json:"action"`
+	JobID    int64         `json:"job_id"`
+	Metadata []byte        `json:"metadata,omitempty"`
+	Queue    string        `json:"queue"`
 }
 
 type insertPayload struct {
@@ -367,7 +427,7 @@ func (p *producer) handleControlNotification(workCtx context.Context) func(notif
 		}
 
 		switch decoded.Action {
-		case controlActionPause, controlActionResume:
+		case controlActionMetadataChanged, controlActionPause, controlActionResume:
 			if decoded.Queue != rivercommon.AllQueuesString && decoded.Queue != p.config.Queue {
 				p.Logger.DebugContext(workCtx, p.Name+": Queue control notification for other queue", slog.String("action", string(decoded.Action)))
 				return
@@ -432,6 +492,15 @@ func (p *producer) fetchAndRunLoop(fetchCtx, workCtx context.Context, fetchLimit
 			return
 		case msg := <-p.queueControlCh:
 			switch msg.Action {
+			case controlActionCancel:
+				// Separate this case to make linter happy:
+				p.Logger.DebugContext(workCtx, p.Name+": Unhandled queue control action", "action", msg.Action)
+			case controlActionMetadataChanged:
+				p.Logger.DebugContext(workCtx, p.Name+": Queue metadata changed", slog.String("queue", p.config.Queue), slog.String("queue_in_message", msg.Queue))
+				p.testSignals.MetadataChanged.Signal(struct{}{})
+				if err := p.pilot.QueueMetadataChanged(workCtx, p.exec, p.state, msg.Metadata); err != nil {
+					p.Logger.ErrorContext(workCtx, p.Name+": Error updating queue metadata with pilot", slog.String("queue", p.config.Queue), slog.String("err", err.Error()))
+				}
 			case controlActionPause:
 				if p.paused {
 					continue
@@ -452,9 +521,6 @@ func (p *producer) fetchAndRunLoop(fetchCtx, workCtx context.Context, fetchLimit
 				if p.config.QueueEventCallback != nil {
 					p.config.QueueEventCallback(&Event{Kind: EventKindQueueResumed, Queue: &rivertype.Queue{Name: p.config.Queue}})
 				}
-			case controlActionCancel:
-				// Separate this case to make linter happy:
-				p.Logger.DebugContext(workCtx, p.Name+": Unhandled queue control action", "action", msg.Action)
 			default:
 				p.Logger.DebugContext(workCtx, p.Name+": Unknown queue control action", "action", msg.Action)
 			}
@@ -473,7 +539,7 @@ func (p *producer) fetchAndRunLoop(fetchCtx, workCtx context.Context, fetchLimit
 			default:
 			}
 		case result := <-p.jobResultCh:
-			p.removeActiveJob(result.ID)
+			p.removeActiveJob(result)
 			if p.fetchWhenSlotsAreAvailable {
 				// If we missed a fetch because all worker slots were full, or if we
 				// fetched the maximum number of jobs on the last attempt, get a little
@@ -515,7 +581,7 @@ func (p *producer) innerFetchLoop(workCtx context.Context, fetchResultCh chan pr
 			}
 			return
 		case result := <-p.jobResultCh:
-			p.removeActiveJob(result.ID)
+			p.removeActiveJob(result)
 		case jobID := <-p.cancelCh:
 			p.maybeCancelJob(jobID)
 		}
@@ -527,8 +593,55 @@ func (p *producer) executorShutdownLoop() {
 	// in-progress jobs to complete.
 	for len(p.activeJobs) != 0 {
 		result := <-p.jobResultCh
-		p.removeActiveJob(result.ID)
+		p.removeActiveJob(result)
 	}
+}
+
+func (p *producer) finalizeShutdown(ctx context.Context) {
+	p.Logger.Debug(p.Name + ": Finalizing shutdown")
+
+	const (
+		maxAttempts = 4                      // Maximum number of shutdown attempts
+		baseTimeout = 100 * time.Millisecond // Base timeout for the first attempt
+	)
+
+	attemptShutdown := func(timeout time.Duration) error {
+		ctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		if err := p.pilot.ProducerShutdown(ctx, p.exec, p.id, p.state); err != nil {
+			// Don't retry on these errors:
+			// - context.Canceled: parent context is canceled, so retrying with a new timeout won't help
+			// - ErrClosedPool: the database connection pool is closed, so retrying won't succeed
+			if errors.Is(err, context.Canceled) || errors.Is(err, riverdriver.ErrClosedPool) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+
+	// Progressive retry with increasing timeouts:
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		// Exponential backoff with base 5
+		// Attempt 1: 100ms, Attempt 2: 500ms, Attempt 3: 2.5s, Attempt 4: 12.5s
+		timeout := baseTimeout * time.Duration(math.Pow(5, float64(attempt-1)))
+
+		if ctx.Err() != nil {
+			return // Don't retry if parent context is already done
+		}
+
+		if err := attemptShutdown(timeout); err != nil {
+			p.Logger.ErrorContext(ctx, p.Name+": Error shutting down producer with pilot",
+				slog.String("err", err.Error()),
+				slog.Int("attempt", attempt),
+				slog.Duration("timeout", timeout))
+			continue
+		}
+		return
+	}
+
+	p.Logger.WarnContext(ctx, p.Name+": Failed to cleanly shutdown producer after all attempts")
 }
 
 func (p *producer) addActiveJob(id int64, executor *jobexecutor.JobExecutor) {
@@ -536,10 +649,11 @@ func (p *producer) addActiveJob(id int64, executor *jobexecutor.JobExecutor) {
 	p.activeJobs[id] = executor
 }
 
-func (p *producer) removeActiveJob(id int64) {
-	delete(p.activeJobs, id)
+func (p *producer) removeActiveJob(job *rivertype.JobRow) {
+	delete(p.activeJobs, job.ID)
 	p.numJobsActive.Add(-1)
 	p.numJobsRan.Add(1)
+	p.state.JobFinish(job)
 }
 
 func (p *producer) maybeCancelJob(id int64) {
@@ -558,21 +672,28 @@ func (p *producer) dispatchWork(workCtx context.Context, count int, fetchResultC
 	// risk of shutting down when we had already fetched jobs in the database,
 	// leaving those jobs stranded. We'd then potentially have to release them
 	// back to the queue.
-	jobs, err := p.exec.JobGetAvailable(context.WithoutCancel(workCtx), &riverdriver.JobGetAvailableParams{
-		AttemptedBy: p.config.ClientID,
-		Max:         count,
-		Queue:       p.config.Queue,
+	ctx := context.WithoutCancel(workCtx)
+
+	jobs, err := p.pilot.JobGetAvailable(ctx, p.exec, p.state, &riverdriver.JobGetAvailableParams{
+		ClientID:   p.config.ClientID,
+		Max:        count,
+		Queue:      p.config.Queue,
+		ProducerID: p.id,
 	})
 	if err != nil {
+		p.Logger.Error(p.Name+": Error fetching jobs", slog.String("err", err.Error()), slog.String("queue", p.config.Queue))
 		fetchResultCh <- producerFetchResult{err: err}
 		return
 	}
+
 	fetchResultCh <- producerFetchResult{jobs: jobs}
 }
 
 // Periodically logs an informational log line giving some insight into the
 // current state of the producer.
-func (p *producer) heartbeatLogLoop(ctx context.Context) {
+func (p *producer) heartbeatLogLoop(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	type jobCount struct {
@@ -643,7 +764,7 @@ func (p *producer) handleWorkerDone(job *rivertype.JobRow) {
 	p.jobResultCh <- job
 }
 
-func (p *producer) pollForSettingChanges(ctx context.Context, lastPaused bool) {
+func (p *producer) pollForSettingChanges(ctx context.Context, lastPaused bool, lastMetadata []byte) {
 	ticker := time.NewTicker(p.config.QueuePollInterval)
 	for {
 		select {
@@ -655,6 +776,13 @@ func (p *producer) pollForSettingChanges(ctx context.Context, lastPaused bool) {
 				p.Logger.ErrorContext(ctx, p.Name+": Error fetching queue settings", slog.String("err", err.Error()))
 				continue
 			}
+
+			if updatedQueue == nil {
+				p.Logger.ErrorContext(ctx, p.Name+": Queue row not found when polling for setting changes", slog.String("queue", p.config.Queue))
+				continue
+			}
+
+			// Look for a change in the paused state:
 			shouldBePaused := (updatedQueue.PausedAt != nil)
 			if lastPaused != shouldBePaused {
 				action := controlActionPause
@@ -678,6 +806,26 @@ func (p *producer) pollForSettingChanges(ctx context.Context, lastPaused bool) {
 					p.Logger.WarnContext(ctx, p.Name+": Queue control notification dropped due to full buffer", slog.String("action", string(action)))
 				}
 			}
+
+			// Look for a change in the queue's metadata:
+			if !metadataEqual(lastMetadata, updatedQueue.Metadata) {
+				payload := &controlEventPayload{
+					Action:   controlActionMetadataChanged,
+					Queue:    p.config.Queue,
+					Metadata: updatedQueue.Metadata,
+				}
+				p.Logger.DebugContext(ctx, p.Name+": Queue metadata changed from polling",
+					slog.String("queue", p.config.Queue),
+				)
+
+				select {
+				case p.queueControlCh <- payload:
+					lastMetadata = updatedQueue.Metadata
+				default:
+					p.Logger.WarnContext(ctx, p.Name+": Queue control notification dropped due to full buffer", slog.String("action", string(controlActionMetadataChanged)))
+				}
+			}
+
 			p.testSignals.PolledQueueConfig.Signal(struct{}{})
 		}
 	}
@@ -690,7 +838,48 @@ func (p *producer) fetchQueueSettings(ctx context.Context) (*rivertype.Queue, er
 	return p.exec.QueueGet(ctx, p.config.Queue)
 }
 
-func (p *producer) reportQueueStatusLoop(ctx context.Context) {
+func (p *producer) reportProducerStatusLoop(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(0, time.Second))
+	reportTicker := timeutil.NewTickerWithInitialTick(ctx, p.config.ProducerReportInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-reportTicker.C:
+			p.reportProducerStatusOnce(ctx)
+		}
+	}
+}
+
+func (p *producer) reportProducerStatusOnce(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	p.Logger.DebugContext(ctx, p.Name+": Reporting producer status", slog.Int64("id", p.id), slog.String("queue", p.config.Queue))
+	err := p.pilot.ProducerKeepAlive(ctx, p.exec, &riverdriver.ProducerKeepAliveParams{
+		ID:                    p.id,
+		QueueName:             p.config.Queue,
+		StaleUpdatedAtHorizon: p.Time.NowUTC().Add(-p.config.StaleProducerRetentionPeriod),
+	})
+	if err != nil && errors.Is(context.Cause(ctx), startstop.ErrStop) {
+		return
+	}
+	if err != nil {
+		p.Logger.ErrorContext(ctx, p.Name+": Producer status update, error updating in database",
+			slog.Int64("id", p.id),
+			slog.String("queue", p.config.Queue),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+	p.testSignals.ReportedProducerStatus.Signal(struct{}{})
+}
+
+func (p *producer) reportQueueStatusLoop(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(0, time.Second))
 	reportTicker := time.NewTicker(p.config.QueueReportInterval)
 	for {
@@ -740,4 +929,26 @@ func (e *errorHandlerAdapter) HandleError(ctx context.Context, job *rivertype.Jo
 func (e *errorHandlerAdapter) HandlePanic(ctx context.Context, job *rivertype.JobRow, panicVal any, trace string) *jobexecutor.ErrorHandlerResult {
 	result := e.errorHandler.HandlePanic(ctx, job, panicVal, trace)
 	return (*jobexecutor.ErrorHandlerResult)(result)
+}
+
+// metadataEqual compares two JSON byte slices for semantic equality by parsing
+// them into maps and re-marshaling them. This handles cases where the JSON is
+// equivalent but formatted differently (whitespace, field order, etc).
+func metadataEqual(a, b []byte) bool {
+	var unmarshaledA, unmarshaledB map[string]any
+	if err := json.Unmarshal(a, &unmarshaledA); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &unmarshaledB); err != nil {
+		return false
+	}
+	marshaledA, err := json.Marshal(unmarshaledA)
+	if err != nil {
+		return false
+	}
+	marshaledB, err := json.Marshal(unmarshaledB)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(marshaledA, marshaledB)
 }

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -165,6 +165,7 @@ type Executor interface {
 	QueueList(ctx context.Context, limit int) ([]*rivertype.Queue, error)
 	QueuePause(ctx context.Context, name string) error
 	QueueResume(ctx context.Context, name string) error
+	QueueUpdate(ctx context.Context, params *QueueUpdateParams) (*rivertype.Queue, error)
 
 	// TableExists checks whether a table exists for the schema in the current
 	// search schema.
@@ -501,4 +502,10 @@ type QueueCreateOrSetUpdatedAtParams struct {
 type QueueDeleteExpiredParams struct {
 	Max              int
 	UpdatedAtHorizon time.Time
+}
+
+type QueueUpdateParams struct {
+	Metadata         []byte
+	MetadataDoUpdate bool
+	Name             string
 }

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -26,8 +26,9 @@ const AllQueuesString = "*"
 const MigrationLineMain = "main"
 
 var (
-	ErrClosedPool     = errors.New("underlying driver pool is closed")
-	ErrNotImplemented = errors.New("driver does not implement this functionality")
+	ErrClosedPool       = errors.New("underlying driver pool is closed")
+	ErrNotImplemented   = errors.New("driver does not implement this functionality")
+	ErrRetryTransaction = errors.New("expected transaction collision, retry required")
 )
 
 // Driver provides a database driver for use with river.Client.
@@ -222,10 +223,11 @@ type JobDeleteBeforeParams struct {
 }
 
 type JobGetAvailableParams struct {
-	AttemptedBy string
-	Max         int
-	Now         *time.Time
-	Queue       string
+	ClientID   string
+	Max        int
+	Now        *time.Time
+	Queue      string
+	ProducerID int64
 }
 
 type JobGetByKindAndUniquePropertiesParams struct {
@@ -490,6 +492,12 @@ type Migration struct {
 type NotifyManyParams struct {
 	Payload []string
 	Topic   string
+}
+
+type ProducerKeepAliveParams struct {
+	ID                    int64
+	QueueName             string
+	StaleUpdatedAtHorizon time.Time
 }
 
 type QueueCreateOrSetUpdatedAtParams struct {

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -815,6 +815,18 @@ func (e *Executor) QueueResume(ctx context.Context, name string) error {
 	return nil
 }
 
+func (e *Executor) QueueUpdate(ctx context.Context, params *riverdriver.QueueUpdateParams) (*rivertype.Queue, error) {
+	queue, err := dbsqlc.New().QueueUpdate(ctx, e.dbtx, &dbsqlc.QueueUpdateParams{
+		Metadata:         string(params.Metadata),
+		MetadataDoUpdate: params.MetadataDoUpdate,
+		Name:             params.Name,
+	})
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return queueFromInternal(queue), nil
+}
+
 func (e *Executor) TableExists(ctx context.Context, tableName string) (bool, error) {
 	exists, err := dbsqlc.New().TableExists(ctx, e.dbtx, tableName)
 	return exists, interpretError(err)

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -151,7 +151,7 @@ func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobD
 
 func (e *Executor) JobGetAvailable(ctx context.Context, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
 	jobs, err := dbsqlc.New().JobGetAvailable(ctx, e.dbtx, &dbsqlc.JobGetAvailableParams{
-		AttemptedBy: params.AttemptedBy,
+		AttemptedBy: params.ClientID,
 		Max:         int32(min(params.Max, math.MaxInt32)), //nolint:gosec
 		Now:         params.Now,
 		Queue:       params.Queue,

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql
@@ -94,3 +94,11 @@ WHERE name = @name
 UNION
 SELECT *
 FROM updated_queue;
+
+-- name: QueueUpdate :one
+UPDATE river_queue
+SET
+    metadata = CASE WHEN @metadata_do_update::boolean THEN @metadata::jsonb ELSE metadata END,
+    updated_at = now()
+WHERE name = @name::text
+RETURNING river_queue.*;

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql.go
@@ -209,3 +209,31 @@ FROM updated_queue
 func (q *Queries) QueueResume(ctx context.Context, db DBTX, name string) (pgconn.CommandTag, error) {
 	return db.Exec(ctx, queueResume, name)
 }
+
+const queueUpdate = `-- name: QueueUpdate :one
+UPDATE river_queue
+SET
+    metadata = CASE WHEN $1::boolean THEN $2::jsonb ELSE metadata END,
+    updated_at = now()
+WHERE name = $3::text
+RETURNING river_queue.name, river_queue.created_at, river_queue.metadata, river_queue.paused_at, river_queue.updated_at
+`
+
+type QueueUpdateParams struct {
+	MetadataDoUpdate bool
+	Metadata         []byte
+	Name             string
+}
+
+func (q *Queries) QueueUpdate(ctx context.Context, db DBTX, arg *QueueUpdateParams) (*RiverQueue, error) {
+	row := db.QueryRow(ctx, queueUpdate, arg.MetadataDoUpdate, arg.Metadata, arg.Name)
+	var i RiverQueue
+	err := row.Scan(
+		&i.Name,
+		&i.CreatedAt,
+		&i.Metadata,
+		&i.PausedAt,
+		&i.UpdatedAt,
+	)
+	return &i, err
+}

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -684,6 +684,18 @@ func (e *Executor) QueueResume(ctx context.Context, name string) error {
 	return nil
 }
 
+func (e *Executor) QueueUpdate(ctx context.Context, params *riverdriver.QueueUpdateParams) (*rivertype.Queue, error) {
+	queue, err := dbsqlc.New().QueueUpdate(ctx, e.dbtx, &dbsqlc.QueueUpdateParams{
+		Metadata:         params.Metadata,
+		MetadataDoUpdate: params.MetadataDoUpdate,
+		Name:             params.Name,
+	})
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return queueFromInternal(queue), nil
+}
+
 func (e *Executor) TableExists(ctx context.Context, tableName string) (bool, error) {
 	exists, err := dbsqlc.New().TableExists(ctx, e.dbtx, tableName)
 	return exists, interpretError(err)

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -157,7 +157,7 @@ func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobD
 
 func (e *Executor) JobGetAvailable(ctx context.Context, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
 	jobs, err := dbsqlc.New().JobGetAvailable(ctx, e.dbtx, &dbsqlc.JobGetAvailableParams{
-		AttemptedBy: params.AttemptedBy,
+		AttemptedBy: params.ClientID,
 		Max:         int32(min(params.Max, math.MaxInt32)), //nolint:gosec
 		Now:         params.Now,
 		Queue:       params.Queue,

--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -2,13 +2,20 @@ package riverpilot
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivertype"
 )
 
-type StandardPilot struct{}
+type StandardPilot struct {
+	seq atomic.Int64
+}
+
+func (p *StandardPilot) JobGetAvailable(ctx context.Context, exec riverdriver.Executor, state ProducerState, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
+	return exec.JobGetAvailable(ctx, params)
+}
 
 func (p *StandardPilot) JobInsertMany(
 	ctx context.Context,
@@ -23,5 +30,28 @@ func (p *StandardPilot) JobSetStateIfRunningMany(ctx context.Context, tx riverdr
 }
 
 func (p *StandardPilot) PilotInit(archetype *baseservice.Archetype) {
-	// Noop
+	// No-op
+}
+
+func (p *StandardPilot) ProducerInit(ctx context.Context, exec riverdriver.Executor, params *ProducerInitParams) (int64, ProducerState, error) {
+	id := p.seq.Add(1)
+	return id, &standardProducerState{}, nil
+}
+
+func (p *StandardPilot) ProducerKeepAlive(ctx context.Context, exec riverdriver.Executor, params *riverdriver.ProducerKeepAliveParams) error {
+	return nil
+}
+
+func (p *StandardPilot) ProducerShutdown(ctx context.Context, exec riverdriver.Executor, producerID int64, state ProducerState) error {
+	return nil
+}
+
+func (p *StandardPilot) QueueMetadataChanged(ctx context.Context, exec riverdriver.Executor, state ProducerState, metadata []byte) error {
+	return nil
+}
+
+type standardProducerState struct{}
+
+func (s *standardProducerState) JobFinish(job *rivertype.JobRow) {
+	// No-op
 }

--- a/rivershared/testfactory/test_factory.go
+++ b/rivershared/testfactory/test_factory.go
@@ -4,7 +4,6 @@ package testfactory
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -28,7 +27,7 @@ type JobOpts struct {
 	FinalizedAt  *time.Time
 	Kind         *string
 	MaxAttempts  *int
-	Metadata     json.RawMessage
+	Metadata     []byte
 	Priority     *int
 	Queue        *string
 	ScheduledAt  *time.Time

--- a/worker.go
+++ b/worker.go
@@ -102,7 +102,7 @@ func (w WorkerDefaults[T]) Timeout(*Job[T]) time.Duration { return 0 }
 // an application with invalid hardcoded runtime configuration. If you want to
 // avoid panics, use AddWorkerSafely instead.
 func AddWorker[T JobArgs](workers *Workers, worker Worker[T]) {
-	if err := AddWorkerSafely[T](workers, worker); err != nil {
+	if err := AddWorkerSafely(workers, worker); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
This adds expanded integration points at the Pilot level for enabling producer job state tracking. It also adds producer-level monitoring of queue metadata (propagated to the pilot upon change) and a `QueueUpdate` API on the client.

I'm debating a bit on how to document `QueueUpdateMetadata` because it's an advanced API and potentially very footgun-prone. Also how to document it in the changelog for the same reason. The UI will call this for some upcoming features. Thoughts?