### PR TITLE
Use simply `old_name` in job rename example

### DIFF
--- a/job.go
+++ b/job.go
@@ -54,7 +54,7 @@ type JobArgs interface {
 //	type jobArgsBeingRenamed struct{}
 //
 //	func (a jobArgsBeingRenamed) Kind() string          { return "new_name" }
-//	func (a jobArgsBeingRenamed) KindAliases() []string { return []string{"old_name_still_recognized"} }
+//	func (a jobArgsBeingRenamed) KindAliases() []string { return []string{"old_name"} }
 //
 // After all jobs inserted under the original name have finished working
 // (including all their possible retries, which notably might take up to three


### PR DESCRIPTION
In the docs for `JobArgsWithKindAliases` we walk through an example of
renaming `old_name` to `new_name`, but in the phase where aliases are
added, we have the old name `old_name_still_recognized`.

As I writing up docs for renaming jobs, this didn't really feel like it
made much sense to me. We're supposed to be showing that `old_name` gets
moved into `KindAliases`, but if `old_name` changes to something else,
it defeats the clarity of the example such that it doesn't make all that
much sense anymore.

Here, use `old_name` in `KindAliases` instead.