### PR TITLE
Drop `valutil.FirstNonZero`

### DIFF
--- a/rivershared/util/valutil/val_util.go
+++ b/rivershared/util/valutil/val_util.go
@@ -19,18 +19,3 @@ func ValOrDefaultFunc[T comparable](val T, defaultFunc func() T) T {
 	}
 	return defaultFunc()
 }
-
-// FirstNonZero returns the first argument that is non-zero, or the zero value if
-// all are zero.
-//
-// Deprecated: Use `cmp.Or` instead. This function will be removed in a near
-// future version.
-func FirstNonZero[T comparable](values ...T) T {
-	var zero T
-	for _, val := range values {
-		if val != zero {
-			return val
-		}
-	}
-	return zero
-}


### PR DESCRIPTION
This has been deprecated for a while and other projects are off of it
already, so it should be okay to drop it at this point.