### PR TITLE
Make sure to use test logger to swallow invalid job kind warning

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6521,6 +6521,9 @@ func Test_NewClient_Validations(t *testing.T) {
 		{
 			name: "Job kind validation skipped with SkipJobKindValidation",
 			configFunc: func(config *Config) {
+				// this run will emit a warning; make sure it's collated under
+				// this test as opposed to going to stdout/stderr
+				config.Logger = riversharedtest.Logger(t)
 				config.SkipJobKindValidation = true
 				AddWorker(config.Workers, &invalidKindWorker{})
 			},


### PR DESCRIPTION
A small follow up to #879. The test checking that validations are
skipped with `SkipJobKindValidation` produces a warning to the logger,
and that's currently going to the default logger initialized in
`WithDefaults`, whose output is just sent to unassociated stdout/stderr
when the test is run. You can see an example of that here [1].

    time=2025-05-04T21:12:44.791Z level=WARN msg="job kind should match regex; this will be an error in future versions" kind="this kind is invalid" regex=\A[\w][\w\-\[\]<>\/.·:+]+\z

This change puts the test on a testing logger so that its output is
collated with the rest from its particular test case, stopping it from
going to the unowned bucket.

[1] https://github.com/riverqueue/river/actions/runs/14825225948/job/41617481943