### PR TITLE
rivercli: restore ability to set custom DriverProcurer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a riverpro CLI integration point broken in v0.23.0. [PR #945](https://github.com/riverqueue/river/pull/945)
+
 ## [0.23.0] - 2025-06-04
 
 ⚠️ Internal APIs used for communication between River and River Pro have changed. If using River Pro, make sure to update River and River Pro to latest at the same time to get compatible versions. River v0.23.0 is compatible with River Pro v0.15.0.

--- a/cmd/river/rivercli/driver_procurer.go
+++ b/cmd/river/rivercli/driver_procurer.go
@@ -23,6 +23,10 @@ type DriverProcurer interface {
 	QueryRow(ctx context.Context, sql string, args ...any) riverdriver.Row
 }
 
+type DriverProcurerPgxV5 interface {
+	InitPgxV5(pool *pgxpool.Pool)
+}
+
 // BenchmarkerInterface is an interface to a Benchmarker. Its reason for
 // existence is to wrap a benchmarker to strip it of its generic parameter,
 // letting us pass it around without having to know the transaction type.

--- a/cmd/river/rivercli/river_cli.go
+++ b/cmd/river/rivercli/river_cli.go
@@ -29,6 +29,10 @@ import (
 )
 
 type Config struct {
+	// DriverProcurer is used to procure a driver for the database. If not
+	// specified, a default one will be initialized based on the database URL
+	// scheme.
+	DriverProcurer DriverProcurer
 	// Name is the human-friendly named of the executable, used while showing
 	// version output. Usually this is just "River", but it could be "River
 	// Pro".
@@ -37,14 +41,16 @@ type Config struct {
 
 // CLI provides a common base of commands for the River CLI.
 type CLI struct {
-	name string
-	out  io.Writer
+	driverProcurer DriverProcurer
+	name           string
+	out            io.Writer
 }
 
 func NewCLI(config *Config) *CLI {
 	return &CLI{
-		name: config.Name,
-		out:  os.Stdout,
+		driverProcurer: config.DriverProcurer,
+		name:           config.Name,
+		out:            os.Stdout,
 	}
 }
 
@@ -72,10 +78,11 @@ func (c *CLI) BaseCommandSet() *cobra.Command {
 	// Make a bundle for RunCommand. Takes a database URL pointer because not every command is required to take a database URL.
 	makeCommandBundle := func(databaseURL *string, schema string) *RunCommandBundle {
 		return &RunCommandBundle{
-			DatabaseURL: databaseURL,
-			Logger:      makeLogger(),
-			OutStd:      c.out,
-			Schema:      schema,
+			DatabaseURL:    databaseURL,
+			DriverProcurer: c.driverProcurer,
+			Logger:         makeLogger(),
+			OutStd:         c.out,
+			Schema:         schema,
 		}
 	}
 

--- a/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
+++ b/internal/riverinternaltest/riverdrivertest/riverdrivertest.go
@@ -3105,7 +3105,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 		now := time.Now().UTC()
 
-		leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
+		_ = testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
 			LeaderID: ptrutil.Ptr(clientID),
 			Now:      &now,
 		})


### PR DESCRIPTION
#870 broke a Pro CLI integration point for making Pro migrations available via a custom `DriverProcurer`. This restores that ability to set a custom procurer.