### PR TITLE
prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2025-05-02
+
 ⚠️ Internal APIs used for communication between River and River Pro have changed. If using River Pro, make sure to update River and River Pro to latest at the same time to get compatible versions.
 
 ### Added

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,11 +7,11 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/lmittmann/tint v1.0.7
-	github.com/riverqueue/river v0.20.2
-	github.com/riverqueue/river/riverdriver v0.20.2
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.20.2
-	github.com/riverqueue/river/rivershared v0.20.2
-	github.com/riverqueue/river/rivertype v0.20.2
+	github.com/riverqueue/river v0.21.0
+	github.com/riverqueue/river/riverdriver v0.21.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.21.0
+	github.com/riverqueue/river/rivershared v0.21.0
+	github.com/riverqueue/river/rivertype v0.21.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 )
@@ -34,7 +34,3 @@ require (
 	golang.org/x/text v0.24.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/riverqueue/river => ../../
-
-replace github.com/riverqueue/river/rivershared => ../../rivershared

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.20.2
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.20.2
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.20.2
-	github.com/riverqueue/river/rivershared v0.20.2
-	github.com/riverqueue/river/rivertype v0.20.2
+	github.com/riverqueue/river/riverdriver v0.21.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.21.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.21.0
+	github.com/riverqueue/river/rivershared v0.21.0
+	github.com/riverqueue/river/rivertype v0.21.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
@@ -33,5 +33,3 @@ require (
 	golang.org/x/crypto v0.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/riverqueue/river/rivershared => ./rivershared

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/riverqueue/river/rivertype v0.20.2
+	github.com/riverqueue/river/rivertype v0.21.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.20.2
-	github.com/riverqueue/river/riverdriver v0.20.2
-	github.com/riverqueue/river/rivershared v0.20.2
-	github.com/riverqueue/river/rivertype v0.20.2
+	github.com/riverqueue/river v0.21.0
+	github.com/riverqueue/river/riverdriver v0.21.0
+	github.com/riverqueue/river/rivershared v0.21.0
+	github.com/riverqueue/river/rivertype v0.21.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river v0.20.2
-	github.com/riverqueue/river/riverdriver v0.20.2
-	github.com/riverqueue/river/rivershared v0.20.2
-	github.com/riverqueue/river/rivertype v0.20.2
+	github.com/riverqueue/river v0.21.0
+	github.com/riverqueue/river/riverdriver v0.21.0
+	github.com/riverqueue/river/rivershared v0.21.0
+	github.com/riverqueue/river/rivertype v0.21.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -6,9 +6,9 @@ toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.4
-	github.com/riverqueue/river v0.20.2
-	github.com/riverqueue/river/riverdriver v0.20.2
-	github.com/riverqueue/river/rivertype v0.20.2
+	github.com/riverqueue/river v0.21.0
+	github.com/riverqueue/river/riverdriver v0.21.0
+	github.com/riverqueue/river/rivertype v0.21.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.24.0


### PR DESCRIPTION
Also remove replace directives in `cmd/river/go.mod`

[skip ci]