### PR TITLE
Add pilot hooks for periodic jobs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6892,7 +6892,7 @@ func Test_NewClient_Validations(t *testing.T) {
 			configFunc: func(config *Config) {
 				AddWorker(config.Workers, &invalidKindWorker{})
 			},
-			wantErr: fmt.Errorf("job kind %q should match regex %q", "this kind is invalid", jobKindRE.String()),
+			wantErr: fmt.Errorf("job kind %q should match regex %s", "this kind is invalid", rivercommon.UserSpecifiedIDOrKindRE.String()),
 		},
 		{
 			name: "Job kind validation skipped with SkipJobKindValidation",
@@ -7605,24 +7605,4 @@ func TestDefaultClientIDWithHost(t *testing.T) {
 	require.Equal(t, strings.Repeat("a", 59)+"_2024_03_07T04_39_12_123456", defaultClientIDWithHost(startedAt, strings.Repeat("a", 59)))
 	require.Equal(t, strings.Repeat("a", 60)+"_2024_03_07T04_39_12_123456", defaultClientIDWithHost(startedAt, strings.Repeat("a", 60)))
 	require.Equal(t, strings.Repeat("a", 60)+"_2024_03_07T04_39_12_123456", defaultClientIDWithHost(startedAt, strings.Repeat("a", 61)))
-}
-
-func TestJobKindRE(t *testing.T) {
-	t.Parallel()
-
-	require.Regexp(t, jobKindRE, "kind")
-	require.Regexp(t, jobKindRE, "kind123")
-	require.Regexp(t, jobKindRE, "with.dot")
-	require.Regexp(t, jobKindRE, "with:colon")
-	require.Regexp(t, jobKindRE, "with+plus")
-	require.Regexp(t, jobKindRE, "with-hyphen")
-	require.Regexp(t, jobKindRE, "with_underscore")
-	require.Regexp(t, jobKindRE, "with[brackets]")
-	require.Regexp(t, jobKindRE, "with<triangle_brackets>")
-	require.Regexp(t, jobKindRE, "with/slash")
-	require.Regexp(t, jobKindRE, "JobArgsReflectKind[github.com/riverqueue/river.JobArgs·12]")
-
-	require.NotRegexp(t, jobKindRE, "with space")
-	require.NotRegexp(t, jobKindRE, "with,comma")
-	require.NotRegexp(t, jobKindRE, ":no_leading_special_characters")
 }

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -3,6 +3,7 @@ package maintenance
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivershared/riverpilot"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/startstoptest"
@@ -21,6 +23,55 @@ import (
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
+
+func TestPeriodicJob(t *testing.T) {
+	t.Parallel()
+
+	validPeriodicJob := func() *PeriodicJob {
+		return &PeriodicJob{
+			ConstructorFunc: func() (*rivertype.JobInsertParams, error) { return nil, nil },
+			ScheduleFunc:    func(t time.Time) time.Time { return time.Time{} },
+		}
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, validPeriodicJob().validate())
+	})
+
+	t.Run("IDTooLong", func(t *testing.T) {
+		t.Parallel()
+
+		periodicJob := validPeriodicJob()
+		periodicJob.ID = strings.Repeat("a", 128)
+		require.EqualError(t, periodicJob.validate(), "PeriodicJob.ID must be less than 128 characters")
+	})
+
+	t.Run("IDIllegalCharacters", func(t *testing.T) {
+		t.Parallel()
+
+		periodicJob := validPeriodicJob()
+		periodicJob.ID = "shouldn't have spaces and stuff"
+		require.EqualError(t, periodicJob.validate(), `PeriodicJob.ID "shouldn't have spaces and stuff" should match regex `+rivercommon.UserSpecifiedIDOrKindRE.String())
+	})
+
+	t.Run("ConstructorFuncMissing", func(t *testing.T) {
+		t.Parallel()
+
+		periodicJob := validPeriodicJob()
+		periodicJob.ConstructorFunc = nil
+		require.EqualError(t, periodicJob.validate(), "PeriodicJob.ConstructorFunc must be set")
+	})
+
+	t.Run("ScheduleFuncMissing", func(t *testing.T) {
+		t.Parallel()
+
+		periodicJob := validPeriodicJob()
+		periodicJob.ScheduleFunc = nil
+		require.EqualError(t, periodicJob.validate(), "PeriodicJob.ScheduleFunc must be set")
+	})
+}
 
 type noOpArgs struct{}
 
@@ -34,6 +85,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 	type testBundle struct {
 		exec                 riverdriver.Executor
 		notificationsByQueue map[string]int
+		pilotMock            *PilotPeriodicJobMock
 		schema               string
 		waitChan             chan (struct{})
 	}
@@ -103,11 +155,17 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		bundle := &testBundle{
 			exec:                 riverpgxv5.New(dbPool).GetExecutor(),
 			notificationsByQueue: make(map[string]int),
+			pilotMock:            NewPilotPeriodicJobMock(),
 			schema:               schema,
 			waitChan:             make(chan struct{}),
 		}
 
-		svc := NewPeriodicJobEnqueuer(riversharedtest.BaseServiceArchetype(t), &PeriodicJobEnqueuerConfig{Insert: makeInsertFunc(schema)}, bundle.exec)
+		svc, err := NewPeriodicJobEnqueuer(riversharedtest.BaseServiceArchetype(t), &PeriodicJobEnqueuerConfig{
+			Insert: makeInsertFunc(schema),
+			Pilot:  bundle.pilotMock,
+			Schema: schema,
+		}, bundle.exec)
+		require.NoError(t, err)
 		svc.StaggerStartupDisable(true)
 		svc.TestSignals.Init(t)
 
@@ -160,10 +218,11 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc, bundle := setup(t)
 
-		svc.AddMany([]*PeriodicJob{
+		_, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
 			{ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false)},
 		})
+		require.NoError(t, err)
 
 		startService(t, svc)
 
@@ -197,12 +256,13 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 			}
 		}
 
-		svc.AddMany([]*PeriodicJob{
+		_, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorWithMetadata("p_md_nil", nil)},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorWithMetadata("p_md_empty_string", []byte(""))},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorWithMetadata("p_md_empty_obj", []byte("{}"))},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorWithMetadata("p_md_existing", []byte(`{"key": "value"}`))},
 		})
+		require.NoError(t, err)
 
 		startService(t, svc)
 
@@ -224,9 +284,10 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc, bundle := setup(t)
 
-		svc.AddMany([]*PeriodicJob{
+		_, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false), RunOnStart: true},
 		})
+		require.NoError(t, err)
 
 		startService(t, svc)
 
@@ -251,9 +312,10 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc, bundle := setup(t)
 
-		svc.AddMany([]*PeriodicJob{
+		_, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("unique_periodic_job_500ms", true)},
 		})
+		require.NoError(t, err)
 
 		startService(t, svc)
 
@@ -277,10 +339,11 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc, bundle := setup(t)
 
-		svc.AddMany([]*PeriodicJob{
+		_, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorFunc("periodic_job_5s", false), RunOnStart: true},
 			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorFunc("unique_periodic_job_5s", true), RunOnStart: true},
 		})
+		require.NoError(t, err)
 
 		start := time.Now()
 		startService(t, svc)
@@ -298,12 +361,13 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc, _ := setup(t)
 
-		svc.AddMany([]*PeriodicJob{
+		_, err := svc.AddManySafely([]*PeriodicJob{
 			// skip this insert when it returns nil:
 			{ScheduleFunc: periodicIntervalSchedule(time.Second), ConstructorFunc: func() (*rivertype.JobInsertParams, error) {
 				return nil, ErrNoJobToInsert
 			}, RunOnStart: true},
 		})
+		require.NoError(t, err)
 
 		startService(t, svc)
 
@@ -318,7 +382,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		now := svc.Time.StubNowUTC(time.Now())
 
 		svc.periodicJobs = make(map[rivertype.PeriodicJobHandle]*PeriodicJob)
-		periodicJobHandles := svc.AddMany([]*PeriodicJob{
+		periodicJobHandles, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
 			{ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false)},
 			{ScheduleFunc: periodicIntervalSchedule(5 * time.Second), ConstructorFunc: jobConstructorFunc("periodic_job_5s", false)},
@@ -326,6 +390,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 			{ScheduleFunc: periodicIntervalSchedule(3 * time.Hour), ConstructorFunc: jobConstructorFunc("periodic_job_3h", false)},
 			{ScheduleFunc: periodicIntervalSchedule(7 * 24 * time.Hour), ConstructorFunc: jobConstructorFunc("periodic_job_7d", false)},
 		})
+		require.NoError(t, err)
 
 		startService(t, svc)
 
@@ -379,13 +444,16 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc, _ := setup(t)
 
-		svc.Add(&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(time.Microsecond), ConstructorFunc: jobConstructorFunc("periodic_job_1us", false)})
+		_, err := svc.AddSafely(&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(time.Microsecond), ConstructorFunc: jobConstructorFunc("periodic_job_1us", false)})
+		require.NoError(t, err)
+
 		// make a longer list of jobs so the loop has to run for longer
 		for i := 1; i < 100; i++ {
-			svc.Add(&PeriodicJob{
+			_, err := svc.AddSafely(&PeriodicJob{
 				ScheduleFunc:    periodicIntervalSchedule(time.Duration(i) * time.Hour),
 				ConstructorFunc: jobConstructorFunc(fmt.Sprintf("periodic_job_%dh", i), false),
 			})
+			require.NoError(t, err)
 		}
 
 		startService(t, svc)
@@ -402,7 +470,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		_, bundle := setup(t)
 
-		svc := NewPeriodicJobEnqueuer(
+		svc, err := NewPeriodicJobEnqueuer(
 			riversharedtest.BaseServiceArchetype(t),
 			&PeriodicJobEnqueuerConfig{
 				Insert: makeInsertFunc(bundle.schema),
@@ -411,6 +479,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 					{ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false), RunOnStart: true},
 				},
 			}, bundle.exec)
+		require.NoError(t, err)
 		svc.StaggerStartupDisable(true)
 		svc.TestSignals.Init(t)
 
@@ -428,12 +497,14 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		startService(t, svc)
 
-		svc.Add(
+		_, err := svc.AddSafely(
 			&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
 		)
-		svc.Add(
+		require.NoError(t, err)
+		_, err = svc.AddSafely(
 			&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
 		)
+		require.NoError(t, err)
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 		requireNJobs(t, bundle, "periodic_job_500ms", 0)
@@ -447,10 +518,11 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		startService(t, svc)
 
-		svc.AddMany([]*PeriodicJob{
+		_, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
 		})
+		require.NoError(t, err)
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 		requireNJobs(t, bundle, "periodic_job_500ms", 0)
@@ -464,10 +536,11 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		startService(t, svc)
 
-		handles := svc.AddMany([]*PeriodicJob{
+		handles, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
 		})
+		require.NoError(t, err)
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 		requireNJobs(t, bundle, "periodic_job_500ms", 0)
@@ -477,9 +550,10 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		require.Empty(t, svc.periodicJobs)
 
-		handleAfterClear := svc.Add(
+		handleAfterClear, err := svc.AddSafely(
 			&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_new", false)},
 		)
+		require.NoError(t, err)
 
 		// Handles are not reused.
 		require.NotEqual(t, handles[0], handleAfterClear)
@@ -493,10 +567,11 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		startService(t, svc)
 
-		handles := svc.AddMany([]*PeriodicJob{
+		handles, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
 		})
+		require.NoError(t, err)
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 		requireNJobs(t, bundle, "periodic_job_500ms", 0)
@@ -514,11 +589,12 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		startService(t, svc)
 
-		handles := svc.AddMany([]*PeriodicJob{
+		handles, err := svc.AddManySafely([]*PeriodicJob{
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_other", false)},
 			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), RunOnStart: true},
 		})
+		require.NoError(t, err)
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
 		requireNJobs(t, bundle, "periodic_job_500ms", 0)
@@ -552,10 +628,12 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 				defer wg.Done()
 
 				for range 50 {
-					handle := svc.Add(&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(time.Millisecond), ConstructorFunc: jobConstructorFunc(jobBaseName, false)})
+					handle, err := svc.AddSafely(&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(time.Millisecond), ConstructorFunc: jobConstructorFunc(jobBaseName, false)})
+					require.NoError(t, err)
 					randomSleep()
 
-					svc.Add(&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(time.Millisecond), ConstructorFunc: jobConstructorFunc(jobBaseName+"_second", false)})
+					_, err = svc.AddSafely(&PeriodicJob{ScheduleFunc: periodicIntervalSchedule(time.Millisecond), ConstructorFunc: jobConstructorFunc(jobBaseName+"_second", false)})
+					require.NoError(t, err)
 					randomSleep()
 
 					svc.Remove(handle)
@@ -653,4 +731,150 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		// pick job with soonest next run amongst some not scheduled yet
 		require.Equal(t, 1*time.Hour, svc.timeUntilNextRun())
 	})
+
+	t.Run("InvokesPilot", func(t *testing.T) {
+		t.Parallel()
+
+		svc, bundle := setup(t)
+
+		now := time.Now()
+
+		bundle.pilotMock.PeriodicJobGetAllMock = func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobGetAllParams) ([]*riverpilot.PeriodicJob, error) {
+			require.Equal(t, bundle.schema, params.Schema)
+			return []*riverpilot.PeriodicJob{
+				{ID: "periodic_job_500ms", NextRunAt: now.Add(1 * time.Hour)},
+				{ID: "periodic_job_1500ms", NextRunAt: now.Add(2 * time.Hour)},
+				{ID: "periodic_job_999ms", NextRunAt: now.Add(3 * time.Hour)},
+			}, nil
+		}
+
+		var periodicJobDeleteByIDManyMockCalled bool
+		bundle.pilotMock.PeriodicJobDeleteByIDManyMock = func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobDeleteByIDManyParams) ([]*riverpilot.PeriodicJob, error) {
+			periodicJobDeleteByIDManyMockCalled = true
+			require.Equal(t, []string{"periodic_job_999ms"}, params.ID)
+			require.Equal(t, bundle.schema, params.Schema)
+			return nil, nil
+		}
+
+		var PeriodicJobUpsertManyMockCalled bool
+		bundle.pilotMock.PeriodicJobUpsertManyMock = func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobUpsertManyParams) ([]*riverpilot.PeriodicJob, error) {
+			PeriodicJobUpsertManyMockCalled = true
+			require.Equal(t, []string{"periodic_job_100ms"}, sliceutil.Map(params.Jobs, func(j *riverpilot.PeriodicJobUpsertParams) string { return j.ID }))
+			require.Equal(t, bundle.schema, params.Schema)
+			return nil, nil
+		}
+
+		handles, err := svc.AddManySafely([]*PeriodicJob{
+			{ID: "periodic_job_100ms", ScheduleFunc: periodicIntervalSchedule(100 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_100ms", false)},
+			{ID: "periodic_job_500ms", ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
+			{ID: "periodic_job_1500ms", ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false)},
+		})
+		require.NoError(t, err)
+
+		startService(t, svc)
+
+		svc.TestSignals.InsertedJobs.WaitOrTimeout()
+		requireNJobs(t, bundle, "periodic_job_100ms", 1)
+		requireNJobs(t, bundle, "periodic_job_500ms", 0)
+		requireNJobs(t, bundle, "periodic_job_1500ms", 0)
+
+		require.True(t, periodicJobDeleteByIDManyMockCalled)
+		require.True(t, PeriodicJobUpsertManyMockCalled)
+
+		svc.Stop()
+
+		require.WithinDuration(t, now.Add(1*time.Hour), svc.periodicJobs[handles[1]].nextRunAt, time.Microsecond)
+		require.WithinDuration(t, now.Add(2*time.Hour), svc.periodicJobs[handles[2]].nextRunAt, time.Microsecond)
+	})
+
+	t.Run("PilotNotInvokedWithoutID", func(t *testing.T) {
+		t.Parallel()
+
+		svc, bundle := setup(t)
+
+		bundle.pilotMock.PeriodicJobGetAllMock = func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobGetAllParams) ([]*riverpilot.PeriodicJob, error) {
+			return nil, nil
+		}
+
+		var periodicJobDeleteByIDManyMockCalled bool
+		bundle.pilotMock.PeriodicJobDeleteByIDManyMock = func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobDeleteByIDManyParams) ([]*riverpilot.PeriodicJob, error) {
+			periodicJobDeleteByIDManyMockCalled = true
+			return nil, nil
+		}
+
+		var PeriodicJobUpsertManyMockCalled bool
+		bundle.pilotMock.PeriodicJobUpsertManyMock = func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobUpsertManyParams) ([]*riverpilot.PeriodicJob, error) {
+			PeriodicJobUpsertManyMockCalled = true
+			return nil, nil
+		}
+
+		_, err := svc.AddManySafely([]*PeriodicJob{
+			{ScheduleFunc: periodicIntervalSchedule(100 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_100ms", false)},
+			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
+			{ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false)},
+		})
+		require.NoError(t, err)
+
+		startService(t, svc)
+
+		svc.TestSignals.InsertedJobs.WaitOrTimeout()
+		requireNJobs(t, bundle, "periodic_job_100ms", 1)
+
+		require.False(t, periodicJobDeleteByIDManyMockCalled)
+		require.False(t, PeriodicJobUpsertManyMockCalled)
+	})
+
+	t.Run("DuplicateIDError", func(t *testing.T) {
+		t.Parallel()
+
+		svc, bundle := setup(t)
+
+		periodicJobs := []*PeriodicJob{
+			{ID: "periodic_job_100ms", ScheduleFunc: periodicIntervalSchedule(100 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_100ms", false)},
+			{ID: "periodic_job_100ms", ScheduleFunc: periodicIntervalSchedule(100 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
+		}
+
+		_, err := NewPeriodicJobEnqueuer(riversharedtest.BaseServiceArchetype(t), &PeriodicJobEnqueuerConfig{
+			Insert:       makeInsertFunc(bundle.schema),
+			PeriodicJobs: periodicJobs,
+			Pilot:        bundle.pilotMock,
+			Schema:       bundle.schema,
+		}, bundle.exec)
+		require.EqualError(t, err, "periodic job with ID already registered: periodic_job_100ms")
+
+		_, err = svc.AddManySafely(periodicJobs)
+		require.EqualError(t, err, "periodic job with ID already registered: periodic_job_100ms")
+	})
+}
+
+type PilotPeriodicJobMock struct {
+	PeriodicJobDeleteByIDManyMock func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobDeleteByIDManyParams) ([]*riverpilot.PeriodicJob, error)
+	PeriodicJobGetAllMock         func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobGetAllParams) ([]*riverpilot.PeriodicJob, error)
+	PeriodicJobUpsertManyMock     func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobUpsertManyParams) ([]*riverpilot.PeriodicJob, error)
+}
+
+func NewPilotPeriodicJobMock() *PilotPeriodicJobMock {
+	return &PilotPeriodicJobMock{
+		PeriodicJobDeleteByIDManyMock: func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobDeleteByIDManyParams) ([]*riverpilot.PeriodicJob, error) {
+			return nil, nil
+		},
+		PeriodicJobGetAllMock: func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobGetAllParams) ([]*riverpilot.PeriodicJob, error) {
+			return nil, nil
+		},
+		PeriodicJobUpsertManyMock: func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobUpsertManyParams) ([]*riverpilot.PeriodicJob, error) {
+			return nil, nil
+		},
+	}
+}
+
+func (p *PilotPeriodicJobMock) PeriodicJobDeleteByIDMany(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobDeleteByIDManyParams) ([]*riverpilot.PeriodicJob, error) {
+	return p.PeriodicJobDeleteByIDManyMock(ctx, exec, params)
+}
+
+func (p *PilotPeriodicJobMock) PeriodicJobGetAll(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobGetAllParams) ([]*riverpilot.PeriodicJob, error) {
+	return p.PeriodicJobGetAllMock(ctx, exec, params)
+}
+
+func (p *PilotPeriodicJobMock) PeriodicJobUpsertMany(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobUpsertManyParams) ([]*riverpilot.PeriodicJob, error) {
+	return p.PeriodicJobUpsertManyMock(ctx, exec, params)
 }

--- a/internal/rivercommon/river_common.go
+++ b/internal/rivercommon/river_common.go
@@ -2,6 +2,7 @@ package rivercommon
 
 import (
 	"errors"
+	"regexp"
 )
 
 // These constants are made available in rivercommon so that they're accessible
@@ -27,3 +28,9 @@ type ContextKeyClient struct{}
 // CancelCauseFuncs when it's stopping. It may be used by components for such
 // cases like avoiding logging an error during a normal shutdown procedure.
 var ErrStop = errors.New("stop initiated")
+
+// UserSpecifiedIDOrKindRE is a regular expression to which the format of job
+// kinds and some other user-specified IDs (e.g. periodic job names) must
+// comply. Mainly, minimal special characters, and excluding spaces and commas
+// which are problematic for the search UI.
+var UserSpecifiedIDOrKindRE = regexp.MustCompile(`\A[\w][\w\-\[\]<>\/.·:+]+\z`)

--- a/internal/rivercommon/river_common_test.go
+++ b/internal/rivercommon/river_common_test.go
@@ -1,0 +1,27 @@
+package rivercommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobKindRE(t *testing.T) {
+	t.Parallel()
+
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "kind")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "kind123")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with.dot")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with:colon")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with+plus")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with-hyphen")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with_underscore")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with[brackets]")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with<triangle_brackets>")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "with/slash")
+	require.Regexp(t, UserSpecifiedIDOrKindRE, "JobArgsReflectKind[github.com/riverqueue/river.JobArgs·12]")
+
+	require.NotRegexp(t, UserSpecifiedIDOrKindRE, "with space")
+	require.NotRegexp(t, UserSpecifiedIDOrKindRE, "with,comma")
+	require.NotRegexp(t, UserSpecifiedIDOrKindRE, ":no_leading_special_characters")
+}

--- a/producer.go
+++ b/producer.go
@@ -448,7 +448,6 @@ func (p *producer) TriggerJobFetch() {
 func (p *producer) TriggerQueueControlEvent(controlEvent *controlEventPayload) {
 	p.queueControlCh <- controlEvent
 	p.testSignals.QueueControlEventTriggered.Signal(controlEvent)
-
 }
 
 type controlAction string

--- a/rivershared/riverpilot/pilot.go
+++ b/rivershared/riverpilot/pilot.go
@@ -52,15 +52,17 @@ type Pilot interface {
 // extracted as its own interface so there's less surface area to mock in places
 // like the periodic job enqueuer where that's needed.
 type PilotPeriodicJob interface {
-	// PeriodicJobDeleteByIDMany deletes many periodic jobs by ID.
-	//
-	// API is not stable. DO NOT USE.
-	PeriodicJobDeleteByIDMany(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobDeleteByIDManyParams) ([]*PeriodicJob, error)
-
 	// PeriodicJobGetAll gets all currently known periodic jobs.
 	//
 	// API is not stable. DO NOT USE.
 	PeriodicJobGetAll(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobGetAllParams) ([]*PeriodicJob, error)
+
+	// PeriodicJobTouchMany updates the `updated_at` timestamp on many jobs at
+	// once to keep them alive and reaps any jobs that haven't been seen in some
+	// time.
+	//
+	// API is not stable. DO NOT USE.
+	PeriodicJobKeepAliveAndReap(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobKeepAliveAndReapParams) ([]*PeriodicJob, error)
 
 	// PeriodicJobUpsertMany upserts many periodic jobs.
 	//
@@ -75,12 +77,12 @@ type PeriodicJob struct {
 	UpdatedAt time.Time
 }
 
-type PeriodicJobDeleteByIDManyParams struct {
-	ID     []string
+type PeriodicJobGetAllParams struct {
 	Schema string
 }
 
-type PeriodicJobGetAllParams struct {
+type PeriodicJobKeepAliveAndReapParams struct {
+	ID     []string
 	Schema string
 }
 

--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -32,7 +32,7 @@ func (p *StandardPilot) JobSetStateIfRunningMany(ctx context.Context, execTx riv
 	return execTx.JobSetStateIfRunningMany(ctx, params)
 }
 
-func (p *StandardPilot) PeriodicJobDeleteByIDMany(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobDeleteByIDManyParams) ([]*PeriodicJob, error) {
+func (p *StandardPilot) PeriodicJobKeepAliveAndReap(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobKeepAliveAndReapParams) ([]*PeriodicJob, error) {
 	return nil, nil
 }
 

--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -32,6 +32,18 @@ func (p *StandardPilot) JobSetStateIfRunningMany(ctx context.Context, execTx riv
 	return execTx.JobSetStateIfRunningMany(ctx, params)
 }
 
+func (p *StandardPilot) PeriodicJobDeleteByIDMany(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobDeleteByIDManyParams) ([]*PeriodicJob, error) {
+	return nil, nil
+}
+
+func (p *StandardPilot) PeriodicJobGetAll(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobGetAllParams) ([]*PeriodicJob, error) {
+	return nil, nil
+}
+
+func (p *StandardPilot) PeriodicJobUpsertMany(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobUpsertManyParams) ([]*PeriodicJob, error) {
+	return nil, nil
+}
+
 func (p *StandardPilot) PilotInit(archetype *baseservice.Archetype) {
 	// No-op
 }


### PR DESCRIPTION
Add pilot hooks for periodic jobs, thereby giving River plugins the
capability to extend certain parts of the periodic job enqueuer.