### PR TITLE
Finish accidentally not pushed `@ttl` comment

### DIFF
--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
@@ -13,7 +13,7 @@ import (
 
 const leaderAttemptElect = `-- name: LeaderAttemptElect :execrows
 INSERT INTO /* TEMPLATE: schema */river_leader (leader_id, elected_at, expires_at)
-    -- @ttl is inserted as 
+    -- @ttl is inserted as as seconds rather than a duration because ` + "`" + `lib/pq` + "`" + ` doesn't support the latter
     VALUES ($1, coalesce($2::timestamptz, now()), coalesce($2::timestamptz, now()) + make_interval(secs => $3))
 ON CONFLICT (name)
     DO NOTHING

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql
@@ -9,7 +9,7 @@ CREATE UNLOGGED TABLE river_leader(
 
 -- name: LeaderAttemptElect :execrows
 INSERT INTO /* TEMPLATE: schema */river_leader (leader_id, elected_at, expires_at)
-    -- @ttl is inserted as 
+    -- @ttl is inserted as as seconds rather than a duration because `lib/pq` doesn't support the latter
     VALUES (@leader_id, coalesce(sqlc.narg('now')::timestamptz, now()), coalesce(sqlc.narg('now')::timestamptz, now()) + make_interval(secs => @ttl))
 ON CONFLICT (name)
     DO NOTHING;

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
@@ -14,7 +14,7 @@ import (
 
 const leaderAttemptElect = `-- name: LeaderAttemptElect :execrows
 INSERT INTO /* TEMPLATE: schema */river_leader (leader_id, elected_at, expires_at)
-    -- @ttl is inserted as 
+    -- @ttl is inserted as as seconds rather than a duration because ` + "`" + `lib/pq` + "`" + ` doesn't support the latter
     VALUES ($1, coalesce($2::timestamptz, now()), coalesce($2::timestamptz, now()) + make_interval(secs => $3))
 ON CONFLICT (name)
     DO NOTHING


### PR DESCRIPTION
This is just a dumb one where I was addressing code review feedback from
the `lib/pq` change #883, specifically a half finished comment on
`@ttl`, then forgot to push the change up to my branch before merging
it. Here, address the problem by finishing the comment.