### PR TITLE
Add `JobArgsWithKindAliases`, providing an easy/safe way of renaming kinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A new `JobArgsWithKindAliases` interface lets job args implement `KindAliases` to register a second kind that their worker will respond to. This provides a way to safely rename job kinds even with jobs using the original kind already in the database. [PR #XXX](https://github.com/riverqueue/river/pull/XXX).
+
 ### Changed
 
-- Job kinds must comply to a format of `\A[\w][\w\-\[\]<>\/.·:+]+\z`, mainly in an attempt to eliminate commas and spaces to make format more predictable for an upcoming search UI. This check can be disabled for now using `Config.SkipJobKindValidation`, but this option will likely be removed in a future version of River. [PR #879](https://github.com/riverqueue/river/pull/879).
+- Job kinds must comply to a format of `\A[\w][\w\-\[\]<>\/.·:+]+\z`, mainly in an attempt to eliminate commas and spaces to make format more predictable for an upcoming search UI. This check can be disabled for now using `Config.SkipJobKindValidation`, but this option will likely be removed in a future version of River. The new `JobArgsWithKindAliases` interface (see above) can be used to rename non-compliant kinds. [PR #879](https://github.com/riverqueue/river/pull/879).
 
 ## [0.21.0] - 2025-05-02
 


### PR DESCRIPTION
Here, add `JobArgsWithKindAliases`, a job args interface that lets job
args implement a second `KindAliases` that returns alternate kinds
that its worker will respond to. This provides an easy and safe way of
renaming jobs even when existing jobs under the original name are still
in the database.

Renaming a job is a three part process. To begin, a job args with its
original name:

    type jobArgsBeingRenamed struct{}

    func (a jobArgsBeingRenamed) Kind() string { return "old_name" }

Rename by putting the new name in `Kind` and moving the old name to
`KindAliases`:

    type jobArgsBeingRenamed struct{}

    func (a jobArgsBeingRenamed) Kind() string          { return "new_name" }
    func (a jobArgsBeingRenamed) KindAliases() []string { return "old_name_still_recognized" }

After all jobs inserted under the original name have finished working
(including all their possible retries, which notably might take up to
three weeks on the default retry policy), remove `KindAliases`:

    type jobArgsBeingRenamed struct{}

    func (a jobArgsBeingRenamed) Kind() string { return "new_name" }

This addition is largely driven by #879, which may make some users kinds
invalid if they contain banned characters like spaces or commas. Without
this change, users wouldn't have a particularly easy way of renaming
kinds that aren't compliant, and would have to resort to something like
fully duplicating a job args and worker and doing a find/replace.
