### PR TITLE
Prepare release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2025-05-10
+
 ### Added
 
-- A new `JobArgsWithKindAliases` interface lets job args implement `KindAliases` to register a second kind that their worker will respond to. This provides a way to safely rename job kinds even with jobs using the original kind already in the database. [PR #XXX](https://github.com/riverqueue/river/pull/XXX).
+- A new `JobArgsWithKindAliases` interface lets job args implement `KindAliases` to register a second kind that their worker will respond to. This provides a way to safely rename job kinds even with jobs using the original kind already in the database. [PR #880](https://github.com/riverqueue/river/pull/880).
 
 ### Changed
 

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,11 +7,11 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/lmittmann/tint v1.0.7
-	github.com/riverqueue/river v0.21.0
-	github.com/riverqueue/river/riverdriver v0.21.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.21.0
-	github.com/riverqueue/river/rivershared v0.21.0
-	github.com/riverqueue/river/rivertype v0.21.0
+	github.com/riverqueue/river v0.22.0
+	github.com/riverqueue/river/riverdriver v0.22.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.22.0
+	github.com/riverqueue/river/rivershared v0.22.0
+	github.com/riverqueue/river/rivertype v0.22.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.21.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.21.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.21.0
-	github.com/riverqueue/river/rivershared v0.21.0
-	github.com/riverqueue/river/rivertype v0.21.0
+	github.com/riverqueue/river/riverdriver v0.22.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.22.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.22.0
+	github.com/riverqueue/river/rivershared v0.22.0
+	github.com/riverqueue/river/rivertype v0.22.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/riverqueue/river/rivertype v0.21.0
+	github.com/riverqueue/river/rivertype v0.22.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.21.0
-	github.com/riverqueue/river/riverdriver v0.21.0
-	github.com/riverqueue/river/rivershared v0.21.0
-	github.com/riverqueue/river/rivertype v0.21.0
+	github.com/riverqueue/river v0.22.0
+	github.com/riverqueue/river/riverdriver v0.22.0
+	github.com/riverqueue/river/rivershared v0.22.0
+	github.com/riverqueue/river/rivertype v0.22.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river v0.21.0
-	github.com/riverqueue/river/riverdriver v0.21.0
-	github.com/riverqueue/river/rivershared v0.21.0
-	github.com/riverqueue/river/rivertype v0.21.0
+	github.com/riverqueue/river v0.22.0
+	github.com/riverqueue/river/riverdriver v0.22.0
+	github.com/riverqueue/river/rivershared v0.22.0
+	github.com/riverqueue/river/rivertype v0.22.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -6,9 +6,9 @@ toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.4
-	github.com/riverqueue/river v0.21.0
-	github.com/riverqueue/river/riverdriver v0.21.0
-	github.com/riverqueue/river/rivertype v0.21.0
+	github.com/riverqueue/river v0.22.0
+	github.com/riverqueue/river/riverdriver v0.22.0
+	github.com/riverqueue/river/rivertype v0.22.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.24.0


### PR DESCRIPTION
Prepare release v0.22.0, largely containing a more functional
`database/sql` driver that'll work with `lib/pq`, stricter validation on
job kinds, and a way to safely rename job kinds with `KindAliases()`.

[skip ci]