### PR TITLE
Accept `river migrate-down --target-version 0` to remove all River tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove unecessary transactions where a single database operation will do. This reduces the number of subtransactions created which can be an operational benefit it many cases. [PR #950](https://github.com/riverqueue/river/pull/950)
 - Bring all driver tests into separate package so they don't leak dependencies. This removes dependencies from the top level `river` package that most River installations won't need, thereby reducing the transitive dependency load of most River installations. [PR #955](https://github.com/riverqueue/river/pull/955).
+- The River CLI now accepts a `--target-version` of 0 with `river migrate-down` to run all down migrations and remove all River tables (previously, -1 was used for this; -1 still works, but now 0 also works). [PR #966](https://github.com/riverqueue/river/pull/966).
 
 ### Fixed
 

--- a/cmd/river/rivercli/river_cli_test.go
+++ b/cmd/river/rivercli/river_cli_test.go
@@ -556,3 +556,15 @@ func TestRoundDuration(t *testing.T) {
 	require.Equal(t, "34.04s", roundDuration(mustParseDuration("34.042234s")).String())
 	require.Equal(t, "2m34.04s", roundDuration(mustParseDuration("2m34.042234s")).String())
 }
+
+func TestTargetVersion(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 1, targetVersionTranslateDefault(1))
+	require.Equal(t, 2, targetVersionTranslateDefault(2))
+	require.Equal(t, 3, targetVersionTranslateDefault(3))
+
+	require.Equal(t, 0, targetVersionTranslateDefault(-2))
+	require.Equal(t, -1, targetVersionTranslateDefault(-1))
+	require.Equal(t, -1, targetVersionTranslateDefault(0))
+}


### PR DESCRIPTION
There was a bit of an unfortunate UX quirk in the CLI wherein to remove
all River tables you needed to specify a special value of
`--target-version -1`. This is a relic of how the CLI uses `rivermigrate`
internally, and `rivermigrate`'s options have a `TargetVersion int` that
makes 0 a reserved value for when the option is unset.

It seems like we can do a little better here for the CLI, so here we add
some code that lets 0 or -1 be used as a `--target-version` to apply all
down migrations. We do this by changing the CLI default value to the
sentinel value -2, which we change back to a real default before
forwarding onto `rivermigrate`.