### PR TITLE
Implement `JobDeleteMany` operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The project now tests against [libSQL](https://github.com/tursodatabase/libsql), a popular SQLite fork. It's used through the same `riversqlite` driver that SQLite uses. [PR #957](https://github.com/riverqueue/river/pull/957)
+- Added `JobDeleteMany` operations that remove many jobs in a single operation according to input criteria. [PR #962](https://github.com/riverqueue/river/pull/962)
 
 ### Changed
 

--- a/delete_many_params.go
+++ b/delete_many_params.go
@@ -1,0 +1,115 @@
+package river
+
+import (
+	"github.com/riverqueue/river/internal/dblist"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// JobDeleteManyParams specifies the parameters for a JobDeleteMany query. It
+// must be initialized with NewJobDeleteManyParams. Params can be built by
+// chaining methods on the JobDeleteManyParams object:
+//
+//	params := NewJobDeleteManyParams().First(100).States(river.JobStateCompleted)
+type JobDeleteManyParams struct {
+	ids        []int64
+	kinds      []string
+	limit      int32
+	priorities []int16
+	queues     []string
+	schema     string
+	states     []rivertype.JobState
+}
+
+// NewJobDeleteManyParams creates a new JobDeleteManyParams to delete jobs
+// sorted by ID in ascending order, deleting 100 jobs at most.
+func NewJobDeleteManyParams() *JobDeleteManyParams {
+	return &JobDeleteManyParams{
+		limit: 100,
+	}
+}
+
+func (p *JobDeleteManyParams) copy() *JobDeleteManyParams {
+	return &JobDeleteManyParams{
+		ids:        append([]int64(nil), p.ids...),
+		kinds:      append([]string(nil), p.kinds...),
+		limit:      p.limit,
+		priorities: append([]int16(nil), p.priorities...),
+		queues:     append([]string(nil), p.queues...),
+		schema:     p.schema,
+		states:     append([]rivertype.JobState(nil), p.states...),
+	}
+}
+
+func (p *JobDeleteManyParams) toDBParams() *dblist.JobListParams {
+	return &dblist.JobListParams{
+		IDs:        p.ids,
+		Kinds:      p.kinds,
+		LimitCount: p.limit,
+		OrderBy:    []dblist.JobListOrderBy{{Expr: "id", Order: dblist.SortOrderAsc}},
+		Priorities: p.priorities,
+		Queues:     p.queues,
+		Schema:     p.schema,
+		States:     p.states,
+	}
+}
+
+// First returns an updated filter set that will only delete the first
+// count jobs.
+//
+// Count must be between 1 and 10_000, inclusive, or this will panic.
+func (p *JobDeleteManyParams) First(count int) *JobDeleteManyParams {
+	if count <= 0 {
+		panic("count must be > 0")
+	}
+	if count > 10000 {
+		panic("count must be <= 10000")
+	}
+	paramsCopy := p.copy()
+	paramsCopy.limit = int32(count)
+	return paramsCopy
+}
+
+// IDs returns an updated filter set that will only delete jobs with the given
+// IDs.
+func (p *JobDeleteManyParams) IDs(ids ...int64) *JobDeleteManyParams {
+	paramsCopy := p.copy()
+	paramsCopy.ids = make([]int64, len(ids))
+	copy(paramsCopy.ids, ids)
+	return paramsCopy
+}
+
+// Kinds returns an updated filter set that will only delete jobs of the given
+// kinds.
+func (p *JobDeleteManyParams) Kinds(kinds ...string) *JobDeleteManyParams {
+	paramsCopy := p.copy()
+	paramsCopy.kinds = make([]string, len(kinds))
+	copy(paramsCopy.kinds, kinds)
+	return paramsCopy
+}
+
+// Priorities returns an updated filter set that will only delete jobs with the
+// given priorities.
+func (p *JobDeleteManyParams) Priorities(priorities ...int16) *JobDeleteManyParams {
+	paramsCopy := p.copy()
+	paramsCopy.priorities = make([]int16, len(priorities))
+	copy(paramsCopy.priorities, priorities)
+	return paramsCopy
+}
+
+// Queues returns an updated filter set that will only delete jobs from the
+// given queues.
+func (p *JobDeleteManyParams) Queues(queues ...string) *JobDeleteManyParams {
+	paramsCopy := p.copy()
+	paramsCopy.queues = make([]string, len(queues))
+	copy(paramsCopy.queues, queues)
+	return paramsCopy
+}
+
+// States returns an updated filter set that will only delete jobs in the given
+// states.
+func (p *JobDeleteManyParams) States(states ...rivertype.JobState) *JobDeleteManyParams {
+	paramsCopy := p.copy()
+	paramsCopy.states = make([]rivertype.JobState, len(states))
+	copy(paramsCopy.states, states)
+	return paramsCopy
+}

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -202,6 +202,7 @@ type Executor interface {
 	JobCountByState(ctx context.Context, params *JobCountByStateParams) (int, error)
 	JobDelete(ctx context.Context, params *JobDeleteParams) (*rivertype.JobRow, error)
 	JobDeleteBefore(ctx context.Context, params *JobDeleteBeforeParams) (int, error)
+	JobDeleteMany(ctx context.Context, params *JobDeleteManyParams) ([]*rivertype.JobRow, error)
 	JobGetAvailable(ctx context.Context, params *JobGetAvailableParams) ([]*rivertype.JobRow, error)
 	JobGetByID(ctx context.Context, params *JobGetByIDParams) (*rivertype.JobRow, error)
 	JobGetByIDMany(ctx context.Context, params *JobGetByIDManyParams) ([]*rivertype.JobRow, error)
@@ -353,6 +354,14 @@ type JobDeleteBeforeParams struct {
 	DiscardedFinalizedAtHorizon time.Time
 	Max                         int
 	Schema                      string
+}
+
+type JobDeleteManyParams struct {
+	Max           int32
+	NamedArgs     map[string]any
+	OrderByClause string
+	Schema        string
+	WhereClause   string
 }
 
 type JobGetAvailableParams struct {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -191,6 +191,72 @@ func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg *JobDeleteBe
 	)
 }
 
+const jobDeleteMany = `-- name: JobDeleteMany :many
+WITH jobs_to_delete AS (
+    SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+    FROM /* TEMPLATE: schema */river_job
+    WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
+        AND state != 'running'
+    ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+    LIMIT $1::int
+    FOR UPDATE
+    SKIP LOCKED
+),
+deleted_jobs AS (
+    DELETE FROM /* TEMPLATE: schema */river_job
+    WHERE id IN (SELECT id FROM jobs_to_delete)
+    RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+)
+SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+FROM /* TEMPLATE: schema */river_job
+WHERE id IN (SELECT id FROM deleted_jobs)
+ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+`
+
+// this last SELECT step is necessary because there's no other way to define
+// order records come back from a DELETE statement
+func (q *Queries) JobDeleteMany(ctx context.Context, db DBTX, max int32) ([]*RiverJob, error) {
+	rows, err := db.QueryContext(ctx, jobDeleteMany, max)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			pq.Array(&i.AttemptedBy),
+			&i.CreatedAt,
+			pq.Array(&i.Errors),
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			pq.Array(&i.Tags),
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const jobGetAvailable = `-- name: JobGetAvailable :many
 WITH locked_jobs AS (
     SELECT
@@ -904,7 +970,7 @@ func (q *Queries) JobInsertFullMany(ctx context.Context, db DBTX, arg *JobInsert
 const jobList = `-- name: JobList :many
 SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 FROM /* TEMPLATE: schema */river_job
-WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
 ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
 LIMIT $1::int
 `

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -230,6 +230,19 @@ func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobD
 	return int(res.RowsAffected()), nil
 }
 
+func (e *Executor) JobDeleteMany(ctx context.Context, params *riverdriver.JobDeleteManyParams) ([]*rivertype.JobRow, error) {
+	ctx = sqlctemplate.WithReplacements(ctx, map[string]sqlctemplate.Replacement{
+		"order_by_clause": {Value: params.OrderByClause},
+		"where_clause":    {Value: params.WhereClause},
+	}, params.NamedArgs)
+
+	jobs, err := dbsqlc.New().JobDeleteMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.Max)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return sliceutil.MapError(jobs, jobRowFromInternal)
+}
+
 func (e *Executor) JobGetAvailable(ctx context.Context, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
 	jobs, err := dbsqlc.New().JobGetAvailable(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobGetAvailableParams{
 		AttemptedBy: params.ClientID,

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
@@ -80,6 +80,18 @@ WHERE id IN (
     LIMIT @max
 );
 
+-- name: JobDeleteMany :many
+DELETE FROM /* TEMPLATE: schema */river_job
+WHERE id IN (
+    SELECT id
+    FROM /* TEMPLATE: schema */river_job
+    WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
+        AND state != 'running'
+    ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+    LIMIT @max
+)
+RETURNING *;
+
 -- Differs from the Postgres version in that we don't have `FOR UPDATE SKIP
 -- LOCKED`. It doesn't exist in SQLite, but more aptly, there's only one writer
 -- on SQLite at a time, so nothing else has the rows locked.
@@ -273,7 +285,7 @@ INSERT INTO /* TEMPLATE: schema */river_job(
 -- name: JobList :many
 SELECT *
 FROM /* TEMPLATE: schema */river_job
-WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
 ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
 LIMIT @max;
 

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
@@ -150,6 +150,61 @@ func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg *JobDeleteBe
 	)
 }
 
+const jobDeleteMany = `-- name: JobDeleteMany :many
+DELETE FROM /* TEMPLATE: schema */river_job
+WHERE id IN (
+    SELECT id
+    FROM /* TEMPLATE: schema */river_job
+    WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
+        AND state != 'running'
+    ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
+    LIMIT ?1
+)
+RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+`
+
+func (q *Queries) JobDeleteMany(ctx context.Context, db DBTX, max int64) ([]*RiverJob, error) {
+	rows, err := db.QueryContext(ctx, jobDeleteMany, max)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			&i.AttemptedBy,
+			&i.CreatedAt,
+			&i.Errors,
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			&i.Tags,
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const jobGetAvailable = `-- name: JobGetAvailable :many
 UPDATE /* TEMPLATE: schema */river_job
 SET
@@ -736,7 +791,7 @@ func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFull
 const jobList = `-- name: JobList :many
 SELECT id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 FROM /* TEMPLATE: schema */river_job
-WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
 ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
 LIMIT ?1
 `

--- a/rivershared/sqlctemplate/sqlc_template.go
+++ b/rivershared/sqlctemplate/sqlc_template.go
@@ -25,7 +25,7 @@
 //	-- name: JobList :many
 //	SELECT *
 //	FROM river_job
-//	WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+//	WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
 //	ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
 //	LIMIT @max::int;
 //

--- a/rivershared/sqlctemplate/sqlc_template_test.go
+++ b/rivershared/sqlctemplate/sqlc_template_test.go
@@ -99,7 +99,7 @@ func TestReplacer(t *testing.T) {
 			-- name: JobList :many
 			SELECT *
 			FROM river_job
-			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+			WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
 			ORDER BY /* TEMPLATE_BEGIN: order_by_clause */ id /* TEMPLATE_END */
 			LIMIT @max::int;
 		`, nil)
@@ -233,7 +233,7 @@ func TestReplacer(t *testing.T) {
 		updatedSQL, args, err := replacer.RunSafely(ctx, "$", `
 			SELECT count(*)
 			FROM /* TEMPLATE: schema */river_job
-			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */;
+			WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */;
 		`, nil)
 		require.NoError(t, err)
 		require.Nil(t, args)
@@ -350,7 +350,7 @@ func TestReplacer(t *testing.T) {
 		updatedSQL, args, err := replacer.RunSafely(ctx, "$", `
 			SELECT count(*)
 			FROM river_job
-			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */;
+			WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */;
 		`, nil)
 		require.NoError(t, err)
 		require.Equal(t, []any{"no_op"}, args)
@@ -375,7 +375,7 @@ func TestReplacer(t *testing.T) {
 		updatedSQL, args, err := replacer.RunSafely(ctx, "$", `
 			SELECT count(*)
 			FROM river_job
-			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */
+			WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */
 				AND status = $1;
 		`, []any{"succeeded"})
 		require.NoError(t, err)
@@ -409,7 +409,7 @@ func TestReplacer(t *testing.T) {
 		updatedSQL, args, err := replacer.RunSafely(ctx, "$", `
 			SELECT count(*)
 			FROM /* TEMPLATE: schema */river_job
-			WHERE /* TEMPLATE_BEGIN: where_clause */ 1 /* TEMPLATE_END */;
+			WHERE /* TEMPLATE_BEGIN: where_clause */ true /* TEMPLATE_END */;
 		`, nil)
 		require.NoError(t, err)
 		require.Equal(t, []any{"no_op", "succeeded"}, args)


### PR DESCRIPTION
Here, add functions for `Client.JobDeleteMany` which lets jobs be
deleted in batches. The main impetus for this is to give us a way of
implementing a "purge queue" function, which has been previously
requested by users, and which is generally just a good feature.

We copy the `JobList` API very closely and use almost all the same
implementation, with the caveat that I've removed some of the more
complex features that I don't think will be as necessary for deletion,
with the sorting features being the biggest one, but also arbitrary SQL
in `WHERE` queries. These can always be added in later because they're
purely additive to the API, but I'm hoping that we won't need them.