### PR TITLE
Drop callback args in favor of single, uniform test convention

### DIFF
--- a/periodic_job_test.go
+++ b/periodic_job_test.go
@@ -42,7 +42,7 @@ func TestPeriodicJobBundle(t *testing.T) {
 			nil,
 		)
 
-		return newPeriodicJobBundle(newTestConfig(t, nil), periodicJobEnqueuer), &testBundle{}
+		return newPeriodicJobBundle(newTestConfig(t, ""), periodicJobEnqueuer), &testBundle{}
 	}
 
 	t.Run("ConstructorFuncGeneratesNewArgsOnEachCall", func(t *testing.T) {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -29,13 +29,13 @@ func TestClientDriverPlugin(t *testing.T) {
 		t.Helper()
 
 		var (
-			config       = newTestConfig(t, nil)
-			dbPool       = riversharedtest.DBPool(ctx, t)
-			driver       = riverpgxv5.New(dbPool)
-			schema       = riverdbtest.TestSchema(ctx, t, driver, nil)
-			pluginDriver = newDriverWithPlugin(t, dbPool)
+			dbPool = riversharedtest.DBPool(ctx, t)
+			driver = riverpgxv5.New(dbPool)
+			schema = riverdbtest.TestSchema(ctx, t, driver, nil)
+			config = newTestConfig(t, schema)
 		)
-		config.Schema = schema
+
+		pluginDriver := newDriverWithPlugin(t, dbPool)
 
 		client, err := NewClient(pluginDriver, config)
 		require.NoError(t, err)
@@ -98,14 +98,13 @@ func TestClientPilotPlugin(t *testing.T) {
 		t.Helper()
 
 		var (
-			config       = newTestConfig(t, nil)
 			dbPool       = riversharedtest.DBPool(ctx, t)
 			driver       = riverpgxv5.New(dbPool)
 			schema       = riverdbtest.TestSchema(ctx, t, driver, nil)
+			config       = newTestConfig(t, schema)
 			pluginDriver = newDriverWithPlugin(t, dbPool)
 			pluginPilot  = newPilotWithPlugin(t)
 		)
-		config.Schema = schema
 		pluginDriver.pilot = pluginPilot
 
 		client, err := NewClient(pluginDriver, config)

--- a/recorded_output_test.go
+++ b/recorded_output_test.go
@@ -39,11 +39,10 @@ func Test_RecordedOutput(t *testing.T) {
 			dbPool = riversharedtest.DBPool(ctx, t)
 			driver = riverpgxv5.New(dbPool)
 			schema = riverdbtest.TestSchema(ctx, t, driver, nil)
-			config = newTestConfig(t, nil)
+			config = newTestConfig(t, schema)
+			client = newTestClient(t, dbPool, config)
 		)
-		config.Schema = schema
 
-		client := newTestClient(t, dbPool, config)
 		t.Cleanup(func() { require.NoError(t, client.Stop(ctx)) })
 
 		return client, &testBundle{


### PR DESCRIPTION
This one's largely a cosmetic change. We remove callback args/worker in
favor of using test case local args using `JobArgsReflectKind` and a
standard invocation to `AddWorker`:

    type JobArgs struct {
        JobArgsReflectKind[JobArgs]
    }

    AddWorker(config.Workers, WorkFunc(func(ctx context.Context, job *Job[JobArgs]) error {
        return JobCancel(errors.New("oops"))
    }))

It's a little more verbose, but has the advantage of using only normal
River primitives, meaning that one has to be familiar with fewer test
helpers to understand what's going on.

Besides that and convention, another small benefit is that it introduces
a little more type safety and makes job args impossible to accidentally
cross reference between test cases. Previously, a test could insert a
callback args while intending to use a callback for them registered in a
different test case. With the new approach, it's very obvious when
`JobArgs` is either forgotten (a compilation error), or when there's a
missing `AddWorker` (because that's supposed to live close to the
definition of `JobArgs`).