### PR TITLE
Add unique states bitmask helpers to `rivershared/uniquestates`

### DIFF
--- a/internal/dbunique/db_unique_test.go
+++ b/internal/dbunique/db_unique_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/riverqueue/river/rivershared/riversharedtest"
+	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -254,7 +255,7 @@ func TestUniqueKey(t *testing.T) {
 				ScheduledAt:  &now,
 				State:        "Pending",
 				Tags:         []string{"notification", "email"},
-				UniqueStates: UniqueStatesToBitmask(states),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(states),
 			}
 
 			if tt.modifyInsertParamsFunc != nil {
@@ -309,25 +310,11 @@ func TestUniqueOptsStateBitmask(t *testing.T) {
 	t.Parallel()
 
 	emptyOpts := &UniqueOpts{}
-	require.Equal(t, UniqueStatesToBitmask(uniqueOptsByStateDefault), emptyOpts.StateBitmask(), "Empty unique options should have default bitmask")
+	require.Equal(t, uniquestates.UniqueStatesToBitmask(uniqueOptsByStateDefault), emptyOpts.StateBitmask(), "Empty unique options should have default bitmask")
 
 	otherStates := []rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStateCompleted}
 	nonEmptyOpts := &UniqueOpts{
 		ByState: otherStates,
 	}
-	require.Equal(t, UniqueStatesToBitmask([]rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStateCompleted}), nonEmptyOpts.StateBitmask(), "Non-empty unique options should have correct bitmask")
-}
-
-func TestUniqueStatesToBitmask(t *testing.T) {
-	t.Parallel()
-
-	bitmask := UniqueStatesToBitmask(uniqueOptsByStateDefault)
-	require.Equal(t, byte(0b11110101), bitmask, "Default unique states should be all set except cancelled and discarded")
-
-	for state, position := range jobStateBitPositions {
-		bitmask = UniqueStatesToBitmask([]rivertype.JobState{state})
-		// Bit shifting uses postgres bit numbering with MSB on the right, so we
-		// need to flip the position when shifting manually:
-		require.Equal(t, byte(1<<(7-position)), bitmask, "Bitmask should be set for single state %s", state)
-	}
+	require.Equal(t, uniquestates.UniqueStatesToBitmask([]rivertype.JobState{rivertype.JobStateAvailable, rivertype.JobStateCompleted}), nonEmptyOpts.StateBitmask(), "Non-empty unique options should have correct bitmask")
 }

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
+	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -170,7 +170,7 @@ func TestJobScheduler(t *testing.T) {
 			rivertype.JobStateRunning,
 			rivertype.JobStateScheduled,
 		}
-		uniqueMap := dbunique.UniqueStatesToBitmask(uniqueStates)
+		uniqueMap := uniquestates.UniqueStatesToBitmask(uniqueStates)
 
 		retryableJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("1"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
 		retryableJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("2"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/internal/notifier"
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdbtest"
@@ -30,6 +29,7 @@ import (
 	"github.com/riverqueue/river/rivermigrate"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
+	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/hashutil"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/randutil"
@@ -2103,13 +2103,13 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 				ScheduledAt:  &beforeHorizon,
 				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-1"),
-				UniqueStates: dbunique.UniqueStatesToBitmask(nonRetryableUniqueStates),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
 				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-2"),
-				UniqueStates: dbunique.UniqueStatesToBitmask(nonRetryableUniqueStates),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 			// job3 has no conflict (it's the only one with this key), so it should be
 			// scheduled.
@@ -2117,7 +2117,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 				ScheduledAt:  &beforeHorizon,
 				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-3"),
-				UniqueStates: dbunique.UniqueStatesToBitmask(defaultUniqueStates),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(defaultUniqueStates),
 			})
 
 			// This one is a conflict with job1 because it's already running and has
@@ -2126,7 +2126,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 				ScheduledAt:  &beforeHorizon,
 				State:        ptrutil.Ptr(rivertype.JobStateRunning),
 				UniqueKey:    []byte("unique-key-1"),
-				UniqueStates: dbunique.UniqueStatesToBitmask(nonRetryableUniqueStates),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 			// This one is *not* a conflict with job2 because it's completed, which
 			// isn't in the unique states:
@@ -2134,7 +2134,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 				ScheduledAt:  &beforeHorizon,
 				State:        ptrutil.Ptr(rivertype.JobStateCompleted),
 				UniqueKey:    []byte("unique-key-2"),
-				UniqueStates: dbunique.UniqueStatesToBitmask(nonRetryableUniqueStates),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 
 			result, err := exec.JobSchedule(ctx, &riverdriver.JobScheduleParams{
@@ -2182,13 +2182,13 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 				ScheduledAt:  &beforeHorizon,
 				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-1"),
-				UniqueStates: dbunique.UniqueStatesToBitmask(nonRetryableUniqueStates),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
 				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-1"),
-				UniqueStates: dbunique.UniqueStatesToBitmask(nonRetryableUniqueStates),
+				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 
 			result, err := exec.JobSchedule(ctx, &riverdriver.JobScheduleParams{

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/lib/pq"
 
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverdatabasesql/internal/dbsqlc"
 	"github.com/riverqueue/river/riverdriver/riverdatabasesql/internal/pgtypealias"
 	"github.com/riverqueue/river/rivershared/sqlctemplate"
+	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
@@ -998,7 +998,7 @@ func jobRowFromInternal(internal *dbsqlc.RiverJob) (*rivertype.JobRow, error) {
 		State:        rivertype.JobState(internal.State),
 		Tags:         internal.Tags,
 		UniqueKey:    internal.UniqueKey,
-		UniqueStates: dbunique.UniqueBitmaskToStates(byte(bitIntegerToBits(ptrutil.ValOrDefault(internal.UniqueStates, 0), 8))),
+		UniqueStates: uniquestates.UniqueBitmaskToStates(byte(bitIntegerToBits(ptrutil.ValOrDefault(internal.UniqueStates, 0), 8))),
 	}, nil
 }
 

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -24,10 +24,10 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/puddle/v2"
 
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5/internal/dbsqlc"
 	"github.com/riverqueue/river/rivershared/sqlctemplate"
+	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
@@ -1032,7 +1032,7 @@ func jobRowFromInternal(internal *dbsqlc.RiverJob) (*rivertype.JobRow, error) {
 		State:        rivertype.JobState(internal.State),
 		Tags:         internal.Tags,
 		UniqueKey:    internal.UniqueKey,
-		UniqueStates: dbunique.UniqueBitmaskToStates(uniqueStatesByte),
+		UniqueStates: uniquestates.UniqueBitmaskToStates(uniqueStatesByte),
 	}, nil
 }
 

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -34,12 +34,12 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
-	"github.com/riverqueue/river/internal/dbunique"
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/internal/util/dbutil"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riversqlite/internal/dbsqlc"
 	"github.com/riverqueue/river/rivershared/sqlctemplate"
+	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
@@ -1320,7 +1320,7 @@ func jobRowFromInternal(internal *dbsqlc.RiverJob) (*rivertype.JobRow, error) {
 		State:        rivertype.JobState(internal.State),
 		Tags:         tags,
 		UniqueKey:    internal.UniqueKey,
-		UniqueStates: dbunique.UniqueBitmaskToStates(uniqueStatesByte),
+		UniqueStates: uniquestates.UniqueBitmaskToStates(uniqueStatesByte),
 	}, nil
 }
 

--- a/rivershared/uniquestates/unique_states.go
+++ b/rivershared/uniquestates/unique_states.go
@@ -1,0 +1,47 @@
+package uniquestates
+
+import (
+	"slices"
+
+	"github.com/riverqueue/river/rivertype"
+)
+
+func UniqueBitmaskToStates(mask byte) []rivertype.JobState {
+	var states []rivertype.JobState
+
+	for state, bitIndex := range jobStateBitPositions {
+		bitPosition := 7 - (bitIndex % 8)
+		if mask&(1<<bitPosition) != 0 {
+			states = append(states, state)
+		}
+	}
+
+	slices.Sort(states)
+	return states
+}
+
+var jobStateBitPositions = map[rivertype.JobState]uint{ //nolint:gochecknoglobals
+	rivertype.JobStateAvailable: 7,
+	rivertype.JobStateCancelled: 6,
+	rivertype.JobStateCompleted: 5,
+	rivertype.JobStateDiscarded: 4,
+	rivertype.JobStatePending:   3,
+	rivertype.JobStateRetryable: 2,
+	rivertype.JobStateRunning:   1,
+	rivertype.JobStateScheduled: 0,
+}
+
+func UniqueStatesToBitmask(states []rivertype.JobState) byte {
+	var val byte
+
+	for _, state := range states {
+		bitIndex, exists := jobStateBitPositions[state]
+		if !exists {
+			continue // Ignore unknown states
+		}
+		bitPosition := 7 - (bitIndex % 8)
+		val |= 1 << bitPosition
+	}
+
+	return val
+}

--- a/rivershared/uniquestates/unique_states_test.go
+++ b/rivershared/uniquestates/unique_states_test.go
@@ -1,0 +1,22 @@
+package uniquestates
+
+import (
+	"testing"
+
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUniqueStatesToBitmask(t *testing.T) {
+	t.Parallel()
+
+	bitmask := UniqueStatesToBitmask(rivertype.UniqueOptsByStateDefault())
+	require.Equal(t, byte(0b11110101), bitmask, "Default unique states should be all set except cancelled and discarded")
+
+	for state, position := range jobStateBitPositions {
+		bitmask = UniqueStatesToBitmask([]rivertype.JobState{state})
+		// Bit shifting uses postgres bit numbering with MSB on the right, so we
+		// need to flip the position when shifting manually:
+		require.Equal(t, byte(1<<(7-position)), bitmask, "Bitmask should be set for single state %s", state)
+	}
+}


### PR DESCRIPTION
This one's aimed at a bug discovered in Pro wherein because the project
didn't have access to the unique states bitmask helpers, the
`UniqueStates` property was left off job rows. Here, put the headers in
a general location in `rivershared` that can be accessed from both
projects.