### PR TITLE
Let logger be overridden from `rivertest.Worker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The River CLI now accepts a `--target-version` of 0 with `river migrate-down` to run all down migrations and remove all River tables (previously, -1 was used for this; -1 still works, but now 0 also works). [PR #966](https://github.com/riverqueue/river/pull/966).
 - **Breaking change:** The `HookWorkEnd` interface's `WorkEnd` function now receives a `JobRow` parameter in addition to the `error` it received before. Having a `JobRow` to work with is fairly crucial to most functionality that a hook would implement, and its previous omission was entirely an error. [PR #970](https://github.com/riverqueue/river/pull/970).
 - Add maximum bound to each job's `attempted_by` array so that in degenerate cases where a job is run many, many times (say it's snoozed hundreds of times), it doesn't grow to unlimited bounds. [PR #974](https://github.com/riverqueue/river/pull/974).
+- A logger passed in via `river.Config` now overrides the default test-based logger when using `rivertest.NewWorker`. [PR #980](https://github.com/riverqueue/river/pull/980).
 
 ### Fixed
 

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -139,6 +139,9 @@ func (w *Worker[T, TTx]) workJob(ctx context.Context, tb testing.TB, tx TTx, job
 	exec := w.client.Driver().UnwrapExecutor(tx)
 	subscribeCh := make(chan []jobcompleter.CompleterJobUpdated, 1)
 	archetype := riversharedtest.BaseServiceArchetype(tb)
+	if w.config.Logger != nil {
+		archetype.Logger = w.config.Logger
+	}
 	if withStub, ok := timeGen.(baseservice.TimeGeneratorWithStub); ok {
 		archetype.Time = withStub
 	} else {


### PR DESCRIPTION
Currently, `rivertest.Worker` always used a log based on the input
`testing.T` test case, ignoring a logger that's passed in via
configuration. This isn't normally a problem, but an be in cases like if
a user is trying to discard all logging like described in #979.

Here, let the logger be overridden by passing in one explicitly via the
River configuration struct.

Fixes #979.