### PR TITLE
Suppress producer error log on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Resuming an already unpaused queue is now fully an no-op, and won't touch the row's `updated_at` like it (unintentionally) did before. [PR #870](https://github.com/riverqueue/river/pull/870).
+- Suppress an error log line from the producer that may occur on normal shutdown when operating in poll-only mode. [PR #896](https://github.com/riverqueue/river/pull/896).
 
 ## [0.22.0] - 2025-05-10
 


### PR DESCRIPTION
I noticed when running some benchmarking tonight that I'd occasionally
get an error line at the end even though things seem to finish cleanly:

    May 13 18:13:36.622 ERR producer: Error fetching queue settings err="context canceled"

Looking at the implementation, it looks like this is something that
could happen randomly in the poll-only path. If the producer happens to
be polling for queue changes as shutdown happens, it'll log an error as
the context is cancelled. This is more likely to happen for SQLite
because we constrain the connection pool to only one active connection.

Here, only produce an error log conditionally in cases where the parent
context has not been cancelled.