### PR TITLE
Replace uses of `valutil.FirstNonZero` with `cmp.Or` + deprecate former

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package river
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1323,9 +1324,9 @@ func insertParamsFromConfigArgsAndOptions(archetype *baseservice.Archetype, conf
 	// by drivers as necessary.
 	createdAt := archetype.Time.NowUTCOrNil()
 
-	maxAttempts := valutil.FirstNonZero(insertOpts.MaxAttempts, jobInsertOpts.MaxAttempts, config.MaxAttempts)
-	priority := valutil.FirstNonZero(insertOpts.Priority, jobInsertOpts.Priority, rivercommon.PriorityDefault)
-	queue := valutil.FirstNonZero(insertOpts.Queue, jobInsertOpts.Queue, rivercommon.QueueDefault)
+	maxAttempts := cmp.Or(insertOpts.MaxAttempts, jobInsertOpts.MaxAttempts, config.MaxAttempts)
+	priority := cmp.Or(insertOpts.Priority, jobInsertOpts.Priority, rivercommon.PriorityDefault)
+	queue := cmp.Or(insertOpts.Queue, jobInsertOpts.Queue, rivercommon.QueueDefault)
 
 	if err := validateQueueName(queue); err != nil {
 		return nil, err

--- a/internal/jobexecutor/job_executor.go
+++ b/internal/jobexecutor/job_executor.go
@@ -1,6 +1,7 @@
 package jobexecutor
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -20,7 +21,6 @@ import (
 	"github.com/riverqueue/river/internal/workunit"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
-	"github.com/riverqueue/river/rivershared/util/valutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -203,7 +203,7 @@ func (e *JobExecutor) execute(ctx context.Context) (res *jobExecutorResult) {
 			return err
 		}
 
-		jobTimeout := valutil.FirstNonZero(e.WorkUnit.Timeout(), e.ClientJobTimeout)
+		jobTimeout := cmp.Or(e.WorkUnit.Timeout(), e.ClientJobTimeout)
 		ctx, cancel := execution.MaybeApplyTimeout(ctx, jobTimeout)
 		defer cancel()
 

--- a/rivershared/util/valutil/val_util.go
+++ b/rivershared/util/valutil/val_util.go
@@ -22,6 +22,9 @@ func ValOrDefaultFunc[T comparable](val T, defaultFunc func() T) T {
 
 // FirstNonZero returns the first argument that is non-zero, or the zero value if
 // all are zero.
+//
+// Deprecated: Use `cmp.Or` instead. This function will be removed in a near
+// future version.
 func FirstNonZero[T comparable](values ...T) T {
 	var zero T
 	for _, val := range values {


### PR DESCRIPTION
`cmp.Or` wasn't available originally in River, but was add in 1.22.
We're now minimum version 1.23, so it's fine to switch over it given it
does exactly the same thing as the custom `valutil.FirstNonZero`.

We have some dependencies using `valutil.FirstNonZero` so we shouldn't
remove it until there's at least one more version of those that've been
cut to avoid potential version compatibility problems. For now, mark the
function as deprecated to warn against use.