### PR TITLE
Add `WHERE` escape hatch for job listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI `river migrate-get` now takes a `--schema` option to inject a custom schema into dumped migrations and schema comments are hidden if `--schema` option isn't provided. [PR #903](https://github.com/riverqueue/river/pull/903).
 - Added `riverlog.NewMiddlewareCustomContext` that makes the use of `riverlog` job-persisted logging possible with non-slog loggers. [PR #919](https://github.com/riverqueue/river/pull/919).
 - Added `RequireInsertedOpts.Schema`, allowing an explicit schema to be set when asserting on job inserts with `rivertest`. [PR #926](https://github.com/riverqueue/river/pull/926).
+- Added `JobListParams.Where`, which provides an escape hatch for job listing that runs arbitrary SQL with named parameters. [PR #933](https://github.com/riverqueue/river/pull/933).
 
 ### Changed
 

--- a/client.go
+++ b/client.go
@@ -2017,7 +2017,7 @@ func (c *Client[TTx]) JobList(ctx context.Context, params *JobListParams) (*JobL
 	}
 	params.schema = c.config.Schema
 
-	if c.driver.DatabaseName() == databaseNameSQLite && params.metadataFragment != "" {
+	if c.driver.DatabaseName() == databaseNameSQLite && params.metadataCalled {
 		return nil, errJobListParamsMetadataNotSupportedSQLite
 	}
 
@@ -2052,7 +2052,7 @@ func (c *Client[TTx]) JobListTx(ctx context.Context, tx TTx, params *JobListPara
 	}
 	params.schema = c.config.Schema
 
-	if c.driver.DatabaseName() == databaseNameSQLite && params.metadataFragment != "" {
+	if c.driver.DatabaseName() == databaseNameSQLite && params.metadataCalled {
 		return nil, errJobListParamsMetadataNotSupportedSQLite
 	}
 


### PR DESCRIPTION
Alright, so this one's generally in pursuit of resolving this issue [1].
I added SQLite support a few weeks back, but a caveat of that is that
the `Metadata` filter on job listing is not usable because it depended
on an operator that was highly specific to Postgres. Someone turned out
to be using it, and I had nothing to suggest beyond not using SQLite
because there's no workaround.

Here, I propose we bring in an escape hatch for job listing that lets a
user add an arbitrary predicate in cases where no other APIs will get
the job done. For example, querying Postgres with a JSON path comparison:

    listParams = listParams.Where("jsonb_path_query_first(metadata, @json_path) = @json_val", NamedArgs{"json_path": "$.foo", "json_val": `"bar"`})

Or performing the same action on SQLite instead:

    listParams = listParams.Where("metadata ->> @json_path = @json_val", NamedArgs{"json_path": "$.foo", "json_val": "bar"})

All of Postgres, SQLite, and MySQL support JSON path in some form, so my
first instinct was to add a new job list filter like `MetadataPathEq`,
but after writing it up I found that what I'd added was so specific to
allow exactly one possible use case. JSON Path is very expressive, and
we'd undoubtedly get requests to reveal more of it, and so I think the
best approach is to give people a way to use any JSON Path expression
and comparison they want.

The trouble with the new `Where` is that it's not database agnostic, but
I think the use of raw SQL written by the user helps make it clear that
perfect compatibility is obviously not guaranteed. It's also less safe
(users could refuse to use named args and open themselves up to SQL
injection more easily), so to handle that we recommend they prefer other
filters first and only drop down to `Where` when absolutely necessary.

[1] https://github.com/riverqueue/river/issues/923#issuecomment-2904994102