### PR TITLE
use json.RawMessage for controlEventPayload.Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the serialization of queue control event payloads emitted by `QueueUpdate`. [PR #834](https://github.com/riverqueue/river/pull/834).
+
 ## [0.20.0] - 2025-04-04
 
 ### Added

--- a/client_test.go
+++ b/client_test.go
@@ -1114,9 +1114,9 @@ func Test_Client(t *testing.T) {
 		startClient(ctx, t, client)
 
 		type metadataUpdatePayload struct {
-			Action   string `json:"action"`
-			Metadata []byte `json:"metadata"`
-			Queue    string `json:"queue"`
+			Action   string          `json:"action"`
+			Metadata json.RawMessage `json:"metadata"`
+			Queue    string          `json:"queue"`
 		}
 		type notification struct {
 			topic   notifier.NotificationTopic
@@ -1125,7 +1125,7 @@ func Test_Client(t *testing.T) {
 		notifyCh := make(chan notification, 10)
 
 		handleNotification := func(topic notifier.NotificationTopic, payload string) {
-			t.Logf("received notification: %s, %s", topic, payload)
+			t.Logf("received notification: %s, %q", topic, payload)
 			notif := notification{topic: topic}
 			require.NoError(t, json.Unmarshal([]byte(payload), &notif.payload))
 			notifyCh <- notif

--- a/producer.go
+++ b/producer.go
@@ -411,10 +411,10 @@ const (
 )
 
 type controlEventPayload struct {
-	Action   controlAction `json:"action"`
-	JobID    int64         `json:"job_id,omitempty"`
-	Metadata []byte        `json:"metadata,omitempty"`
-	Queue    string        `json:"queue"`
+	Action   controlAction   `json:"action"`
+	JobID    int64           `json:"job_id,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
+	Queue    string          `json:"queue"`
 }
 
 type insertPayload struct {


### PR DESCRIPTION
Go serializes `[]byte` as a base64 encoded string, which is not what we want for a raw JSON payload.