### PR TITLE
Add docs for `UnwrapTx`

### DIFF
--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -103,6 +103,10 @@ type Driver[TTx any] interface {
 	// API is not stable. DO NOT USE.
 	UnwrapExecutor(tx TTx) ExecutorTx
 
+	// UnwrapTx gets a driver transaction from an executor. This is currently
+	// only needed for test transaction helpers.
+	//
+	// API is not stable. DO NOT USE.
 	UnwrapTx(execTx ExecutorTx) TTx
 }
 


### PR DESCRIPTION
Small follow up to #848 to add missing docs for `UnwrapTx`. I wouldn't
normally bother, but all the other driver functions are fully documented.