### PR TITLE
Fix intermittent test: `Test_Client_Stop/JobsInProgressCompletingPromptly`

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1292,19 +1292,11 @@ func Test_Client_Stop(t *testing.T) {
 
 		client := runNewTestClient(ctx, t, newTestConfig(t, makeAwaitCallback(startedCh, doneCh)))
 
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-
 		// enqueue job:
 		insertRes, err := client.Insert(ctx, callbackArgs{}, nil)
 		require.NoError(err)
 
-		var startedJobID int64
-		select {
-		case startedJobID = <-startedCh:
-		case <-time.After(1 * time.Second):
-			t.Fatal("timed out waiting for job to start")
-		}
+		startedJobID := riversharedtest.WaitOrTimeout(t, startedCh)
 		require.Equal(insertRes.Job.ID, startedJobID)
 
 		// Should not shut down immediately, not until jobs are given the signal to


### PR DESCRIPTION
Fix another failing intermittent test [1] that has timing constraints
that are in practice just too tight for slower environments like GitHub
Actions CI where there might be a lot of parallelism going on and
goroutines may be paused for extended periods.

    --- FAIL: Test_Client_Stop (0.00s)
        --- FAIL: Test_Client_Stop/JobsInProgressCompletingPromptly (7.80s)
            client_test.go:1293: Generated schema "river_test_2025_04_26t20_00_18_schema_14" with migrations [1 2 3 4 5 6] on line "main" in 1.427488883s [14 generated] [8 reused]
            logger.go:256: time=2025-04-26T20:00:20.940Z level=INFO msg="River client started" client_id=fv-az1676-608_2025_04_26T20_00_20_859010
            client_test.go:1306: timed out waiting for job to start
            logger.go:256: time=2025-04-26T20:00:22.416Z level=INFO msg="callback job started with id=1"
            logger.go:256: time=2025-04-26T20:00:25.941Z level=INFO msg="producer: Producer job counts" num_completed_jobs=0 num_jobs_running=1 queue=default
            client_test.go:166:
                    Error Trace:	/home/runner/work/river/river/client_test.go:166
                                                            /opt/hostedtoolcache/go/1.24.2/x64/src/testing/testing.go:1211
                                                            /opt/hostedtoolcache/go/1.24.2/x64/src/testing/testing.go:1445
                                                            /opt/hostedtoolcache/go/1.24.2/x64/src/testing/testing.go:1786
                                                            /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/panic.go:636
                                                            /opt/hostedtoolcache/go/1.24.2/x64/src/testing/testing.go:1041
                                                            /opt/hostedtoolcache/go/1.24.2/x64/src/testing/testing.go:1118
                                                            /home/runner/work/river/river/client_test.go:1306
                    Error:      	Received unexpected error:
                                    context deadline exceeded
                    Test:       	Test_Client_Stop/JobsInProgressCompletingPromptly
            riverdbtest.go:277: Checked in schema "river_test_2025_04_26t20_00_18_schema_14"; 1 idle schema(s) [16 generated] [9 reused]
    FAIL
    FAIL	github.com/riverqueue/river	34.083s

Switch to `riversharedtest.WaitOrTimeout` which tolerates up to 10
seconds in GitHub Actions instead of only 1. Get rid of context timeout
that won't accomplish anything except make tests fail intermittently
(and in general we should use the Go test `-timeout` flag instead
because it prints good stack trace information).

[1] https://github.com/riverqueue/river/actions/runs/14684606192/job/41211616466