### PR TITLE
Allow explicit schema injection to `rivertest.Require*` test functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preliminary River driver for SQLite (`riverdriver/riversqlite`). This driver seems to produce good results as judged by the test suite, but so far has minimal real world vetting. Try it and let us know how it works out. [PR #870](https://github.com/riverqueue/river/pull/870).
 - CLI `river migrate-get` now takes a `--schema` option to inject a custom schema into dumped migrations and schema comments are hidden if `--schema` option isn't provided. [PR #903](https://github.com/riverqueue/river/pull/903).
 - Added `riverlog.NewMiddlewareCustomContext` that makes the use of `riverlog` job-persisted logging possible with non-slog loggers. [PR #919](https://github.com/riverqueue/river/pull/919).
+- Added `RequireInsertedOpts.Schema`, allowing an explicit schema to be set when asserting on job inserts with `rivertest`. [PR #926](https://github.com/riverqueue/river/pull/926).
 
 ### Changed
 


### PR DESCRIPTION
Here, resolve #907 by letting an explicit schema be injected into
`rivertest.Require*` assertions in a similar way that one can be used in
a client.

This approach adds a schema in `RequireInsertedOpts`. This comment does
a good job of highlight all the potential approaches for adding a schema
[1], and unfortunately none of them are all that great. I implemented
one other version of this (a variant of option 2 in that list), which as
some advantages, but in the end it just ended up ballooning the API out
to an uncomfortable degree.

The worst part about adding schema to `RequireInsertedOpts` is its
interact with the `RequireMany*` functions, where each expectation can
set its own schema, and it's not clear what would happen if different
expectations set different schemas. I resolved this ambiguity by making
it an error to mix and match schemas. Assertions are allowed to send a
schema in only the first position like:

    jobs := requireManyInserted(ctx, bundle.mockT, bundle.driver, []ExpectedJob{
        {Args: &Job1Args{String: "foo"}, Opts: bundle.schemaOpts},
        {Args: &Job1Args{String: "bar"}},
    })

Or send the same schema in all positions:

    jobs := requireManyInserted(ctx, bundle.mockT, bundle.driver, []ExpectedJob{
        {Args: &Job1Args{String: "foo"}, Opts: bundle.schemaOpts},
        {Args: &Job1Args{String: "bar"}, Opts: bundle.schemaOpts},
    })

But they aren't allowed to set a schema only in position other than the
first, or mix and match schemas between expectations.

Fixes #907.

[1] https://github.com/riverqueue/river/issues/907#issuecomment-2896783495