### PR TITLE
Arbitrary context call for `riverlog` middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Preliminary River driver for SQLite (`riverdriver/riversqlite`). This driver seems to produce good results as judged by the test suite, but so far has minimal real world vetting. Try it and let us know how it works out. [PR #870](https://github.com/riverqueue/river/pull/870).
 - CLI `river migrate-get` now takes a `--schema` option to inject a custom schema into dumped migrations and schema comments are hidden if `--schema` option isn't provided. [PR #903](https://github.com/riverqueue/river/pull/903).
+- Added `riverlog.NewMiddlewareCustomContext` that makes the use of `riverlog` job-persisted logging possible with non-slog loggers. [PR #919](https://github.com/riverqueue/river/pull/919).
 
 ### Changed
 
 - Optimized the job completer's query `JobSetStateIfRunningMany`, resulting in an approximately 15% reduction in its duration when completing 2000 jobs, and around a 15-20% increase in `riverbench` throughput. [PR #904](https://github.com/riverqueue/river/pull/904).
 - `TimeStub` has been removed from the `rivertest` package. Its original inclusion was entirely accidentally and it should be considered entirely an internal API. [PR #912](https://github.com/riverqueue/river/pull/912).
+- When storing job-persisted logging with `riverlog`, if a work run's logging was completely empty no metadata value is stored at all (previously, an empty value was stored). [PR #919](https://github.com/riverqueue/river/pull/919).
 
 ### Fixed
 

--- a/riverlog/example_new_middleware_custom_context_test.go
+++ b/riverlog/example_new_middleware_custom_context_test.go
@@ -1,0 +1,108 @@
+package riverlog_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdbtest"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/riverlog"
+	"github.com/riverqueue/river/rivershared/riversharedtest"
+	"github.com/riverqueue/river/rivershared/util/slogutil"
+	"github.com/riverqueue/river/rivershared/util/testutil"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// Callers should define their own context key to extract their a logger back
+// out of work context.
+type customContextKey struct{}
+
+type CustomContextLoggingArgs struct{}
+
+func (CustomContextLoggingArgs) Kind() string { return "logging" }
+
+type CustomContextLoggingWorker struct {
+	river.WorkerDefaults[CustomContextLoggingArgs]
+}
+
+func (w *CustomContextLoggingWorker) Work(ctx context.Context, job *river.Job[CustomContextLoggingArgs]) error {
+	logger := ctx.Value(customContextKey{}).(*log.Logger) //nolint:forcetypeassert
+	logger.Printf("Raw log from worker")
+	return nil
+}
+
+// ExampleNewMiddlewareCustomContext demonstrates the use of riverlog middleware
+// with an arbitrary new context function that can be used to inject any sort of
+// logger into context.
+func ExampleNewMiddlewareCustomContext() {
+	ctx := context.Background()
+
+	dbPool, err := pgxpool.New(ctx, riversharedtest.TestDatabaseURL())
+	if err != nil {
+		panic(err)
+	}
+	defer dbPool.Close()
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &CustomContextLoggingWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 100},
+		},
+		Middleware: []rivertype.Middleware{
+			riverlog.NewMiddlewareCustomContext(func(ctx context.Context, w io.Writer) context.Context {
+				// For demonstration purposes we show the use of a built-in
+				// non-slog logger, but this could be anything like Logrus or
+				// Zap. Even the raw writer could be stored if so desired.
+				logger := log.New(w, "", 0)
+				return context.WithValue(ctx, customContextKey{}, logger)
+			}, nil),
+		},
+		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
+		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
+		Workers:  workers,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Out of example scope, but used to wait until a job is worked.
+	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
+	defer subscribeCancel()
+
+	if err := riverClient.Start(ctx); err != nil {
+		panic(err)
+	}
+
+	_, err = riverClient.Insert(ctx, CustomContextLoggingArgs{}, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Wait for job to complete, extract log data out of metadata, and print it.
+	for _, event := range riversharedtest.WaitOrTimeoutN(testutil.PanicTB(), subscribeChan, 1) {
+		var metadataWithLog metadataWithLog
+		if err := json.Unmarshal(event.Job.Metadata, &metadataWithLog); err != nil {
+			panic(err)
+		}
+		for _, logAttempt := range metadataWithLog.RiverLog {
+			fmt.Print(logAttempt.Log)
+		}
+	}
+
+	if err := riverClient.Stop(ctx); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Raw log from worker
+}

--- a/riverlog/example_new_middleware_test.go
+++ b/riverlog/example_new_middleware_test.go
@@ -33,9 +33,9 @@ func (w *LoggingWorker) Work(ctx context.Context, job *river.Job[LoggingArgs]) e
 	return nil
 }
 
-// Example_middleware demonstrates the use of riverlog middleware to inject a
+// ExampleNewMiddleware demonstrates the use of riverlog middleware to inject a
 // logger into context that'll persist its output onto the job record.
-func Example_middleware() {
+func ExampleNewMiddleware() {
 	ctx := context.Background()
 
 	dbPool, err := pgxpool.New(ctx, riversharedtest.TestDatabaseURL())
@@ -83,12 +83,6 @@ func Example_middleware() {
 		panic(err)
 	}
 
-	type metadataWithLog struct {
-		RiverLog []struct {
-			Log string `json:"log"`
-		} `json:"river:log"`
-	}
-
 	// Wait for job to complete, extract log data out of metadata, and print it.
 	for _, event := range riversharedtest.WaitOrTimeoutN(testutil.PanicTB(), subscribeChan, 1) {
 		var metadataWithLog metadataWithLog
@@ -107,4 +101,10 @@ func Example_middleware() {
 	// Output:
 	// Logged from worker
 	// Another line logged from worker
+}
+
+type metadataWithLog struct {
+	RiverLog []struct {
+		Log string `json:"log"`
+	} `json:"river:log"`
 }


### PR DESCRIPTION
This one's inspired by #914. Our current `riverlog` implementation
should work pretty well for most users, but it does force them to use
slog. I'm inclined to provide additional options here because in all
honesty, slog's API is terrible, and I wouldn't want to use it myself.

Here, we add the new initializer `NewMiddlewareCustomContext`. Users
will have to bring their own context key like:

    type CustomContextKey struct{}

New middleware takes a `newContext` function that should initialize
whatever it wants with an input writer and put it in context:

    riverlog.NewMiddlewareCustomContext(func(ctx context.Context, w io.Writer) context.Context {
        logger := log.New(w, "", 0)
        return context.WithValue(ctx, CustomContextKey{}, logger)
    }, nil),

Work functions then re-extract whatever they added to context (in
reality, they'd probably define their own shorthand helpers over what's
shown below):

    func (w *CustomContextLoggingWorker) Work(ctx context.Context, job *river.Job[CustomContextLogginArgs]) error {
        logger := ctx.Value(CustomContextKey{}).(*log.Logger)
        logger.Printf("Raw log from worker")
        return nil
    }

An alternative to this might be to expose more River innards that'd let
callers set their own metadata, but I'm kind of thinking that a project
like that should involve very thorough consideration, and may not even
be desirable. I think that even if we go that direction, the new
`NewMiddlewareCustomContext` would continue to be useful as a higher
level abstraction.

We also patch up another small `riverlog` problem point out in review in
that previously, we'd store a metadata value even if no logs at all were
emitted during the course of a work function. Here, we put in a check so
that metadata is left unchanged if no logging occurred. A new test case
verifies the behavior.

Fixes #914.
