### PR TITLE
Logging package to add context logger for workers and stores output to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `river/riverlog` containing middleware that injects a context logger to workers that collates log output and persists it with job metadata. This is paired with a River UI enhancement that shows logs in the UI. [PR #844](https://github.com/riverqueue/river/pull/844).
+- Added `JobInsertMiddlewareFunc` and `WorkerMiddlewareFunc` to easily implement middleware with a function instead of a struct. [PR #844](https://github.com/riverqueue/river/pull/844).
+
 ### Changed
 
 - Client no longer returns an error if stopped before startup could complete (previously, it returned the unexported `ErrShutdown`). [PR #841](https://github.com/riverqueue/river/pull/841).

--- a/client.go
+++ b/client.go
@@ -597,6 +597,12 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		}
 	}
 
+	for _, hook := range config.Hooks {
+		if withBaseService, ok := hook.(baseservice.WithBaseService); ok {
+			baseservice.Init(archetype, withBaseService)
+		}
+	}
+
 	client := &Client[TTx]{
 		config:               config,
 		driver:               driver,
@@ -636,6 +642,13 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 
 			middleware = append(middleware, workerMiddleware)
 		}
+
+		for _, middleware := range middleware {
+			if withBaseService, ok := middleware.(baseservice.WithBaseService); ok {
+				baseservice.Init(archetype, withBaseService)
+			}
+		}
+
 		client.middlewareLookupGlobal = middlewarelookup.NewMiddlewareLookup(middleware)
 	}
 

--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -169,5 +169,5 @@ func Example_gracefulShutdown() {
 	// Received SIGINT/SIGTERM; initiating soft stop (try to wait for jobs to finish)
 	// Received SIGINT/SIGTERM again; initiating hard stop (cancel everything)
 	// Job cancelled
-	// JobExecutor: Job errored; retrying
+	// jobexecutor.JobExecutor: Job errored; retrying
 }

--- a/example_job_cancel_from_client_test.go
+++ b/example_job_cancel_from_client_test.go
@@ -99,5 +99,5 @@ func Example_jobCancelFromClient() {
 	}
 
 	// Output:
-	// JobExecutor: job cancelled remotely
+	// jobexecutor.JobExecutor: job cancelled remotely
 }

--- a/hook_defaults_funcs.go
+++ b/hook_defaults_funcs.go
@@ -13,8 +13,8 @@ type HookDefaults struct{}
 
 func (d *HookDefaults) IsHook() bool { return true }
 
-// HookInsertBeginFunc is a convenience helper for implementing HookInsertBegin
-// using a simple function instead of a struct.
+// HookInsertBeginFunc is a convenience helper for implementing
+// rivertype.HookInsertBegin using a simple function instead of a struct.
 type HookInsertBeginFunc func(ctx context.Context, params *rivertype.JobInsertParams) error
 
 func (f HookInsertBeginFunc) InsertBegin(ctx context.Context, params *rivertype.JobInsertParams) error {
@@ -23,8 +23,8 @@ func (f HookInsertBeginFunc) InsertBegin(ctx context.Context, params *rivertype.
 
 func (f HookInsertBeginFunc) IsHook() bool { return true }
 
-// HookWorkBeginFunc is a convenience helper for implementing HookworkBegin
-// using a simple function instead of a struct.
+// HookWorkBeginFunc is a convenience helper for implementing
+// rivertype.HookworkBegin using a simple function instead of a struct.
 type HookWorkBeginFunc func(ctx context.Context, job *rivertype.JobRow) error
 
 func (f HookWorkBeginFunc) WorkBegin(ctx context.Context, job *rivertype.JobRow) error {

--- a/middleware_defaults.go
+++ b/middleware_defaults.go
@@ -25,6 +25,16 @@ func (d *JobInsertMiddlewareDefaults) InsertMany(ctx context.Context, manyParams
 	return doInner(ctx)
 }
 
+// JobInsertMiddlewareFunc is a convenience helper for implementing
+// rivertype.JobInsertMiddleware using a simple function instead of a struct.
+type JobInsertMiddlewareFunc func(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error)
+
+func (f JobInsertMiddlewareFunc) InsertMany(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error) {
+	return f(ctx, manyParams, doInner)
+}
+
+func (f JobInsertMiddlewareFunc) IsMiddleware() bool { return true }
+
 // WorkerInsertMiddlewareDefaults is an embeddable struct that provides default
 // implementations for the rivertype.WorkerMiddleware. Use of this struct is
 // recommended in case rivertype.WorkerMiddleware is expanded in the future so
@@ -36,3 +46,13 @@ type WorkerMiddlewareDefaults struct{ MiddlewareDefaults }
 func (d *WorkerMiddlewareDefaults) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
 	return doInner(ctx)
 }
+
+// WorkerMiddlewareFunc is a convenience helper for implementing
+// rivertype.WorkerMiddleware using a simple function instead of a struct.
+type WorkerMiddlewareFunc func(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error
+
+func (f WorkerMiddlewareFunc) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+	return f(ctx, job, doInner)
+}
+
+func (f WorkerMiddlewareFunc) IsMiddleware() bool { return true }

--- a/middleware_defaults_test.go
+++ b/middleware_defaults_test.go
@@ -1,8 +1,26 @@
 package river
 
-import "github.com/riverqueue/river/rivertype"
+import (
+	"context"
+
+	"github.com/riverqueue/river/rivertype"
+)
 
 var (
 	_ rivertype.JobInsertMiddleware = &JobInsertMiddlewareDefaults{}
 	_ rivertype.WorkerMiddleware    = &WorkerMiddlewareDefaults{}
+
+	_ rivertype.JobInsertMiddleware = JobInsertMiddlewareFunc(func(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error) {
+		return doInner(ctx)
+	})
+	_ rivertype.Middleware = JobInsertMiddlewareFunc(func(ctx context.Context, manyParams []*rivertype.JobInsertParams, doInner func(ctx context.Context) ([]*rivertype.JobInsertResult, error)) ([]*rivertype.JobInsertResult, error) {
+		return doInner(ctx)
+	})
+
+	_ rivertype.Middleware = WorkerMiddlewareFunc(func(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+		return doInner(ctx)
+	})
+	_ rivertype.WorkerMiddleware = WorkerMiddlewareFunc(func(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+		return doInner(ctx)
+	})
 )

--- a/recorded_output.go
+++ b/recorded_output.go
@@ -10,7 +10,10 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-const maxOutputSize = 32 * 1024 * 1024 // 32MB
+const (
+	maxOutputSizeMB    = 32
+	maxOutputSizeBytes = maxOutputSizeMB * 1024 * 1024
+)
 
 // RecordOutput records output JSON from a job. The "output" can be any
 // JSON-encodable value and will be stored in the database on the job row after
@@ -55,8 +58,8 @@ func RecordOutput(ctx context.Context, output any) error {
 
 	// Postgres JSONB is limited to 255MB, but it would be a bad idea to get
 	// anywhere close to that limit here.
-	if len(metadataUpdatesBytes) > maxOutputSize {
-		return fmt.Errorf("output is too large: %d bytes (max 32 MB)", len(metadataUpdatesBytes))
+	if len(metadataUpdatesBytes) > maxOutputSizeBytes {
+		return fmt.Errorf("output is too large: %d bytes (max %d MB)", len(metadataUpdatesBytes), maxOutputSizeMB)
 	}
 
 	metadataUpdates[rivertype.MetadataKeyOutput] = json.RawMessage(metadataUpdatesBytes)

--- a/riverlog/common_test.go
+++ b/riverlog/common_test.go
@@ -1,7 +1,6 @@
-package river_test
+package riverlog_test
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -16,22 +15,9 @@ import (
 // helpers aren't included in Godoc and keep each example more succinct.
 //
 
-type NoOpArgs struct{}
-
-func (NoOpArgs) Kind() string { return "no_op" }
-
-type NoOpWorker struct {
-	river.WorkerDefaults[NoOpArgs]
-}
-
-func (w *NoOpWorker) Work(ctx context.Context, job *river.Job[NoOpArgs]) error {
-	fmt.Printf("NoOpWorker.Work ran\n")
-	return nil
-}
-
 // Wait on the given subscription channel for numJobs. Times out with a panic if
 // jobs take too long to be received.
-func waitForNJobs(subscribeChan <-chan *river.Event, numJobs int) []*rivertype.JobRow { //nolint:unparam
+func waitForNJobs(subscribeChan <-chan *river.Event, numJobs int) []*rivertype.JobRow {
 	var (
 		timeout  = riversharedtest.WaitTimeout()
 		deadline = time.Now().Add(timeout)

--- a/riverlog/example_middleware_test.go
+++ b/riverlog/example_middleware_test.go
@@ -1,0 +1,112 @@
+package riverlog_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/internal/riverinternaltest"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/riverlog"
+	"github.com/riverqueue/river/rivershared/util/slogutil"
+	"github.com/riverqueue/river/rivertype"
+)
+
+type LoggingArgs struct{}
+
+func (LoggingArgs) Kind() string { return "logging" }
+
+type LoggingWorker struct {
+	river.WorkerDefaults[LoggingArgs]
+}
+
+func (w *LoggingWorker) Work(ctx context.Context, job *river.Job[LoggingArgs]) error {
+	riverlog.Logger(ctx).InfoContext(ctx, "Logged from worker")
+	riverlog.Logger(ctx).InfoContext(ctx, "Another line logged from worker")
+	return nil
+}
+
+// Example_middleware demonstrates the use of riverlog middleware to inject a
+// logger into context that'll persist its output onto the job record.
+func Example_middleware() {
+	ctx := context.Background()
+
+	dbPool, err := pgxpool.NewWithConfig(ctx, riverinternaltest.DatabaseConfig("river_test_example"))
+	if err != nil {
+		panic(err)
+	}
+	defer dbPool.Close()
+
+	// Required for the purpose of this test, but not necessary in real usage.
+	if err := riverinternaltest.TruncateRiverTables(ctx, dbPool); err != nil {
+		panic(err)
+	}
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &LoggingWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 100},
+		},
+		Middleware: []rivertype.Middleware{
+			riverlog.NewMiddleware(func(w io.Writer) slog.Handler {
+				// We have to use a specialized handler without timestamps to
+				// make test output reproducible, but in reality this would as
+				// simple as something like:
+				//
+				// 	return slog.NewJSONHandler(w, nil)
+				return &slogutil.SlogMessageOnlyHandler{Out: w}
+			}, nil),
+		},
+		TestOnly: true, // suitable only for use in tests; remove for live environments
+		Workers:  workers,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Out of example scope, but used to wait until a job is worked.
+	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	defer subscribeCancel()
+
+	if err := riverClient.Start(ctx); err != nil {
+		panic(err)
+	}
+
+	_, err = riverClient.Insert(ctx, LoggingArgs{}, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	type metadataWithLog struct {
+		RiverLog []struct {
+			Log string `json:"log"`
+		} `json:"river:log"`
+	}
+
+	// Wait for job to complete, extract log data out of metadata, and print it.
+	for _, job := range waitForNJobs(subscribeChan, 1) {
+		var metadataWithLog metadataWithLog
+		if err := json.Unmarshal(job.Metadata, &metadataWithLog); err != nil {
+			panic(err)
+		}
+		for _, logAttempt := range metadataWithLog.RiverLog {
+			fmt.Print(logAttempt.Log)
+		}
+	}
+
+	if err := riverClient.Stop(ctx); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Logged from worker
+	// Another line logged from worker
+}

--- a/riverlog/river_log.go
+++ b/riverlog/river_log.go
@@ -1,0 +1,149 @@
+// Package riverlog provides a context logging middleware for workers that
+// collates output and stores it to job records.
+package riverlog
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+
+	"github.com/riverqueue/river/internal/jobexecutor"
+	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivertype"
+)
+
+const (
+	maxSizeMB    = 2
+	maxSizeBytes = maxSizeMB * 1024 * 1024
+	metadataKey  = "river:log"
+)
+
+type contextKey struct{}
+
+// Logger extracts a logger from context from within the Work body of a worker.
+// Middleware must be installed on either the worker or client for this function
+// to be usable.
+func Logger(ctx context.Context) *slog.Logger {
+	logger, ok := ctx.Value(contextKey{}).(*slog.Logger)
+	if !ok {
+		panic("no logger in context; do you have riverlog.Middleware configured?")
+	}
+	return logger
+}
+
+// Middleware injects a context logger into the Work function of workers it's
+// installed on (or workers of the client it's installed on) which is accessible
+// with Logger, and which collates all log output to store it to metadata after
+// the job finishes execution. This output is then viewable from River UI.
+type Middleware struct {
+	baseservice.BaseService
+	rivertype.Middleware
+	config     *MiddlewareConfig
+	newHandler func(w io.Writer) slog.Handler
+}
+
+// MiddlewareConfig is configuration for Middleware.
+type MiddlewareConfig struct {
+	// MaxSizeBytes is the maximum size of log data that'll be persisted in
+	// bytes per job attempt. Anything larger will be truncated will be
+	// truncated down to MaxSizeBytes.
+	//
+	// Be careful with this number because the maximum total log size is equal
+	// to maximum number of attempts multiplied by this number (each attempt's
+	// logs are kept separately). For example, 25 * 2 MB = 50 MB maximum
+	// theoretical log size. Log data goes into metadata which is a JSONB field,
+	// and JSONB fields have a maximum size of 255 MB, so any number larger than
+	// 255 divided by maximum number of attempts may cause serious operational
+	// problems.
+	//
+	// Defaults to 2 MB (which is per job attempt).
+	MaxSizeBytes int
+}
+
+// NewMiddleware initializes a new Middleware with the given handler function
+// and configuration.
+//
+// newHandler is a function which is invoked on every Work execution to generate
+// a new slog.Handler for a work-specific slog.Logger. It should take an
+// io.Writer and return a slog.Handler of choice that's configured to suit the
+// caller.
+//
+// For example:
+//
+//	riverlog.NewMiddleware(func(w io.Writer) slog.Handler {
+//		return slog.NewJSONHandler(w, nil)
+//	}, nil)
+func NewMiddleware(newHandler func(w io.Writer) slog.Handler, config *MiddlewareConfig) *Middleware {
+	if config == nil {
+		config = &MiddlewareConfig{}
+	}
+
+	// Assign defaults.
+	config = &MiddlewareConfig{
+		MaxSizeBytes: cmp.Or(config.MaxSizeBytes, maxSizeBytes),
+	}
+
+	return &Middleware{
+		config:     config,
+		newHandler: newHandler,
+	}
+}
+
+type logAttempt struct {
+	Attempt int    `json:"attempt"`
+	Log     string `json:"log"`
+}
+
+type metadataWithLog struct {
+	RiverLog []logAttempt `json:"river:log"`
+}
+
+func (m *Middleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) error {
+	var (
+		existingLogData metadataWithLog
+		logBuf          bytes.Buffer
+		logger          = slog.New(m.newHandler(&logBuf))
+	)
+
+	if err := json.Unmarshal(job.Metadata, &existingLogData); err != nil {
+		return err
+	}
+
+	metadataUpdates, hasMetadataUpdates := jobexecutor.MetadataUpdatesFromWorkContext(ctx)
+	if !hasMetadataUpdates {
+		return errors.New("expected to find metadata updates in context, but didn't")
+	}
+
+	// This all runs invariant of whether the job panics or returns an error.
+	defer func() {
+		logData := logBuf.String()
+
+		// Postgres JSONB is limited to 255MB, but it would be a bad idea to get
+		// anywhere close to that limit here.
+		if len(logData) > m.config.MaxSizeBytes {
+			m.Logger.WarnContext(ctx, m.Name+": Logs size exceeded maximum; truncating",
+				slog.Int("logs_size", len(logData)),
+				slog.Int("max_size", m.config.MaxSizeBytes),
+			)
+			logData = logData[0:m.config.MaxSizeBytes]
+		}
+
+		allLogDataBytes, err := json.Marshal(append(existingLogData.RiverLog, logAttempt{
+			Attempt: job.Attempt,
+			Log:     logData,
+		}))
+		if err != nil {
+			m.Logger.ErrorContext(ctx, m.Name+": Error marshaling log data",
+				slog.String("error", err.Error()),
+			)
+		}
+
+		metadataUpdates[metadataKey] = json.RawMessage(allLogDataBytes)
+	}()
+
+	return doInner(context.WithValue(ctx, contextKey{}, logger))
+}

--- a/riverlog/river_log_test.go
+++ b/riverlog/river_log_test.go
@@ -1,0 +1,208 @@
+package riverlog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivershared/riversharedtest"
+	"github.com/riverqueue/river/rivershared/util/slogutil"
+	"github.com/riverqueue/river/rivertest"
+	"github.com/riverqueue/river/rivertype"
+)
+
+var _ rivertype.WorkerMiddleware = &Middleware{}
+
+type loggingArgs struct {
+	DoError bool   `json:"do_error"`
+	DoPanic bool   `json:"do_panic"`
+	Message string `json:"message"`
+}
+
+func (loggingArgs) Kind() string { return "logging" }
+
+type loggingWorker struct {
+	river.WorkerDefaults[loggingArgs]
+}
+
+func (w *loggingWorker) Work(ctx context.Context, job *river.Job[loggingArgs]) error {
+	Logger(ctx).InfoContext(ctx, job.Args.Message)
+
+	if job.Args.DoError {
+		return errors.New("error from worker")
+	}
+
+	if job.Args.DoPanic {
+		panic("panic from worker")
+	}
+
+	return nil
+}
+
+func TestMiddleware(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		driver *riverpgxv5.Driver
+		tx     pgx.Tx
+	}
+
+	setup := func(t *testing.T, config *MiddlewareConfig) (*rivertest.Worker[loggingArgs, pgx.Tx], *testBundle) {
+		t.Helper()
+
+		var (
+			driver     = riverpgxv5.New(nil)
+			middleware = NewMiddleware(func(w io.Writer) slog.Handler {
+				return &slogutil.SlogMessageOnlyHandler{Out: w}
+			}, config)
+			clientConfig = &river.Config{
+				Middleware: []rivertype.Middleware{middleware},
+			}
+			tx     = riversharedtest.TestTx(ctx, t)
+			worker = &loggingWorker{}
+		)
+
+		return rivertest.NewWorker(t, driver, clientConfig, worker), &testBundle{
+			driver: driver,
+			tx:     tx,
+		}
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		testWorker, bundle := setup(t, nil)
+
+		workRes, err := testWorker.Work(ctx, t, bundle.tx, loggingArgs{Message: "Logged from worker"}, nil)
+		require.NoError(t, err)
+
+		var metadataWithLog metadataWithLog
+		require.NoError(t, json.Unmarshal(workRes.Job.Metadata, &metadataWithLog))
+
+		require.Equal(t, []logAttempt{
+			{
+				Attempt: 1,
+				Log:     "Logged from worker\n",
+			},
+		},
+			metadataWithLog.RiverLog,
+		)
+	})
+
+	t.Run("MultipleAttempts", func(t *testing.T) {
+		t.Parallel()
+
+		testWorker, bundle := setup(t, nil)
+
+		workRes, err := testWorker.Work(ctx, t, bundle.tx, loggingArgs{Message: "Logged from worker"}, nil)
+		require.NoError(t, err)
+
+		// Set state back to available and unfinalize the job to make it runnable again.
+		workRes.Job, err = bundle.driver.UnwrapExecutor(bundle.tx).JobUpdate(ctx, &riverdriver.JobUpdateParams{
+			ID:                  workRes.Job.ID,
+			FinalizedAtDoUpdate: true,
+			FinalizedAt:         nil,
+			StateDoUpdate:       true,
+			State:               rivertype.JobStateAvailable,
+		})
+		require.NoError(t, err)
+
+		// Work the job again.
+		workRes, err = testWorker.WorkJob(ctx, t, bundle.tx, workRes.Job)
+		require.NoError(t, err)
+
+		var metadataWithLog metadataWithLog
+		require.NoError(t, json.Unmarshal(workRes.Job.Metadata, &metadataWithLog))
+
+		require.Equal(t, []logAttempt{
+			{
+				Attempt: 1,
+				Log:     "Logged from worker\n",
+			},
+			{
+				Attempt: 2,
+				Log:     "Logged from worker\n",
+			},
+		},
+			metadataWithLog.RiverLog,
+		)
+	})
+
+	t.Run("OnError", func(t *testing.T) {
+		t.Parallel()
+
+		testWorker, bundle := setup(t, nil)
+
+		workRes, err := testWorker.Work(ctx, t, bundle.tx, loggingArgs{DoError: true, Message: "Logged from worker"}, nil)
+		require.EqualError(t, err, "error from worker")
+
+		var metadataWithLog metadataWithLog
+		require.NoError(t, json.Unmarshal(workRes.Job.Metadata, &metadataWithLog))
+
+		require.Equal(t, []logAttempt{
+			{
+				Attempt: 1,
+				Log:     "Logged from worker\n",
+			},
+		},
+			metadataWithLog.RiverLog,
+		)
+	})
+
+	t.Run("OnPanic", func(t *testing.T) {
+		t.Parallel()
+
+		testWorker, bundle := setup(t, nil)
+
+		workRes, err := testWorker.Work(ctx, t, bundle.tx, loggingArgs{DoPanic: true, Message: "Logged from worker"}, nil)
+		var panicErr *rivertest.PanicError
+		require.ErrorAs(t, err, &panicErr)
+		require.Equal(t, "panic from worker", panicErr.Cause)
+
+		var metadataWithLog metadataWithLog
+		require.NoError(t, json.Unmarshal(workRes.Job.Metadata, &metadataWithLog))
+
+		require.Equal(t, []logAttempt{
+			{
+				Attempt: 1,
+				Log:     "Logged from worker\n",
+			},
+		},
+			metadataWithLog.RiverLog,
+		)
+	})
+
+	t.Run("TruncatedAtMaxSizeBytes", func(t *testing.T) {
+		t.Parallel()
+
+		testWorker, bundle := setup(t, &MiddlewareConfig{
+			MaxSizeBytes: 11,
+		})
+
+		workRes, err := testWorker.Work(ctx, t, bundle.tx, loggingArgs{Message: "Logged from worker"}, nil)
+		require.NoError(t, err)
+
+		var metadataWithLog metadataWithLog
+		require.NoError(t, json.Unmarshal(workRes.Job.Metadata, &metadataWithLog))
+
+		require.Equal(t, []logAttempt{
+			{
+				Attempt: 1,
+				Log:     "Logged from",
+			},
+		},
+			metadataWithLog.RiverLog,
+		)
+	})
+}

--- a/rivershared/baseservice/base_service_test.go
+++ b/rivershared/baseservice/base_service_test.go
@@ -16,7 +16,7 @@ func TestInit(t *testing.T) {
 
 	myService := Init(archetype, &MyService{})
 	require.NotNil(t, myService.Logger)
-	require.Equal(t, "MyService", myService.Name)
+	require.Equal(t, "baseservice.MyService", myService.Name)
 	require.WithinDuration(t, time.Now().UTC(), myService.Time.NowUTC(), 2*time.Second)
 }
 
@@ -29,6 +29,16 @@ func archetype() *Archetype {
 		Logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
 		Time:   &UnStubbableTimeGenerator{},
 	}
+}
+
+func TestLastPkgPathSegmentIfNotRiver(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, lastPkgPathSegmentIfNotRiver("github.com/riverqueue/river"))
+	require.Equal(t, "riverlog.", lastPkgPathSegmentIfNotRiver("github.com/riverqueue/river/riverlog"))
+	require.Equal(t, "riverui.", lastPkgPathSegmentIfNotRiver("github.com/riverqueue/riverui"))
+	require.Empty(t, lastPkgPathSegmentIfNotRiver(""))
+	require.Empty(t, lastPkgPathSegmentIfNotRiver("/"))
 }
 
 func TestSimplifyLogName(t *testing.T) {

--- a/rivershared/util/slogutil/slog_util.go
+++ b/rivershared/util/slogutil/slog_util.go
@@ -3,7 +3,9 @@ package slogutil
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
+	"os"
 )
 
 // SlogMessageOnlyHandler is a trivial slog handler that prints only messages.
@@ -12,6 +14,7 @@ import (
 // lines include timestamps so it's not possible to have reproducible output).
 type SlogMessageOnlyHandler struct {
 	Level slog.Level
+	Out   io.Writer
 }
 
 func (h *SlogMessageOnlyHandler) Enabled(ctx context.Context, level slog.Level) bool {
@@ -19,7 +22,12 @@ func (h *SlogMessageOnlyHandler) Enabled(ctx context.Context, level slog.Level) 
 }
 
 func (h *SlogMessageOnlyHandler) Handle(ctx context.Context, record slog.Record) error {
-	fmt.Printf("%s\n", record.Message)
+	w := h.Out
+	if w == nil {
+		w = os.Stdout
+	}
+
+	fmt.Fprintf(w, "%s\n", record.Message)
 	return nil
 }
 

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -146,6 +146,17 @@ func (w *Worker[T, TTx]) workJob(ctx context.Context, tb testing.TB, tx TTx, job
 	}
 	completer := jobcompleter.NewInlineCompleter(archetype, exec, w.client.Pilot(), subscribeCh)
 
+	for _, hook := range w.config.Hooks {
+		if withBaseService, ok := hook.(baseservice.WithBaseService); ok {
+			baseservice.Init(archetype, withBaseService)
+		}
+	}
+	for _, middleware := range w.config.Middleware {
+		if withBaseService, ok := middleware.(baseservice.WithBaseService); ok {
+			baseservice.Init(archetype, withBaseService)
+		}
+	}
+
 	updatedJobRow, err := exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
 		ID:                  job.ID,
 		Attempt:             job.Attempt + 1,


### PR DESCRIPTION
After adding support for job output, it got me thinking that it might
not be _that_ bad if we put in a way for users to be able to store
limited job-specific logging to job records. Like with output, this
would go in TOAST, and although it could be bad if too much data
accumulated, it shouldn't generally effect performance.

Here, prototype what that would look like. It's implemented as a
middleware in a separate `riverlog` package, which must be installed to
a client or worker to become active. Once it is, logging looks like:

    func (w *LoggingWorker) Work(ctx context.Context, job *river.Job[LoggingArgs]) error {
        riverlog.Logger(ctx).InfoContext(ctx, "Logged from worker")
        return nil
    }

The middleware takes a function that returns a slog handler, which has
the purpose of letting the user select between JSON, text, or something
else, and lets them select options like logging level.

I've left in enough flexibility that we should be able to extend the
interface only slightly to implement a system that sends logs to S3
instead of metadata, but metadata is a good default.

I figure that if we go down this route we can add special handling for
it to River UI to make logs easily accessible for installations even
without a full logging platform.

I also ended up adding support to `Client` and `rivertest.Worker` for
`rivershared.BaseService` in hooks and middleware so that if a hook or
middleware has a base service embedded, it gets its archetype
initialized just like other services in the client. This gives us an
easy way to inherit a client's log instead of a separate one having to
be injected which is _very_ convenient. This shouldn't be used outside
of River core packages, but it should be okay if we make use it.

Also added convenience helpers to make middleware like we already had
for hooks:

* `JobInsertMiddlewareFunc`
* `WorkerMiddlewareFunc `

I put these in because they're great for creating a hook or middleware
that's scoped to a single test case and which is a struct that can embed
something like `baseservice.BaseService`.