### PR TITLE
cleanly error adding queue to client w/out workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set minimum Go version to Go 1.23. [PR #811](https://github.com/riverqueue/river/pull/811).
 - Deprecate `river.JobInsertMiddlewareDefaults` and `river.WorkerMiddlewareDefaults` in favor of the more general `river.MiddlewareDefaults` embeddable struct. The two former structs will be removed in a future version. [PR #815](https://github.com/riverqueue/river/pull/815).
 
+### Fixed
+
+- Cleanly error when attempting to add a queue at runtime to a `Client` which was not configured to run jobs (no `Workers`). [PR #826](https://github.com/riverqueue/river/pull/826).
+
 ## [0.19.0] - 2025-03-16
 
 ⚠️ Version 0.19.0 has minor breaking changes for the `Worker.Middleware`, introduced fairly recently in 0.17.0 that has a worker's `Middleware` function now taking a non-generic `JobRow` parameter instead of a generic `Job[T]`. We tried not to make this change, but found the existing middleware interface insufficient to provide the necessary range of functionality we wanted, and this is a secondary middleware facility that won't be in use for many users, so it seemed worthwhile.

--- a/client_test.go
+++ b/client_test.go
@@ -246,6 +246,19 @@ func Test_Client(t *testing.T) {
 		riversharedtest.WaitOrTimeout(t, workedChan)
 	})
 
+	t.Run("Queues_Add_WhenClientWontExecuteJobs", func(t *testing.T) {
+		t.Parallel()
+
+		config, bundle := setupConfig(t)
+		config.Queues = nil
+		config.Workers = nil
+		client := newTestClient(t, bundle.dbPool, config)
+
+		err := client.Queues().Add("new_queue", QueueConfig{MaxWorkers: 2})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "client is not configured to execute jobs, cannot add queue")
+	})
+
 	t.Run("Queues_Add_BeforeStart", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Prior to this change, calling `.Add()` on the `QueueBundle` for a `Client` which wasn't configured to run any jobs (i.e. no `Workers` configured) resulted in a panic due to a missing completer internally:

```
panic: producerConfig.Completer is required [recovered]
	panic: producerConfig.Completer is required
```

This changes the behavior to cleanly error with a descriptive message instead. Open to any cleaner way to improve this if you have ideas! :pray: