### PR TITLE
Add `--schema` option to `river migrate-get` + hide schema comments otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Preliminary River driver for SQLite (`riverdriver/riversqlite`). This driver seems to produce good results as judged by the test suite, but so far has minimal real world vetting. Try it and let us know how it works out. [PR #870](https://github.com/riverqueue/river/pull/870).
+- CLI `river migrate-get` now takes a `--schema` option to inject a custom schema into dumped migrations and schema comments are hidden if `--schema` option isn't provided. [PR #903](https://github.com/riverqueue/river/pull/903).
 
 ### Fixed
 
 - Resuming an already unpaused queue is now fully an no-op, and won't touch the row's `updated_at` like it (unintentionally) did before. [PR #870](https://github.com/riverqueue/river/pull/870).
 - Suppress an error log line from the producer that may occur on normal shutdown when operating in poll-only mode. [PR #896](https://github.com/riverqueue/river/pull/896).
+- Added missing help documentation for CLI command `river migrate-list`. [PR #903](https://github.com/riverqueue/river/pull/903).
 
 ## [0.22.0] - 2025-05-10
 

--- a/producer.go
+++ b/producer.go
@@ -810,7 +810,6 @@ func (p *producer) pollForSettingChanges(ctx context.Context, wg *sync.WaitGroup
 				// Don't log if this is part of a standard shutdown.
 				if !errors.Is(context.Cause(ctx), startstop.ErrStop) {
 					p.Logger.ErrorContext(ctx, p.Name+": Error fetching queue settings", slog.String("err", err.Error()))
-
 				}
 				continue
 			}

--- a/rivershared/uniquestates/unique_states_test.go
+++ b/rivershared/uniquestates/unique_states_test.go
@@ -3,8 +3,9 @@ package uniquestates
 import (
 	"testing"
 
-	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/rivertype"
 )
 
 func TestUniqueStatesToBitmask(t *testing.T) {


### PR DESCRIPTION
Here, add a `--schema` option to the `river migrate-get` command that
lets the caller inject a custom schema into the SQL generated by the
command. If the `--schema` command is not provided, we hide the
`/* TEMPLATE: schema */` comments for cleanliness (previously, they were
returned, which wasn't harmful but added visual noise).

Since we're making changes anyway, add a test suite for `migrate-get`.
It should've been there before anyway and it will help protect against
regressions.

Only tangentially related, fix a small bug in the migration "flags" that
are output like `-- River main migration 001 [up]` in that when using
the default "main" line, the line was being accidentally omitted.

Also unrelated, but add missing docs for `river migrate-list` which have
apparently accidentally been a TODO for quite some time.

Fixes #902.