### PR TITLE
Return error about job list metadata on SQLite on `JobListTx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Suppress an error log line from the producer that may occur on normal shutdown when operating in poll-only mode. [PR #896](https://github.com/riverqueue/river/pull/896).
 - Added missing help documentation for CLI command `river migrate-list`. [PR #903](https://github.com/riverqueue/river/pull/903).
 - Correct handling an explicit schema in the reindexer maintenance service. [PR #916](https://github.com/riverqueue/river/pull/916).
+- Return specific explanatory error when attempting to use `JobListParams.Metadata` with `JobListTx` on SQLite. [PR #924](https://github.com/riverqueue/river/pull/924).
 
 ## [0.22.0] - 2025-05-10
 

--- a/client.go
+++ b/client.go
@@ -1995,6 +1995,10 @@ type JobListResult struct {
 	LastCursor *JobListCursor
 }
 
+const databaseNameSQLite = "sqlite"
+
+var errJobListParamsMetadataNotSupportedSQLite = errors.New("JobListParams.Metadata is not supported on SQLite")
+
 // JobList returns a paginated list of jobs matching the provided filters. The
 // provided context is used for the underlying Postgres query and can be used to
 // cancel the operation or apply a timeout.
@@ -2014,8 +2018,8 @@ func (c *Client[TTx]) JobList(ctx context.Context, params *JobListParams) (*JobL
 	}
 	params.schema = c.config.Schema
 
-	if c.driver.DatabaseName() == "sqlite" && params.metadataFragment != "" {
-		return nil, errors.New("JobListResult.Metadata is not supported on SQLite")
+	if c.driver.DatabaseName() == databaseNameSQLite && params.metadataFragment != "" {
+		return nil, errJobListParamsMetadataNotSupportedSQLite
 	}
 
 	dbParams, err := params.toDBParams()
@@ -2048,6 +2052,10 @@ func (c *Client[TTx]) JobListTx(ctx context.Context, tx TTx, params *JobListPara
 		params = NewJobListParams()
 	}
 	params.schema = c.config.Schema
+
+	if c.driver.DatabaseName() == databaseNameSQLite && params.metadataFragment != "" {
+		return nil, errJobListParamsMetadataNotSupportedSQLite
+	}
 
 	dbParams, err := params.toDBParams()
 	if err != nil {

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -355,6 +355,14 @@ func (p *JobListParams) Kinds(kinds ...string) *JobListParams {
 	return paramsCopy
 }
 
+// Metadata returns an updated filter set that will return only jobs that has
+// metadata which contains the given JSON fragment at its top level. This is
+// equivalent to the `@>` operator in Postgres:
+//
+// https://www.postgresql.org/docs/current/functions-json.html
+//
+// This function isn't supported in SQLite due to SQLite not having an
+// equivalent operator to use, so there's no efficient way to implement it.
 func (p *JobListParams) Metadata(json string) *JobListParams {
 	paramsCopy := p.copy()
 	paramsCopy.metadataFragment = json


### PR DESCRIPTION
Fix a problem reported in #923. We return a special error on SQLite when
someone tries to use `JobListParams.Metadata` because we can't support
the Postgres `@>` operator, which doesn't exist in any other database.
Somehow, this error was only returned on `JobList` and not `JobListTx`.

Here, bring it to `JobListTx` too. Add a new set of client driver tests
for `JobListTx` so we're doing reasonable exercise the function under
SQLite.