### PR TITLE
Have test signals take a `testutil.TestingTB` for attributable failures

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/maputil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -530,26 +531,26 @@ type clientTestSignals struct {
 	reindexer           *maintenance.ReindexerTestSignals
 }
 
-func (ts *clientTestSignals) Init() {
-	ts.electedLeader.Init()
+func (ts *clientTestSignals) Init(tb testutil.TestingTB) {
+	ts.electedLeader.Init(tb)
 
 	if ts.jobCleaner != nil {
-		ts.jobCleaner.Init()
+		ts.jobCleaner.Init(tb)
 	}
 	if ts.jobRescuer != nil {
-		ts.jobRescuer.Init()
+		ts.jobRescuer.Init(tb)
 	}
 	if ts.jobScheduler != nil {
-		ts.jobScheduler.Init()
+		ts.jobScheduler.Init(tb)
 	}
 	if ts.periodicJobEnqueuer != nil {
-		ts.periodicJobEnqueuer.Init()
+		ts.periodicJobEnqueuer.Init(tb)
 	}
 	if ts.queueCleaner != nil {
-		ts.queueCleaner.Init()
+		ts.queueCleaner.Init(tb)
 	}
 	if ts.reindexer != nil {
-		ts.reindexer.Init()
+		ts.reindexer.Init(tb)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1162,7 +1162,7 @@ func Test_Client(t *testing.T) {
 		client, err := NewClient(riverdatabasesql.New(stdPool), config)
 		require.NoError(t, err)
 
-		client.testSignals.Init()
+		client.testSignals.Init(t)
 
 		// Notifier should not have been initialized at all.
 		require.Nil(t, client.notifier)
@@ -1190,7 +1190,7 @@ func Test_Client(t *testing.T) {
 		bundle.config.PollOnly = true
 
 		client := newTestClient(t, bundle.dbPool, config)
-		client.testSignals.Init()
+		client.testSignals.Init(t)
 
 		// Notifier should not have been initialized at all.
 		require.Nil(t, client.notifier)
@@ -3973,7 +3973,7 @@ func Test_Client_Maintenance(t *testing.T) {
 		config.Schema = schema
 
 		client := newTestClient(t, dbPool, config)
-		client.testSignals.Init()
+		client.testSignals.Init(t)
 
 		return client, &testBundle{
 			exec:   client.driver.GetExecutor(),
@@ -4270,7 +4270,7 @@ func Test_Client_Maintenance(t *testing.T) {
 		AddWorker(config.Workers, worker)
 
 		client := newTestClient(t, dbPool, config)
-		client.testSignals.Init()
+		client.testSignals.Init(t)
 		startClient(ctx, t, client)
 
 		exec := client.driver.GetExecutor()
@@ -4310,7 +4310,7 @@ func Test_Client_Maintenance(t *testing.T) {
 		AddWorker(config.Workers, worker)
 
 		client := newTestClient(t, dbPool, config)
-		client.testSignals.Init()
+		client.testSignals.Init(t)
 		exec := client.driver.GetExecutor()
 
 		handle := client.PeriodicJobs().Add(
@@ -4409,7 +4409,7 @@ func Test_Client_Maintenance(t *testing.T) {
 			config = newTestConfig(t, schema)
 			client = newTestClient(t, dbPool, config)
 		)
-		client.testSignals.Init()
+		client.testSignals.Init(t)
 
 		exec := client.driver.GetExecutor()
 

--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -17,6 +17,7 @@ import (
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
 
@@ -63,12 +64,12 @@ type electorTestSignals struct {
 	ResignedLeadership   testsignal.TestSignal[struct{}] // notifies when elector resigns leadership
 }
 
-func (ts *electorTestSignals) Init() {
-	ts.DeniedLeadership.Init()
-	ts.GainedLeadership.Init()
-	ts.LostLeadership.Init()
-	ts.MaintainedLeadership.Init()
-	ts.ResignedLeadership.Init()
+func (ts *electorTestSignals) Init(tb testutil.TestingTB) {
+	ts.DeniedLeadership.Init(tb)
+	ts.GainedLeadership.Init(tb)
+	ts.LostLeadership.Init(tb)
+	ts.MaintainedLeadership.Init(tb)
+	ts.ResignedLeadership.Init(tb)
 }
 
 type Config struct {

--- a/internal/leadership/elector_test.go
+++ b/internal/leadership/elector_test.go
@@ -151,7 +151,7 @@ func testElector[TElectorBundle any](
 		electorBundle := makeElectorBundle(ctx, t, opts.stress)
 
 		elector := makeElector(t, electorBundle)
-		elector.testSignals.Init()
+		elector.testSignals.Init(t)
 
 		return elector, &testBundle{
 			electorBundle: electorBundle,
@@ -303,7 +303,7 @@ func testElector[TElectorBundle any](
 		elector2 := makeElector(t, bundle.electorBundle)
 		elector2.config.ClientID = "elector2"
 		elector2.exec = elector1.exec
-		elector2.testSignals.Init()
+		elector2.testSignals.Init(t)
 
 		{
 			startElector(ctx, t, elector2)

--- a/internal/maintenance/job_cleaner.go
+++ b/internal/maintenance/job_cleaner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -30,8 +31,8 @@ type JobCleanerTestSignals struct {
 	DeletedBatch testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
-func (ts *JobCleanerTestSignals) Init() {
-	ts.DeletedBatch.Init()
+func (ts *JobCleanerTestSignals) Init(tb testutil.TestingTB) {
+	ts.DeletedBatch.Init(tb)
 }
 
 type JobCleanerConfig struct {

--- a/internal/maintenance/job_cleaner_test.go
+++ b/internal/maintenance/job_cleaner_test.go
@@ -50,7 +50,7 @@ func TestJobCleaner(t *testing.T) {
 			},
 			bundle.exec)
 		cleaner.StaggerStartupDisable(true)
-		cleaner.TestSignals.Init()
+		cleaner.TestSignals.Init(t)
 		t.Cleanup(cleaner.Stop)
 
 		return cleaner, bundle

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 	"github.com/riverqueue/river/rivertype"
@@ -33,9 +34,9 @@ type JobRescuerTestSignals struct {
 	UpdatedBatch testsignal.TestSignal[struct{}] // notifies when runOnce has updated rescued jobs from a batch
 }
 
-func (ts *JobRescuerTestSignals) Init() {
-	ts.FetchedBatch.Init()
-	ts.UpdatedBatch.Init()
+func (ts *JobRescuerTestSignals) Init(tb testutil.TestingTB) {
+	ts.FetchedBatch.Init(tb)
+	ts.UpdatedBatch.Init(tb)
 }
 
 type JobRescuerConfig struct {

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -100,7 +100,7 @@ func TestJobRescuer(t *testing.T) {
 			},
 			bundle.exec)
 		rescuer.StaggerStartupDisable(true)
-		rescuer.TestSignals.Init()
+		rescuer.TestSignals.Init(t)
 		t.Cleanup(rescuer.Stop)
 
 		return rescuer, bundle

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 	"github.com/riverqueue/river/rivertype"
@@ -29,9 +30,9 @@ type JobSchedulerTestSignals struct {
 	ScheduledBatch testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
-func (ts *JobSchedulerTestSignals) Init() {
-	ts.NotifiedQueues.Init()
-	ts.ScheduledBatch.Init()
+func (ts *JobSchedulerTestSignals) Init(tb testutil.TestingTB) {
+	ts.NotifiedQueues.Init(tb)
+	ts.ScheduledBatch.Init(tb)
 }
 
 type InsertFunc func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) ([]*rivertype.JobInsertResult, error)

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -59,7 +59,7 @@ func TestJobScheduler(t *testing.T) {
 				Schema: opts.schema,
 			},
 			bundle.exec)
-		scheduler.TestSignals.Init()
+		scheduler.TestSignals.Init(t)
 		t.Cleanup(scheduler.Stop)
 
 		return scheduler, bundle

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/maputil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -28,10 +29,10 @@ type PeriodicJobEnqueuerTestSignals struct {
 	SkippedJob   testsignal.TestSignal[struct{}] // notifies when a job is skipped because of nil JobInsertParams
 }
 
-func (ts *PeriodicJobEnqueuerTestSignals) Init() {
-	ts.EnteredLoop.Init()
-	ts.InsertedJobs.Init()
-	ts.SkippedJob.Init()
+func (ts *PeriodicJobEnqueuerTestSignals) Init(tb testutil.TestingTB) {
+	ts.EnteredLoop.Init(tb)
+	ts.InsertedJobs.Init(tb)
+	ts.SkippedJob.Init(tb)
 }
 
 // PeriodicJob is a periodic job to be run. It's similar to the top-level

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -116,7 +116,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc := NewPeriodicJobEnqueuer(riversharedtest.BaseServiceArchetype(t), &PeriodicJobEnqueuerConfig{Insert: makeInsertFunc(schema)}, bundle.exec)
 		svc.StaggerStartupDisable(true)
-		svc.TestSignals.Init()
+		svc.TestSignals.Init(t)
 
 		return svc, bundle
 	}
@@ -419,7 +419,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 				},
 			}, bundle.exec)
 		svc.StaggerStartupDisable(true)
-		svc.TestSignals.Init()
+		svc.TestSignals.Init(t)
 
 		startService(t, svc)
 

--- a/internal/maintenance/queue_cleaner.go
+++ b/internal/maintenance/queue_cleaner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
@@ -28,8 +29,8 @@ type QueueCleanerTestSignals struct {
 	DeletedBatch testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
-func (ts *QueueCleanerTestSignals) Init() {
-	ts.DeletedBatch.Init()
+func (ts *QueueCleanerTestSignals) Init(tb testutil.TestingTB) {
+	ts.DeletedBatch.Init(tb)
 }
 
 type QueueCleanerConfig struct {

--- a/internal/maintenance/queue_cleaner_test.go
+++ b/internal/maintenance/queue_cleaner_test.go
@@ -45,7 +45,7 @@ func TestQueueCleaner(t *testing.T) {
 			},
 			bundle.exec)
 		cleaner.StaggerStartupDisable(true)
-		cleaner.TestSignals.Init()
+		cleaner.TestSignals.Init(t)
 		t.Cleanup(cleaner.Stop)
 
 		return cleaner, bundle

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -30,7 +31,7 @@ func newTestService(tb testing.TB) *testService {
 	tb.Helper()
 
 	testSvc := baseservice.Init(riversharedtest.BaseServiceArchetype(tb), &testService{})
-	testSvc.testSignals.Init()
+	testSvc.testSignals.Init(tb)
 
 	return testSvc
 }
@@ -58,9 +59,9 @@ type testServiceTestSignals struct {
 	started   testsignal.TestSignal[struct{}]
 }
 
-func (ts *testServiceTestSignals) Init() {
-	ts.returning.Init()
-	ts.started.Init()
+func (ts *testServiceTestSignals) Init(tb testutil.TestingTB) {
+	ts.returning.Init(tb)
+	ts.started.Init(tb)
 }
 
 func TestQueueMaintainer(t *testing.T) {

--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/valutil"
 )
 
@@ -25,8 +26,8 @@ type ReindexerTestSignals struct {
 	Reindexed testsignal.TestSignal[struct{}] // notifies when a run finishes executing reindexes for all indexes
 }
 
-func (ts *ReindexerTestSignals) Init() {
-	ts.Reindexed.Init()
+func (ts *ReindexerTestSignals) Init(tb testutil.TestingTB) {
+	ts.Reindexed.Init(tb)
 }
 
 type ReindexerConfig struct {

--- a/internal/maintenance/reindexer_test.go
+++ b/internal/maintenance/reindexer_test.go
@@ -51,7 +51,7 @@ func TestReindexer(t *testing.T) {
 			Schema:       schema,
 		}, bundle.exec)
 		svc.StaggerStartupDisable(true)
-		svc.TestSignals.Init()
+		svc.TestSignals.Init(t)
 		t.Cleanup(svc.Stop)
 
 		return svc, bundle

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -16,6 +16,7 @@ import (
 	"github.com/riverqueue/river/rivershared/util/maputil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
 type NotificationTopic string
@@ -67,10 +68,10 @@ type notifierTestSignals struct {
 	ListeningEnd   testsignal.TestSignal[struct{}] // notifier has left a listen loop
 }
 
-func (ts *notifierTestSignals) Init() {
-	ts.BackoffError.Init()
-	ts.ListeningBegin.Init()
-	ts.ListeningEnd.Init()
+func (ts *notifierTestSignals) Init(tb testutil.TestingTB) {
+	ts.BackoffError.Init(tb)
+	ts.ListeningBegin.Init(tb)
+	ts.ListeningEnd.Init(tb)
 }
 
 type Notifier struct {

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -64,7 +64,7 @@ func TestNotifier(t *testing.T) {
 		)
 
 		notifier := New(riversharedtest.BaseServiceArchetype(t), listener)
-		notifier.testSignals.Init()
+		notifier.testSignals.Init(t)
 
 		return notifier, &testBundle{
 			dbPool: dbPool,

--- a/producer.go
+++ b/producer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -49,15 +50,15 @@ type producerTestSignals struct {
 	StartedExecutors           testsignal.TestSignal[struct{}] // notifies when runOnce finishes a pass
 }
 
-func (ts *producerTestSignals) Init() {
-	ts.DeletedExpiredQueueRecords.Init()
-	ts.MetadataChanged.Init()
-	ts.Paused.Init()
-	ts.PolledQueueConfig.Init()
-	ts.ReportedQueueStatus.Init()
-	ts.ReportedProducerStatus.Init()
-	ts.Resumed.Init()
-	ts.StartedExecutors.Init()
+func (ts *producerTestSignals) Init(tb testutil.TestingTB) {
+	ts.DeletedExpiredQueueRecords.Init(tb)
+	ts.MetadataChanged.Init(tb)
+	ts.Paused.Init(tb)
+	ts.PolledQueueConfig.Init(tb)
+	ts.ReportedQueueStatus.Init(tb)
+	ts.ReportedProducerStatus.Init(tb)
+	ts.Resumed.Init(tb)
+	ts.StartedExecutors.Init(tb)
 }
 
 type producerConfig struct {

--- a/producer_test.go
+++ b/producer_test.go
@@ -288,7 +288,7 @@ func testProducer(t *testing.T, makeProducer func(ctx context.Context, t *testin
 		timeBeforeStart := time.Now().UTC()
 
 		producer, jobUpdates := makeProducer(ctx, t)
-		producer.testSignals.Init()
+		producer.testSignals.Init(t)
 		config := newTestConfig(t, producer.config.Schema)
 
 		jobUpdatesFlattened := make(chan jobcompleter.CompleterJobUpdated, 10)


### PR DESCRIPTION
A problem with the current test signals system is that when they fail
they panic, which means that in tests you a generic error which can't be
traced back to any particular test [1]:

    panic: test only signal channel is full

    goroutine 55152 [running]:
    github.com/riverqueue/river/rivershared/testsignal.(*TestSignal[...]).Signal(...)
            /home/runner/work/river/river/rivershared/testsignal/test_signal.go:51
    github.com/riverqueue/river/internal/maintenance.(*Reindexer).Start.func1()
            /home/runner/work/river/river/internal/maintenance/reindexer.go:130 +0xd38
    created by github.com/riverqueue/river/internal/maintenance.(*Reindexer).Start in goroutine 55141
            /home/runner/work/river/river/internal/maintenance/reindexer.go:105 +0x1a7
    FAIL	github.com/riverqueue/river	22.678s

This makes the problem ~impossible to track down, especially in the
event the problem is intermittent and can't reproduce with `-parallel 1`
or any other trick.

Here, I propose that when initializing a test signal, its `Init` takes a
`testutil.TestingTB`. On failure, we feed the error into that instead of
panicking with it, thus attributing it to the test case that failed.

I think I was hesitant to do this originally because it feels pretty bad
to reference `*testing.T` or `*testing.B` in non-test code, but given
that `testutil.TestingTB` is a fairly minimal interface that doesn't
import the `testing` package, it seems a little more acceptable to use
this trick.

[1] https://github.com/riverqueue/river/actions/runs/14814948318/job/41594255006