### PR TITLE
Truncate tables across all migration lines in `riverdbtest`

### DIFF
--- a/riverdbtest/riverdbtest.go
+++ b/riverdbtest/riverdbtest.go
@@ -266,7 +266,7 @@ func TestSchema[TTx any](ctx context.Context, tb testutil.TestingTB, driver rive
 			targetVersion = opts.LineTargetVersions[line]
 		}
 
-		truncateTables = driver.GetMigrationTruncateTables(line, targetVersion)
+		truncateTables = append(truncateTables, driver.GetMigrationTruncateTables(line, targetVersion)...)
 	}
 
 	// Adds a hook on `tb.Cleanup` that checks the test schema in after use.


### PR DESCRIPTION
Fixes a bug in `riverdbtest` where in the presence of multiple migration
lines, we'd overwrite our set of truncation tables on every iteration of
the loop, so we'd only end up keeping the last one. Here, make sure to
append all tables so they're all included.

This bug doesn't manifest in the main project because we never have more
than one migration line, but we do see it causing trouble in the Pro
test suite after fixing a bug there in `GetMigrationTruncateTables`.

I didn't add a test for this even though it might be useful because we
unfortunately just don't have any good way of doing it at the moment.
We'd need to have some kind of mock driver to pull this off.