### PR TITLE
allow pilot.JobGetAvailable to be called even if paused

### DIFF
--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -14,6 +14,9 @@ type StandardPilot struct {
 }
 
 func (p *StandardPilot) JobGetAvailable(ctx context.Context, exec riverdriver.Executor, state ProducerState, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
+	if params.Max <= 0 {
+		return nil, nil
+	}
 	return exec.JobGetAvailable(ctx, params)
 }
 


### PR DESCRIPTION
This is an attempt to resolve a Pro bug uncovered last night with concurrency limits. Essentially this change allows them to be synced (at the Pilot's discretion) even if the producer is paused and shouldn't fetch new jobs.

I'm not actually sure if there's any additional tests to add here. I guess I could add a synthetic one that uses an intercepting pilot? Anyway wanted to get your input before I do any more with this.