### PR TITLE
cleanly error on invalid Config.Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Cleanly error on invalid schema names in `Config.Schema`. [PR #952](https://github.com/riverqueue/river/pull/952).
+
 ## [0.23.1] - 2025-06-04
 
 This includes a minor CLI bugfix for riverpro and no other changes, see the v0.23.0 notes for major changes.

--- a/client.go
+++ b/client.go
@@ -51,6 +51,10 @@ const (
 	QueueNumWorkersMax = 10_000
 )
 
+var (
+	postgresSchemaNameRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+)
+
 // TestConfig contains configuration specific to test environments.
 type TestConfig struct {
 	// DisableUniqueEnforcement disables the application of unique job
@@ -470,6 +474,9 @@ func (c *Config) validate() error {
 	maxSchemaLength := 63 - 1 - len(string(notifier.NotificationTopicLongest)) // -1 for the dot in `<schema>.<topic>`
 	if len(c.Schema) > maxSchemaLength {
 		return fmt.Errorf("Schema length must be less than or equal to %d characters", maxSchemaLength) //nolint:staticcheck
+	}
+	if c.Schema != "" && !postgresSchemaNameRE.MatchString(c.Schema) {
+		return fmt.Errorf("Schema name can only contain letters, numbers, and underscores, and must start with a letter or underscore") //nolint:staticcheck
 	}
 
 	for queue, queueConfig := range c.Queues {

--- a/client_test.go
+++ b/client_test.go
@@ -6804,6 +6804,13 @@ func Test_NewClient_Validations(t *testing.T) {
 			wantErr: errors.New("Schema length must be less than or equal to 46 characters"),
 		},
 		{
+			name: "Schema cannot contain invalid characters",
+			configFunc: func(config *Config) {
+				config.Schema = "invalid-schema@name"
+			},
+			wantErr: errors.New("Schema name can only contain letters, numbers, and underscores, and must start with a letter or underscore"),
+		},
+		{
 			name: "Queues can be nil when Workers is also nil",
 			configFunc: func(config *Config) {
 				config.Queues = nil


### PR DESCRIPTION
Had a thought to check if we were doing this for safety's sake, figured we should.