### PR TITLE
Expose `ErrShutdown` sentinel error for client shutdown indication

### DIFF
--- a/error.go
+++ b/error.go
@@ -3,11 +3,15 @@ package river
 import (
 	"time"
 
+	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/rivertype"
 )
 
 // ErrJobCancelledRemotely is a sentinel error indicating that the job was cancelled remotely.
 var ErrJobCancelledRemotely = rivertype.ErrJobCancelledRemotely
+
+// ErrShutdown is a sentinel error indicating that the client is shutting down.
+var ErrShutdown = rivercommon.ErrShutdown
 
 // JobCancelError is the error type returned by JobCancel. It should not be
 // initialized directly, but is returned from the [JobCancel] function and can

--- a/internal/rivercommon/river_common.go
+++ b/internal/rivercommon/river_common.go
@@ -20,6 +20,5 @@ type ContextKeyClient struct{}
 
 // ErrShutdown is a special error injected by the client into its fetch and work
 // CancelCauseFuncs when it's stopping. It may be used by components for such
-// cases like avoiding logging an error during a normal shutdown procedure. This
-// is internal for the time being, but we could also consider exposing it.
+// cases like avoiding logging an error during a normal shutdown procedure.
 var ErrShutdown = errors.New("shutdown initiated")


### PR DESCRIPTION
This PR exposes `ErrShutdown` from `internal/rivercommon` so callers can use `errors.Is` to determine if the error was caused by shutdown.

