### PR TITLE
Fix bad bug in `riversharedtest.DBPool` (which is used by `TestTx`)

### DIFF
--- a/rivershared/riversharedtest/riversharedtest_test.go
+++ b/rivershared/riversharedtest/riversharedtest_test.go
@@ -15,9 +15,13 @@ func TestDBPool(t *testing.T) {
 
 	ctx := context.Background()
 
-	pool := DBPool(ctx, t)
-	_, err := pool.Exec(ctx, "SELECT 1")
+	pool1 := DBPool(ctx, t)
+	_, err := pool1.Exec(ctx, "SELECT 1")
 	require.NoError(t, err)
+
+	// Both pools should be exactly the same object.
+	pool2 := DBPool(ctx, t)
+	require.Equal(t, pool1, pool2)
 }
 
 func TestTestTx(t *testing.T) {


### PR DESCRIPTION
Fixes a bad bug in `riversharedtest.DBPool` in which while lazily
initializing a database pool, *we never actually set the database pool*,
so repeated invocations of `DBPool` would check for an existing pool
that would never exist and create a new one each time. This project
seems to be brute forcing its way by, but I was seeing Postgres
connection exhaustions in other projects.

Boiled down, the problem is that we had this:

    dbPool, err := pgxpool.New(ctx, cmp.Or(
        os.Getenv("TEST_DATABASE_URL"),
        "postgres://localhost:5432/river_test",
    ))

When it should've been this:

    var err error
    dbPool, err = pgxpool.New(ctx, cmp.Or(
        os.Getenv("TEST_DATABASE_URL"),
        "postgres://localhost:5432/river_test",
    ))

Here, fix the problem, and go a step further to simplify the code
somewhat to use a `sync.Once` instead of mutex. The final product is
fewer lines of code, which will hopefully make a bug of this magnitude
easier to spot should it reoccur.