### PR TITLE
Don't log context canceled error on shutdown during benchmark

### DIFF
--- a/cmd/river/riverbench/river_bench.go
+++ b/cmd/river/riverbench/river_bench.go
@@ -202,6 +202,10 @@ func (b *Benchmarker[TTx]) Run(ctx context.Context, duration time.Duration, numT
 					State:  rivertype.JobStateAvailable,
 				})
 				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						return // shut down
+					}
+
 					b.logger.ErrorContext(ctx, "Error counting jobs", "err", err)
 					continue
 				}


### PR DESCRIPTION
I just noticed while running `river bench` with a lot of jobs that when
leaving after finishing up, we'll get errors like these ones:

    May 26 12:25:33.612 ERR Error counting jobs err="context canceled"
    May 26 12:25:33.612 ERR Error counting jobs err="context canceled"

Job counting takes longer due to job volume, so when shutting down, the
count goroutine is more likely to be waiting on a count than sleeping in
the 1 second tick interval, thereby producing the error.

Here, ignore `context.Canceled` so that it's no logged and return as
finished instead.