### PR TITLE
Fix queue-related intermittency in producer tests

### DIFF
--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -2695,17 +2695,19 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			exec, _ := setup(ctx, t)
 
 			metadata := []byte(`{"foo": "bar"}`)
+			now := time.Now().UTC()
 			queue, err := exec.QueueCreateOrSetUpdatedAt(ctx, &riverdriver.QueueCreateOrSetUpdatedAtParams{
 				Metadata: metadata,
 				Name:     "new-queue",
+				Now:      &now,
 				Schema:   "",
 			})
 			require.NoError(t, err)
-			require.WithinDuration(t, time.Now(), queue.CreatedAt, 500*time.Millisecond)
+			require.WithinDuration(t, now, queue.CreatedAt, time.Microsecond)
 			require.Equal(t, metadata, queue.Metadata)
 			require.Equal(t, "new-queue", queue.Name)
 			require.Nil(t, queue.PausedAt)
-			require.WithinDuration(t, time.Now(), queue.UpdatedAt, 500*time.Millisecond)
+			require.WithinDuration(t, now, queue.UpdatedAt, time.Microsecond)
 		})
 
 		t.Run("InsertsANewQueueWithCustomPausedAt", func(t *testing.T) {

--- a/producer.go
+++ b/producer.go
@@ -283,6 +283,7 @@ func (p *producer) StartWorkContext(fetchCtx, workCtx context.Context) error {
 		return p.exec.QueueCreateOrSetUpdatedAt(ctx, &riverdriver.QueueCreateOrSetUpdatedAtParams{
 			Metadata: []byte("{}"),
 			Name:     p.config.Queue,
+			Now:      p.Time.NowUTCOrNil(),
 			Schema:   p.config.Schema,
 		})
 	}()
@@ -931,6 +932,7 @@ func (p *producer) reportQueueStatusOnce(ctx context.Context) {
 	_, err := p.exec.QueueCreateOrSetUpdatedAt(ctx, &riverdriver.QueueCreateOrSetUpdatedAtParams{
 		Metadata: []byte("{}"),
 		Name:     p.config.Queue,
+		Now:      p.Time.NowUTCOrNil(),
 		Schema:   p.config.Schema,
 	})
 	if err != nil && errors.Is(context.Cause(ctx), startstop.ErrStop) {

--- a/producer_test.go
+++ b/producer_test.go
@@ -371,7 +371,8 @@ func testProducer(t *testing.T, makeProducer func(ctx context.Context, t *testin
 		producer, bundle := setup(t)
 		producer.config.QueueReportInterval = 50 * time.Millisecond
 
-		now := time.Now().UTC()
+		now := producer.Time.StubNowUTC(time.Now().UTC())
+
 		startProducer(t, ctx, ctx, producer)
 
 		queue, err := bundle.exec.QueueGet(ctx, &riverdriver.QueueGetParams{
@@ -379,10 +380,10 @@ func testProducer(t *testing.T, makeProducer func(ctx context.Context, t *testin
 			Schema: producer.config.Schema,
 		})
 		require.NoError(t, err)
-		require.WithinDuration(t, now, queue.CreatedAt, 2*time.Second)
+		require.WithinDuration(t, now, queue.CreatedAt, time.Microsecond)
 		require.Equal(t, []byte("{}"), queue.Metadata)
 		require.Equal(t, producer.config.Queue, queue.Name)
-		require.WithinDuration(t, now, queue.UpdatedAt, 2*time.Second)
+		require.WithinDuration(t, now, queue.UpdatedAt, time.Microsecond)
 		require.Equal(t, queue.CreatedAt, queue.UpdatedAt)
 
 		// Queue status should be updated quickly:

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -605,6 +605,7 @@ type ProducerKeepAliveParams struct {
 type QueueCreateOrSetUpdatedAtParams struct {
 	Metadata  []byte
 	Name      string
+	Now       *time.Time
 	PausedAt  *time.Time
 	Schema    string
 	UpdatedAt *time.Time

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_queue.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_queue.sql.go
@@ -19,18 +19,19 @@ INSERT INTO /* TEMPLATE: schema */river_queue(
     paused_at,
     updated_at
 ) VALUES (
-    now(),
-    coalesce($1::jsonb, '{}'::jsonb),
-    $2::text,
-    coalesce($3::timestamptz, NULL),
-    coalesce($4::timestamptz, now())
+    coalesce($1::timestamptz, now()),
+    coalesce($2::jsonb, '{}'::jsonb),
+    $3::text,
+    coalesce($4::timestamptz, NULL),
+    coalesce($5::timestamptz, $1::timestamptz, now())
 ) ON CONFLICT (name) DO UPDATE
 SET
-    updated_at = coalesce($4::timestamptz, now())
+    updated_at = coalesce($5::timestamptz, $1::timestamptz, now())
 RETURNING name, created_at, metadata, paused_at, updated_at
 `
 
 type QueueCreateOrSetUpdatedAtParams struct {
+	Now       *time.Time
 	Metadata  string
 	Name      string
 	PausedAt  *time.Time
@@ -39,6 +40,7 @@ type QueueCreateOrSetUpdatedAtParams struct {
 
 func (q *Queries) QueueCreateOrSetUpdatedAt(ctx context.Context, db DBTX, arg *QueueCreateOrSetUpdatedAtParams) (*RiverQueue, error) {
 	row := db.QueryRowContext(ctx, queueCreateOrSetUpdatedAt,
+		arg.Now,
 		arg.Metadata,
 		arg.Name,
 		arg.PausedAt,

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -753,6 +753,7 @@ func (e *Executor) QueueCreateOrSetUpdatedAt(ctx context.Context, params *riverd
 	queue, err := dbsqlc.New().QueueCreateOrSetUpdatedAt(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.QueueCreateOrSetUpdatedAtParams{
 		Metadata:  valutil.ValOrDefault(string(params.Metadata), "{}"),
 		Name:      params.Name,
+		Now:       params.Now,
 		PausedAt:  params.PausedAt,
 		UpdatedAt: params.UpdatedAt,
 	})

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_queue.sql
@@ -1,6 +1,6 @@
 CREATE TABLE river_queue(
   name text PRIMARY KEY NOT NULL,
-  created_at timestamptz NOT NULL DEFAULT NOW(),
+  created_at timestamptz NOT NULL DEFAULT now(),
   metadata jsonb NOT NULL DEFAULT '{}' ::jsonb,
   paused_at timestamptz,
   updated_at timestamptz NOT NULL
@@ -14,14 +14,14 @@ INSERT INTO /* TEMPLATE: schema */river_queue(
     paused_at,
     updated_at
 ) VALUES (
-    now(),
+    coalesce(sqlc.narg('now')::timestamptz, now()),
     coalesce(@metadata::jsonb, '{}'::jsonb),
     @name::text,
     coalesce(sqlc.narg('paused_at')::timestamptz, NULL),
-    coalesce(sqlc.narg('updated_at')::timestamptz, now())
+    coalesce(sqlc.narg('updated_at')::timestamptz, sqlc.narg('now')::timestamptz, now())
 ) ON CONFLICT (name) DO UPDATE
 SET
-    updated_at = coalesce(sqlc.narg('updated_at')::timestamptz, now())
+    updated_at = coalesce(sqlc.narg('updated_at')::timestamptz, sqlc.narg('now')::timestamptz, now())
 RETURNING *;
 
 -- name: QueueDeleteExpired :many

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -646,6 +646,7 @@ func (e *Executor) QueueCreateOrSetUpdatedAt(ctx context.Context, params *riverd
 	queue, err := dbsqlc.New().QueueCreateOrSetUpdatedAt(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.QueueCreateOrSetUpdatedAtParams{
 		Metadata:  params.Metadata,
 		Name:      params.Name,
+		Now:       params.Now,
 		PausedAt:  params.PausedAt,
 		UpdatedAt: params.UpdatedAt,
 	})


### PR DESCRIPTION
Fix another intermittency problem caused by relying on wall clock time
when testing queues in `TestProducer_WithNotifier/RegistersQueueStatus`
where they're upserted by a producer[1].

    --- FAIL: TestProducer_WithNotifier (0.00s)
        --- FAIL: TestProducer_WithNotifier/RegistersQueueStatus (7.04s)
            producer_test.go:371: Generated schema "river_2025_04_26t04_16_54_schema_15" with migrations [1 2 3 4 5 6] on line "main" in 3.056885981s [15 generated] [8 reused]
            producer_test.go:385:
                    Error Trace:	/home/runner/work/river/river/producer_test.go:385
                    Error:      	Max difference between 2025-04-26 04:17:03.800146245 +0000 UTC and 2025-04-26 04:17:06.08229 +0000 UTC allowed is 2s, but difference was -2.282143755s
                    Test:       	TestProducer_WithNotifier/RegistersQueueStatus
            logger.go:256: time=2025-04-26T04:17:06.091Z level=ERROR msg="producer: Queue status update, error updating in database" err="context canceled"
            riverdbtest.go:277: Checked in schema "river_2025_04_26t04_16_54_schema_15"; 1 idle schema(s) [15 generated] [8 reused]
    FAIL
    FAIL	github.com/riverqueue/river	34.065s

Switch over to using a version based on an injected clock and `now`.

[1] https://github.com/riverqueue/river/actions/runs/14677626265/job/41196195586