### PR TITLE
Driver tests for full `lib/pq` connection + necessary fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Job kinds must comply to a format of `\A[\w][\w\-\[\]<>\/.·:+]+\z`, mainly in an attempt to eliminate commas and spaces to make format more predictable for an upcoming search UI. This check can be disabled for now using `Config.SkipJobKindValidation`, but this option will likely be removed in a future version of River. [PR #879](https://github.com/riverqueue/river/pull/879).
 
+### Fixed
+
+- The `riverdatabasesql` now fully supports raw connections through [`lib/pq`](https://github.com/lib/pq) rather than just `database/sql` through Pgx. We don't recommend the use of `lib/pq` as it's an unmaintained project, but this change should help with compatibility for older projects. [PR #883](https://github.com/riverqueue/river/pull/883).
+
 ## [0.21.0] - 2025-05-02
 
 ⚠️ Internal APIs used for communication between River and River Pro have changed. If using River Pro, make sure to update River and River Pro to latest at the same time to get compatible versions. River v0.21.0 is compatible with River Pro v0.13.0.

--- a/riverdbtest/riverdbtest.go
+++ b/riverdbtest/riverdbtest.go
@@ -399,6 +399,11 @@ func TestTx[TTx any](ctx context.Context, tb testing.TB, driver riverdriver.Driv
 			return
 		}
 
+		// Cancelled context again, but this one from libpq.
+		if err.Error() == "driver: bad connection" {
+			return
+		}
+
 		// Similar to the above, but a newly appeared error that wraps the
 		// above. As far as I can tell, no error variables are available to use
 		// with `errors.Is`.

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/models.go
@@ -8,8 +8,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"time"
-
-	"github.com/riverqueue/river/riverdriver/riverdatabasesql/internal/pgtypealias"
 )
 
 type RiverJobState string
@@ -97,7 +95,7 @@ type RiverJob struct {
 	ScheduledAt  time.Time
 	Tags         []string
 	UniqueKey    []byte
-	UniqueStates pgtypealias.Bits
+	UniqueStates *int
 }
 
 type RiverLeader struct {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -564,7 +564,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     string_to_array(unnest($10::text[]), ','),
 
     unnest($11::bytea[]),
-    unnest($12::bit(8)[])
+    nullif(unnest($12::integer[]), 0)::bit(8)
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
@@ -586,7 +586,7 @@ type JobInsertFastManyParams struct {
 	State        []string
 	Tags         []string
 	UniqueKey    []pgtypealias.NullBytea
-	UniqueStates []pgtypealias.Bits
+	UniqueStates []int32
 }
 
 type JobInsertFastManyRow struct {
@@ -682,7 +682,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     string_to_array(unnest($10::text[]), ','),
 
     unnest($11::bytea[]),
-    unnest($12::bit(8)[])
+    nullif(unnest($12::integer[]), 0)::bit(8)
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
@@ -702,7 +702,7 @@ type JobInsertFastManyNoReturningParams struct {
 	State        []RiverJobState
 	Tags         []string
 	UniqueKey    []pgtypealias.NullBytea
-	UniqueStates []pgtypealias.Bits
+	UniqueStates []int32
 }
 
 func (q *Queries) JobInsertFastManyNoReturning(ctx context.Context, db DBTX, arg *JobInsertFastManyNoReturningParams) (int64, error) {
@@ -762,7 +762,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     $14::/* TEMPLATE: schema */river_job_state,
     coalesce($15::varchar(255)[], '{}'),
     $16,
-    $17
+    nullif($17::integer, 0)::bit(8)
 ) RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 `
 
@@ -783,7 +783,7 @@ type JobInsertFullParams struct {
 	State        RiverJobState
 	Tags         []string
 	UniqueKey    []byte
-	UniqueStates pgtypealias.Bits
+	UniqueStates int32
 }
 
 func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFullParams) (*RiverJob, error) {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
@@ -13,7 +13,8 @@ import (
 
 const leaderAttemptElect = `-- name: LeaderAttemptElect :execrows
 INSERT INTO /* TEMPLATE: schema */river_leader (leader_id, elected_at, expires_at)
-    VALUES ($1, coalesce($2::timestamptz, now()), coalesce($2::timestamptz, now()) + $3::interval)
+    -- @ttl is inserted as 
+    VALUES ($1, coalesce($2::timestamptz, now()), coalesce($2::timestamptz, now()) + make_interval(secs => $3))
 ON CONFLICT (name)
     DO NOTHING
 `
@@ -21,7 +22,7 @@ ON CONFLICT (name)
 type LeaderAttemptElectParams struct {
 	LeaderID string
 	Now      *time.Time
-	TTL      time.Duration
+	TTL      float64
 }
 
 func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAttemptElectParams) (int64, error) {
@@ -34,10 +35,10 @@ func (q *Queries) LeaderAttemptElect(ctx context.Context, db DBTX, arg *LeaderAt
 
 const leaderAttemptReelect = `-- name: LeaderAttemptReelect :execrows
 INSERT INTO /* TEMPLATE: schema */river_leader (leader_id, elected_at, expires_at)
-    VALUES ($1, coalesce($2::timestamptz, now()), coalesce($2::timestamptz, now()) + $3::interval)
+    VALUES ($1, coalesce($2::timestamptz, now()), coalesce($2::timestamptz, now()) + make_interval(secs => $3))
 ON CONFLICT (name)
     DO UPDATE SET
-        expires_at = coalesce($2::timestamptz, now()) + $3
+        expires_at = EXCLUDED.expires_at
     WHERE
         river_leader.leader_id = $1
 `
@@ -45,7 +46,7 @@ ON CONFLICT (name)
 type LeaderAttemptReelectParams struct {
 	LeaderID string
 	Now      *time.Time
-	TTL      time.Duration
+	TTL      float64
 }
 
 func (q *Queries) LeaderAttemptReelect(ctx context.Context, db DBTX, arg *LeaderAttemptReelectParams) (int64, error) {
@@ -93,7 +94,7 @@ INSERT INTO /* TEMPLATE: schema */river_leader(
     leader_id
 ) VALUES (
     coalesce($1::timestamptz, coalesce($2::timestamptz, now())),
-    coalesce($3::timestamptz, coalesce($2::timestamptz, now()) + $4::interval),
+    coalesce($3::timestamptz, coalesce($2::timestamptz, now()) + make_interval(secs => $4)),
     $5
 ) RETURNING elected_at, expires_at, leader_id, name
 `
@@ -102,7 +103,7 @@ type LeaderInsertParams struct {
 	ElectedAt *time.Time
 	Now       *time.Time
 	ExpiresAt *time.Time
-	TTL       time.Duration
+	TTL       float64
 	LeaderID  string
 }
 

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/sqlc.yaml
@@ -49,6 +49,15 @@ sql:
           - db_type: "jsonb"
             go_type: "string"
 
+          - db_type: "pg_catalog.bit"
+            go_type: int
+
+          - db_type: "pg_catalog.bit"
+            go_type:
+              type: int
+              pointer: true
+            nullable: true
+
           - db_type: "pg_catalog.interval"
             go_type: "time.Duration"
 
@@ -59,24 +68,4 @@ sql:
             go_type:
               type: "time.Time"
               pointer: true
-            nullable: true
-
-          # There doesn't appear to be a good type that's suitable for database/sql other
-          # than the ones in pgtype. It's not great to make the database/sql driver take
-          # a dependency on pgx, but the reality is most users will (or should) be using
-          # pgx anyway.
-          #
-          # Unfortunately due to some sqlc limitations, you can't just use the
-          # pgtype package directly (it tries to use the non-v5 import path and
-          # you end up with duplicate pgtype imports). So there's an alias
-          # package that exposes it indirectly.
-          - db_type: "pg_catalog.bit"
-            go_type:
-              import: "github.com/riverqueue/river/riverdriver/riverdatabasesql/internal/pgtypealias"
-              type: "Bits"
-
-          - db_type: "pg_catalog.bit"
-            go_type:
-              import: "github.com/riverqueue/river/riverdriver/riverdatabasesql/internal/pgtypealias"
-              type: "Bits"
             nullable: true

--- a/riverdriver/riverdatabasesql/internal/pgtypealias/pgtype_alias.go
+++ b/riverdriver/riverdatabasesql/internal/pgtypealias/pgtype_alias.go
@@ -1,9 +1,0 @@
-// package pgtypealias exists to work around sqlc bugs with being able to
-// reference v5 the pgtype package from within a dbsql package.
-package pgtypealias
-
-import "github.com/jackc/pgx/v5/pgtype"
-
-type Bits struct {
-	pgtype.Bits
-}

--- a/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
@@ -35,6 +35,32 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestBitIntegerToBits(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 0b0000_0000, bitIntegerToBits(0, 8))
+	require.Equal(t, 0b0000_0001, bitIntegerToBits(1, 8))
+	require.Equal(t, 0b0000_0011, bitIntegerToBits(11, 8))
+	require.Equal(t, 0b0000_0111, bitIntegerToBits(111, 8))
+	require.Equal(t, 0b0000_1111, bitIntegerToBits(1111, 8))
+	require.Equal(t, 0b0001_1111, bitIntegerToBits(1_1111, 8))
+	require.Equal(t, 0b0011_1111, bitIntegerToBits(11_1111, 8))
+	require.Equal(t, 0b0111_1111, bitIntegerToBits(111_1111, 8))
+	require.Equal(t, 0b1111_1111, bitIntegerToBits(1111_1111, 8))
+	require.Equal(t, 0b0000_0010, bitIntegerToBits(10, 8))
+	require.Equal(t, 0b0000_0100, bitIntegerToBits(100, 8))
+	require.Equal(t, 0b0000_1000, bitIntegerToBits(1000, 8))
+	require.Equal(t, 0b0001_0000, bitIntegerToBits(1_0000, 8))
+	require.Equal(t, 0b0010_0000, bitIntegerToBits(10_0000, 8))
+	require.Equal(t, 0b0100_0000, bitIntegerToBits(100_0000, 8))
+	require.Equal(t, 0b1000_0000, bitIntegerToBits(1000_0000, 8))
+	require.Equal(t, 0b1010_1010, bitIntegerToBits(1010_1010, 8))
+	require.Equal(t, 0b101_0101, bitIntegerToBits(101_0101, 8))
+
+	// Extra values past numBits.
+	require.Equal(t, 0b1010, bitIntegerToBits(1010_1010, 4))
+}
+
 func TestInterpretError(t *testing.T) {
 	t.Parallel()
 

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -226,7 +226,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     string_to_array(unnest(@tags::text[]), ','),
 
     unnest(@unique_key::bytea[]),
-    unnest(@unique_states::bit(8)[])
+    nullif(unnest(@unique_states::integer[]), 0)::bit(8)
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
@@ -267,7 +267,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     string_to_array(unnest(@tags::text[]), ','),
 
     unnest(@unique_key::bytea[]),
-    unnest(@unique_states::bit(8)[])
+    nullif(unnest(@unique_states::integer[]), 0)::bit(8)
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
@@ -310,7 +310,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     @state::/* TEMPLATE: schema */river_job_state,
     coalesce(@tags::varchar(255)[], '{}'),
     @unique_key,
-    @unique_states
+    nullif(@unique_states::integer, 0)::bit(8)
 ) RETURNING *;
 
 -- name: JobList :many

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -550,7 +550,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     string_to_array(unnest($10::text[]), ','),
 
     unnest($11::bytea[]),
-    unnest($12::bit(8)[])
+    nullif(unnest($12::integer[]), 0)::bit(8)
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
@@ -572,7 +572,7 @@ type JobInsertFastManyParams struct {
 	State        []string
 	Tags         []string
 	UniqueKey    [][]byte
-	UniqueStates []pgtype.Bits
+	UniqueStates []int32
 }
 
 type JobInsertFastManyRow struct {
@@ -665,7 +665,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     string_to_array(unnest($10::text[]), ','),
 
     unnest($11::bytea[]),
-    unnest($12::bit(8)[])
+    nullif(unnest($12::integer[]), 0)::bit(8)
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
       AND unique_states IS NOT NULL
@@ -685,7 +685,7 @@ type JobInsertFastManyNoReturningParams struct {
 	State        []RiverJobState
 	Tags         []string
 	UniqueKey    [][]byte
-	UniqueStates []pgtype.Bits
+	UniqueStates []int32
 }
 
 func (q *Queries) JobInsertFastManyNoReturning(ctx context.Context, db DBTX, arg *JobInsertFastManyNoReturningParams) (int64, error) {
@@ -745,7 +745,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     $14::/* TEMPLATE: schema */river_job_state,
     coalesce($15::varchar(255)[], '{}'),
     $16,
-    $17
+    nullif($17::integer, 0)::bit(8)
 ) RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 `
 
@@ -766,7 +766,7 @@ type JobInsertFullParams struct {
 	State        RiverJobState
 	Tags         []string
 	UniqueKey    []byte
-	UniqueStates pgtype.Bits
+	UniqueStates int32
 }
 
 func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFullParams) (*RiverJob, error) {


### PR DESCRIPTION
So it turns out that while bearing some relation to `lib/pq` through
various pieces that sqlc pulls in, the `riverdatabasesql` driver didn't
actually work when used with `lib/pq`. When testing it, we'd open a
`sql.DB` pool _via_ Pgx, so Pgx was doing all the heavy lifting.

Here, add an alternate driver test strategy to test `riverdatabasesql`
with a `lib/pq` pool, thereby ensuring that the full range of operations
works even with no Pgx in the mix at all.

Things were broken, so we get those fixed up. There we two main
problems:

* As described in #545, `lib/pq` doesn't handle intervals correctly, and
  reads them in as ints, which is a big problem because they're in
  nanoseconds. We work around this by injecting intervals (like leader
  TTLs) an second floats instead, which really doesn't feel that much
  worse.

* The custom bits class for `unique_states` didn't work. To fix this I
  move to an alternate strategy of inserts `unique_states` as an
  integer, a technique that I've been using in SQLite because there's no
  `bits` type. I could make a strong argument that the use of an integer
  over `bits` would've been a better design from the get go anyway,
  because it makes all the bit-wise arithmetic much simpler as you use
  C-style conventions like `states & (1 << 3)` that are very widespread
  and well understood. Either way though, things work reasonably well if
  we insert as an integer, then transition to storage in bits.

Fixes #545 and #566. Supersedes #882.