### PR TITLE
Add documentation for how to use `migrate-get` for SQLite

### DIFF
--- a/cmd/river/rivercli/river_cli.go
+++ b/cmd/river/rivercli/river_cli.go
@@ -208,8 +208,8 @@ migration SQL to be dumped for use elsewhere.
 
 Specify a version with --version, and one of --down or --up:
 
-    river migrate-get --version 3 --up > river3.up.sql
-    river migrate-get --version 3 --down > river3.down.sql
+    river migrate-get --version 3 --up > river_3.up.sql
+    river migrate-get --version 3 --down > river_3.down.sql
 
 Can also take multiple versions by separating them with commas or passing
 --version multiple times:
@@ -223,6 +223,11 @@ framework, which aren't necessary if using an external framework:
 
     river migrate-get --all --exclude-version 1 --up > river_all.up.sql
     river migrate-get --all --exclude-version 1 --down > river_all.down.sql
+
+Returns migrations for Postgres by default. Use --database-url to hint a
+non-Postgres alternative:
+
+    river migrate-get --version 6 --up --database-url sqlite:// > river_6.up.sql
 	`),
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return RunCommand(ctx, makeCommandBundle(&opts.DatabaseURL, ""), &migrateGet{}, &opts)


### PR DESCRIPTION
A tiny change that I'd had in another branch and am just going to move
it to its own since the other probably won't land. Adds an example to
the docs for `river migrate-get` that spells out specifically how to use
the command to get schema dumps for SQLite.