### PR TITLE
Prepare version v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2025-06-04
+
 ⚠️ Internal APIs used for communication between River and River Pro have changed. If using River Pro, make sure to update River and River Pro to latest at the same time to get compatible versions. River v0.23.0 is compatible with River Pro v0.15.0.
 
 **Terminal UI:** @almottier wrote a very cool [terminal UI for River](https://github.com/almottier/rivertui) featuring real-time job monitoring with automatic refresh, job filtering, a job details view providing detailed information (plus look up by ID in the UI or by command line argument), and job actions like retry and cancellation. And as good as all that might sound, go take a look because it's even better in person.

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,12 +7,12 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/lmittmann/tint v1.1.1
-	github.com/riverqueue/river v0.22.0
-	github.com/riverqueue/river/riverdriver v0.22.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.22.0
-	github.com/riverqueue/river/riverdriver/riversqlite v0.0.0-00010101000000-000000000000
-	github.com/riverqueue/river/rivershared v0.22.0
-	github.com/riverqueue/river/rivertype v0.22.0
+	github.com/riverqueue/river v0.23.0
+	github.com/riverqueue/river/riverdriver v0.23.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.23.0
+	github.com/riverqueue/river/riverdriver/riversqlite v0.23.0
+	github.com/riverqueue/river/rivershared v0.23.0
+	github.com/riverqueue/river/rivertype v0.23.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	modernc.org/sqlite v1.37.1
@@ -46,8 +46,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
-
-// TODO(brandur): Remove this before first release including SQLite driver. It's
-// needed temporarily because there's no riversqlite tag to target (the one
-// referenced above is fake and does not exist).
-replace github.com/riverqueue/river/riverdriver/riversqlite => ../../../river/riverdriver/riversqlite

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river/riverdriver v0.22.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.22.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.22.0
-	github.com/riverqueue/river/riverdriver/riversqlite v0.0.0-00010101000000-000000000000
-	github.com/riverqueue/river/rivershared v0.22.0
-	github.com/riverqueue/river/rivertype v0.22.0
+	github.com/riverqueue/river/riverdriver v0.23.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.23.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.23.0
+	github.com/riverqueue/river/riverdriver/riversqlite v0.23.0
+	github.com/riverqueue/river/rivershared v0.23.0
+	github.com/riverqueue/river/rivertype v0.23.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
@@ -45,8 +45,3 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.10.0 // indirect
 )
-
-// TODO(brandur): Remove this before first release including SQLite driver. It's
-// needed temporarily because there's no riversqlite tag to target (the one
-// referenced above is fake and does not exist).
-replace github.com/riverqueue/river/riverdriver/riversqlite => ../river/riverdriver/riversqlite

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -3110,11 +3110,6 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			Now:      &now,
 		})
 
-		// TODO(brandur): Remove
-		t.Logf("now         = %s", now)
-		t.Logf("elected at  = %s", leader.ElectedAt)
-		t.Logf("expires at  = %s", leader.ExpiresAt)
-
 		leader, err := exec.LeaderGetElectedLeader(ctx, &riverdriver.LeaderGetElectedLeaderParams{})
 		require.NoError(t, err)
 		require.WithinDuration(t, now, leader.ElectedAt, bundle.driver.TimePrecision())

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/riverqueue/river/rivertype v0.22.0
+	github.com/riverqueue/river/rivertype v0.23.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -6,10 +6,10 @@ toolchain go1.24.1
 
 require (
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.22.0
-	github.com/riverqueue/river/riverdriver v0.22.0
-	github.com/riverqueue/river/rivershared v0.22.0
-	github.com/riverqueue/river/rivertype v0.22.0
+	github.com/riverqueue/river v0.23.0
+	github.com/riverqueue/river/riverdriver v0.23.0
+	github.com/riverqueue/river/rivershared v0.23.0
+	github.com/riverqueue/river/rivertype v0.23.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river v0.22.0
-	github.com/riverqueue/river/riverdriver v0.22.0
-	github.com/riverqueue/river/rivershared v0.22.0
-	github.com/riverqueue/river/rivertype v0.22.0
+	github.com/riverqueue/river v0.23.0
+	github.com/riverqueue/river/riverdriver v0.23.0
+	github.com/riverqueue/river/rivershared v0.23.0
+	github.com/riverqueue/river/rivertype v0.23.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/riverdriver/riversqlite/go.mod
+++ b/riverdriver/riversqlite/go.mod
@@ -5,10 +5,10 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
-	github.com/riverqueue/river v0.20.2
-	github.com/riverqueue/river/riverdriver v0.20.2
-	github.com/riverqueue/river/rivershared v0.20.2
-	github.com/riverqueue/river/rivertype v0.20.2
+	github.com/riverqueue/river v0.23.0
+	github.com/riverqueue/river/riverdriver v0.23.0
+	github.com/riverqueue/river/rivershared v0.23.0
+	github.com/riverqueue/river/rivertype v0.23.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -6,9 +6,9 @@ toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.5
-	github.com/riverqueue/river v0.22.0
-	github.com/riverqueue/river/riverdriver v0.22.0
-	github.com/riverqueue/river/rivertype v0.22.0
+	github.com/riverqueue/river v0.23.0
+	github.com/riverqueue/river/riverdriver v0.23.0
+	github.com/riverqueue/river/rivertype v0.23.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.24.0


### PR DESCRIPTION
Prepare version v0.23.0. This one is a little trickier than usual
because of the addition of a new package for SQLite. I ended up having
to manually change some version tags around in our `go.mod`s.

[skip ci]