### PR TITLE
Out of transaction notification on job insert and queue changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI `river migrate-get` now takes a `--schema` option to inject a custom schema into dumped migrations and schema comments are hidden if `--schema` option isn't provided. [PR #903](https://github.com/riverqueue/river/pull/903).
 - Added `riverlog.NewMiddlewareCustomContext` that makes the use of `riverlog` job-persisted logging possible with non-slog loggers. [PR #919](https://github.com/riverqueue/river/pull/919).
 - Added `RequireInsertedOpts.Schema`, allowing an explicit schema to be set when asserting on job inserts with `rivertest`. [PR #926](https://github.com/riverqueue/river/pull/926).
+- When using a driver that doesn't support listen/notify, producers within same process are notified immediately of new job inserts and queue changes (e.g. pause/resume) without having to poll when non-transactional variants are used (i.e. `Insert` instead of `InsertTx`). [PR #928](https://github.com/riverqueue/river/pull/928).
 - Added `JobListParams.Where`, which provides an escape hatch for job listing that runs arbitrary SQL with named parameters. [PR #933](https://github.com/riverqueue/river/pull/933).
 
 ### Changed

--- a/example_sqlite_test.go
+++ b/example_sqlite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
-	"time"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver"
@@ -36,9 +35,7 @@ func Example_sqlite() {
 	river.AddWorker(workers, &SortWorker{})
 
 	riverClient, err := river.NewClient(driver, &river.Config{
-		FetchCooldown:     20 * time.Millisecond,
-		FetchPollInterval: 50 * time.Millisecond, // this driver is poll only, so speed up poll interval so the test runs fater
-		Logger:            slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
+	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivertype"
@@ -35,11 +36,11 @@ func (ts *JobSchedulerTestSignals) Init(tb testutil.TestingTB) {
 	ts.ScheduledBatch.Init(tb)
 }
 
-type InsertFunc func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) ([]*rivertype.JobInsertResult, error)
+type InsertFunc func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) error
 
 // NotifyInsert is a function to call to emit notifications for queues where
 // jobs were scheduled.
-type NotifyInsertFunc func(ctx context.Context, tx riverdriver.ExecutorTx, queues []string) error
+type NotifyInsertFunc func(ctx context.Context, tx riverdriver.ExecutorTx, queuesDeduped []string) error
 
 type JobSchedulerConfig struct {
 	// Interval is the amount of time between periodic checks for jobs to
@@ -186,7 +187,7 @@ func (s *JobScheduler) runOnce(ctx context.Context) (*schedulerRunOnceResult, er
 			}
 
 			if len(queues) > 0 {
-				if err := s.config.NotifyInsert(ctx, tx, queues); err != nil {
+				if err := s.config.NotifyInsert(ctx, tx, sliceutil.Uniq(queues)); err != nil {
 					return 0, fmt.Errorf("error notifying insert: %w", err)
 				}
 				s.TestSignals.NotifiedQueues.Signal(queues)

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -320,8 +320,8 @@ func TestJobScheduler(t *testing.T) {
 
 		scheduler, _ := setup(t, &testOpts{exec: exec, schema: schema})
 		scheduler.config.Interval = time.Minute // should only trigger once for the initial run
-		scheduler.config.NotifyInsert = func(ctx context.Context, tx riverdriver.ExecutorTx, queues []string) error {
-			notifyCh <- queues
+		scheduler.config.NotifyInsert = func(ctx context.Context, tx riverdriver.ExecutorTx, queuesDeduped []string) error {
+			notifyCh <- queuesDeduped
 			return nil
 		}
 		now := time.Now().UTC()
@@ -362,10 +362,10 @@ func TestJobScheduler(t *testing.T) {
 		require.NoError(t, scheduler.Start(ctx))
 		scheduler.TestSignals.ScheduledBatch.WaitOrTimeout()
 
-		expectedQueues := []string{"queue1", "queue2", "queue2", "queue3", "queue4"}
+		expectedQueues := []string{"queue1", "queue2", "queue3", "queue4"}
 
-		notifiedQueues := riversharedtest.WaitOrTimeout(t, notifyCh)
-		sort.Strings(notifiedQueues)
-		require.Equal(t, expectedQueues, notifiedQueues)
+		notifiedQueuesDeduped := riversharedtest.WaitOrTimeout(t, notifyCh)
+		sort.Strings(notifiedQueuesDeduped)
+		require.Equal(t, expectedQueues, notifiedQueuesDeduped)
 	})
 }

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -342,8 +342,7 @@ func (s *PeriodicJobEnqueuer) insertBatch(ctx context.Context, insertParamsMany 
 	defer tx.Rollback(ctx)
 
 	if len(insertParamsMany) > 0 {
-		_, err := s.Config.Insert(ctx, tx, insertParamsMany)
-		if err != nil {
+		if err := s.Config.Insert(ctx, tx, insertParamsMany); err != nil {
 			s.Logger.ErrorContext(ctx, s.Name+": Error inserting periodic jobs",
 				"error", err.Error(), "num_jobs", len(insertParamsMany))
 			return

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -79,22 +79,15 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 	// A simplified version of `Client.insertMany` that only inserts jobs directly
 	// via the driver instead of using the pilot.
-	makeInsertFunc := func(schema string) func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) ([]*rivertype.JobInsertResult, error) {
-		return func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) ([]*rivertype.JobInsertResult, error) {
-			results, err := tx.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+	makeInsertFunc := func(schema string) func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) error {
+		return func(ctx context.Context, tx riverdriver.ExecutorTx, insertParams []*rivertype.JobInsertParams) error {
+			_, err := tx.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
 				Jobs: sliceutil.Map(insertParams, func(params *rivertype.JobInsertParams) *riverdriver.JobInsertFastParams {
 					return (*riverdriver.JobInsertFastParams)(params)
 				}),
 				Schema: schema,
 			})
-			if err != nil {
-				return nil, err
-			}
-			return sliceutil.Map(results,
-				func(result *riverdriver.JobInsertFastResult) *rivertype.JobInsertResult {
-					return (*rivertype.JobInsertResult)(result)
-				},
-			), nil
+			return err
 		}
 	}
 

--- a/rivershared/riverpilot/pilot.go
+++ b/rivershared/riverpilot/pilot.go
@@ -25,11 +25,11 @@ type Pilot interface {
 
 	JobInsertMany(
 		ctx context.Context,
-		tx riverdriver.ExecutorTx,
+		execTx riverdriver.ExecutorTx,
 		params *riverdriver.JobInsertFastManyParams,
 	) ([]*riverdriver.JobInsertFastResult, error)
 
-	JobSetStateIfRunningMany(ctx context.Context, tx riverdriver.ExecutorTx, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error)
+	JobSetStateIfRunningMany(ctx context.Context, execTx riverdriver.ExecutorTx, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error)
 
 	PilotInit(archetype *baseservice.Archetype)
 

--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -22,14 +22,14 @@ func (p *StandardPilot) JobGetAvailable(ctx context.Context, exec riverdriver.Ex
 
 func (p *StandardPilot) JobInsertMany(
 	ctx context.Context,
-	tx riverdriver.ExecutorTx,
+	execTx riverdriver.ExecutorTx,
 	params *riverdriver.JobInsertFastManyParams,
 ) ([]*riverdriver.JobInsertFastResult, error) {
-	return tx.JobInsertFastMany(ctx, params)
+	return execTx.JobInsertFastMany(ctx, params)
 }
 
-func (p *StandardPilot) JobSetStateIfRunningMany(ctx context.Context, tx riverdriver.ExecutorTx, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error) {
-	return tx.JobSetStateIfRunningMany(ctx, params)
+func (p *StandardPilot) JobSetStateIfRunningMany(ctx context.Context, execTx riverdriver.ExecutorTx, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error) {
+	return execTx.JobSetStateIfRunningMany(ctx, params)
 }
 
 func (p *StandardPilot) PilotInit(archetype *baseservice.Archetype) {

--- a/rivershared/testsignal/test_signal_test.go
+++ b/rivershared/testsignal/test_signal_test.go
@@ -49,6 +49,27 @@ func TestTestSignal(t *testing.T) {
 		}
 	})
 
+	t.Run("RequireEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		signal := TestSignal[struct{}]{}
+
+		require.PanicsWithValue(t, "test only signal is not initialized; called outside of tests?", func() {
+			signal.RequireEmpty()
+		})
+
+		mockT := testutil.NewMockT(t)
+		signal.Init(mockT)
+
+		signal.RequireEmpty() // succeeds
+
+		signal.Signal(struct{}{})
+
+		signal.RequireEmpty()
+		require.True(t, mockT.Failed)
+		require.Equal(t, "test signal should be empty, but wasn't\ngot value: {}\n\n", mockT.LogOutput())
+	})
+
 	t.Run("WaitC", func(t *testing.T) {
 		t.Parallel()
 
@@ -74,6 +95,11 @@ func TestTestSignal(t *testing.T) {
 		t.Parallel()
 
 		signal := TestSignal[struct{}]{}
+
+		require.PanicsWithValue(t, "test only signal is not initialized; called outside of tests?", func() {
+			signal.WaitOrTimeout()
+		})
+
 		signal.Init(t)
 
 		signal.Signal(struct{}{})

--- a/rivershared/util/sliceutil/slice_util.go
+++ b/rivershared/util/sliceutil/slice_util.go
@@ -54,3 +54,21 @@ func Map[T any, R any](collection []T, mapFunc func(T) R) []R {
 
 	return result
 }
+
+// Uniq returns a duplicate-free version of an array, in which only the first occurrence of each element is kept.
+// The order of result values is determined by the order they occur in the array.
+func Uniq[T comparable](collection []T) []T {
+	result := make([]T, 0, len(collection))
+	seen := make(map[T]struct{}, len(collection))
+
+	for _, item := range collection {
+		if _, ok := seen[item]; ok {
+			continue
+		}
+
+		seen[item] = struct{}{}
+		result = append(result, item)
+	}
+
+	return result
+}

--- a/rivershared/util/sliceutil/slice_util_test.go
+++ b/rivershared/util/sliceutil/slice_util_test.go
@@ -89,3 +89,12 @@ func TestMap(t *testing.T) {
 	require.Equal(t, []string{"Hello", "Hello", "Hello", "Hello"}, result1)
 	require.Equal(t, []string{"1", "2", "3", "4"}, result2)
 }
+
+func TestUniq(t *testing.T) {
+	t.Parallel()
+
+	result1 := Uniq([]int{1, 2, 2, 1})
+
+	require.Len(t, result1, 2)
+	require.Equal(t, []int{1, 2}, result1)
+}


### PR DESCRIPTION
Here, we try to implement a system that'll make drivers that don't
support listen/notify like SQLite more responsive by default (i.e.
without having to crank their fetch intervals down to miniscule numbers
and have them fetch with hyper-frequency) so they respond to a new job
or queue being paused quickly.

Currently, drivers with listeners send out notifications which are then
received by the producer so that it can enact work. Drivers without
listeners are left out in the cold though because they don't have any
good listen/notify alternative.

This proposal takes non-tx functions like `Client.Insert` or
`Client.QueuePause` and makes a special call to the producer to notify
it of what happened so it can respond quickly without waiting for a
poll.

The approach of course has a couple limitations:

* It only works for non-tx functions. If we were to notify the producer
  within a transaction, the producer would wake up and find nothing to
  do because the relevant data hasn't been persisted yet. This is taken
  care of on the listener drivers because listen/notify is transaction
  friendly.

* Only works within the same process. A client obviously can't notify a
  producer in a different Go process, so those will still have to poll.
  Still, if even one producer can get a notification about an inserted
  job immediately, that job still gets worked faster.

    This improvement is also aimed pretty specifically aimed at our test
    suite, where there's only ever one process running. Being able to
    notify a producer within the same process means that we don't need
    to put an aggressive poll loop into ever example or client test that
    uses SQLite.

Longer term, I'd like to replace this with something else, like a
general purpose unlogged table that could process notifications in a
transaction in a similar way to how listen/notify does it (although I'd
have to do a little more work on this, I'm not sure it'd work), but I
figure that this might be good enough for the time being. This doesn't
change the public API at all, so it should be fairly easy to replace all
changes made here with something more suitable if it comes up.