### PR TITLE
Allow retention periods to be configured to -1 so they're retained indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking change:** The `HookWorkEnd` interface's `WorkEnd` function now receives a `JobRow` parameter in addition to the `error` it received before. Having a `JobRow` to work with is fairly crucial to most functionality that a hook would implement, and its previous omission was entirely an error. [PR #970](https://github.com/riverqueue/river/pull/970).
 - Add maximum bound to each job's `attempted_by` array so that in degenerate cases where a job is run many, many times (say it's snoozed hundreds of times), it doesn't grow to unlimited bounds. [PR #974](https://github.com/riverqueue/river/pull/974).
 - A logger passed in via `river.Config` now overrides the default test-based logger when using `rivertest.NewWorker`. [PR #980](https://github.com/riverqueue/river/pull/980).
+- Cleaner retention periods (`CancelledJobRetentionPeriod`, `CompletedJobRetentionPeriod`, `DiscardedJobRetentionPeriod`) can be configured to -1 to disable them so that the corresponding type of job is retained indefinitely. [PR #990](https://github.com/riverqueue/river/pull/990).
 
 ### Fixed
 

--- a/client.go
+++ b/client.go
@@ -97,17 +97,23 @@ type Config struct {
 	// CancelledJobRetentionPeriod is the amount of time to keep cancelled jobs
 	// around before they're removed permanently.
 	//
+	// The special value -1 disables deletion of cancelled jobs.
+	//
 	// Defaults to 24 hours.
 	CancelledJobRetentionPeriod time.Duration
 
 	// CompletedJobRetentionPeriod is the amount of time to keep completed jobs
 	// around before they're removed permanently.
 	//
+	// The special value -1 disables deletion of completed jobs.
+	//
 	// Defaults to 24 hours.
 	CompletedJobRetentionPeriod time.Duration
 
 	// DiscardedJobRetentionPeriod is the amount of time to keep discarded jobs
 	// around before they're removed permanently.
+	//
+	// The special value -1 disables deletion of discarded jobs.
 	//
 	// Defaults to 7 days.
 	DiscardedJobRetentionPeriod time.Duration
@@ -426,14 +432,14 @@ func (c *Config) WithDefaults() *Config {
 }
 
 func (c *Config) validate() error {
-	if c.CancelledJobRetentionPeriod < 0 {
-		return errors.New("CancelledJobRetentionPeriod time cannot be less than zero")
+	if c.CancelledJobRetentionPeriod < -1 {
+		return errors.New("CancelledJobRetentionPeriod time cannot be less than zero, except for -1 (infinite)")
 	}
-	if c.CompletedJobRetentionPeriod < 0 {
-		return errors.New("CompletedJobRetentionPeriod cannot be less than zero")
+	if c.CompletedJobRetentionPeriod < -1 {
+		return errors.New("CompletedJobRetentionPeriod cannot be less than zero, except for -1 (infinite)")
 	}
-	if c.DiscardedJobRetentionPeriod < 0 {
-		return errors.New("DiscardedJobRetentionPeriod cannot be less than zero")
+	if c.DiscardedJobRetentionPeriod < -1 {
+		return errors.New("DiscardedJobRetentionPeriod cannot be less than zero, except for -1 (infinite)")
 	}
 	if c.FetchCooldown < FetchCooldownMin {
 		return fmt.Errorf("FetchCooldown must be at least %s", FetchCooldownMin)

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -374,8 +374,11 @@ type JobDeleteParams struct {
 }
 
 type JobDeleteBeforeParams struct {
+	CancelledDoDelete           bool
 	CancelledFinalizedAtHorizon time.Time
+	CompletedDoDelete           bool
 	CompletedFinalizedAtHorizon time.Time
+	DiscardedDoDelete           bool
 	DiscardedFinalizedAtHorizon time.Time
 	Max                         int
 	Schema                      string

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -269,25 +269,31 @@ WHERE id IN (
     SELECT id
     FROM /* TEMPLATE: schema */river_job
     WHERE
-        (state = 'cancelled' AND finalized_at < $1::timestamptz) OR
-        (state = 'completed' AND finalized_at < $2::timestamptz) OR
-        (state = 'discarded' AND finalized_at < $3::timestamptz)
+        (state = 'cancelled' AND $1 AND finalized_at < $2::timestamptz) OR
+        (state = 'completed' AND $3 AND finalized_at < $4::timestamptz) OR
+        (state = 'discarded' AND $5 AND finalized_at < $6::timestamptz)
     ORDER BY id
-    LIMIT $4::bigint
+    LIMIT $7::bigint
 )
 `
 
 type JobDeleteBeforeParams struct {
+	CancelledDoDelete           interface{}
 	CancelledFinalizedAtHorizon time.Time
+	CompletedDoDelete           interface{}
 	CompletedFinalizedAtHorizon time.Time
+	DiscardedDoDelete           interface{}
 	DiscardedFinalizedAtHorizon time.Time
 	Max                         int64
 }
 
 func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg *JobDeleteBeforeParams) (sql.Result, error) {
 	return db.ExecContext(ctx, jobDeleteBefore,
+		arg.CancelledDoDelete,
 		arg.CancelledFinalizedAtHorizon,
+		arg.CompletedDoDelete,
 		arg.CompletedFinalizedAtHorizon,
+		arg.DiscardedDoDelete,
 		arg.DiscardedFinalizedAtHorizon,
 		arg.Max,
 	)

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -258,8 +258,11 @@ func (e *Executor) JobDelete(ctx context.Context, params *riverdriver.JobDeleteP
 
 func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobDeleteBeforeParams) (int, error) {
 	res, err := dbsqlc.New().JobDeleteBefore(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobDeleteBeforeParams{
+		CancelledDoDelete:           params.CancelledDoDelete,
 		CancelledFinalizedAtHorizon: params.CancelledFinalizedAtHorizon,
+		CompletedDoDelete:           params.CompletedDoDelete,
 		CompletedFinalizedAtHorizon: params.CompletedFinalizedAtHorizon,
+		DiscardedDoDelete:           params.DiscardedDoDelete,
 		DiscardedFinalizedAtHorizon: params.DiscardedFinalizedAtHorizon,
 		Max:                         int64(params.Max),
 	})

--- a/riverdriver/riverdrivertest/riverdrivertest.go
+++ b/riverdriver/riverdrivertest/riverdrivertest.go
@@ -946,8 +946,11 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 		// Max two deleted on the first pass.
 		numDeleted, err := exec.JobDeleteBefore(ctx, &riverdriver.JobDeleteBeforeParams{
+			CancelledDoDelete:           true,
 			CancelledFinalizedAtHorizon: horizon,
+			CompletedDoDelete:           true,
 			CompletedFinalizedAtHorizon: horizon,
+			DiscardedDoDelete:           true,
 			DiscardedFinalizedAtHorizon: horizon,
 			Max:                         2,
 		})
@@ -956,8 +959,11 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 		// And one more pass gets the last one.
 		numDeleted, err = exec.JobDeleteBefore(ctx, &riverdriver.JobDeleteBeforeParams{
+			CancelledDoDelete:           true,
 			CancelledFinalizedAtHorizon: horizon,
+			CompletedDoDelete:           true,
 			CompletedFinalizedAtHorizon: horizon,
+			DiscardedDoDelete:           true,
 			DiscardedFinalizedAtHorizon: horizon,
 			Max:                         2,
 		})

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -158,9 +158,9 @@ WHERE id IN (
     SELECT id
     FROM /* TEMPLATE: schema */river_job
     WHERE
-        (state = 'cancelled' AND finalized_at < @cancelled_finalized_at_horizon::timestamptz) OR
-        (state = 'completed' AND finalized_at < @completed_finalized_at_horizon::timestamptz) OR
-        (state = 'discarded' AND finalized_at < @discarded_finalized_at_horizon::timestamptz)
+        (state = 'cancelled' AND @cancelled_do_delete AND finalized_at < @cancelled_finalized_at_horizon::timestamptz) OR
+        (state = 'completed' AND @completed_do_delete AND finalized_at < @completed_finalized_at_horizon::timestamptz) OR
+        (state = 'discarded' AND @discarded_do_delete AND finalized_at < @discarded_finalized_at_horizon::timestamptz)
     ORDER BY id
     LIMIT @max::bigint
 );

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -266,8 +266,11 @@ func (e *Executor) JobDelete(ctx context.Context, params *riverdriver.JobDeleteP
 
 func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobDeleteBeforeParams) (int, error) {
 	res, err := dbsqlc.New().JobDeleteBefore(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobDeleteBeforeParams{
+		CancelledDoDelete:           params.CancelledDoDelete,
 		CancelledFinalizedAtHorizon: params.CancelledFinalizedAtHorizon,
+		CompletedDoDelete:           params.CompletedDoDelete,
 		CompletedFinalizedAtHorizon: params.CompletedFinalizedAtHorizon,
+		DiscardedDoDelete:           params.DiscardedDoDelete,
 		DiscardedFinalizedAtHorizon: params.DiscardedFinalizedAtHorizon,
 		Max:                         int64(params.Max),
 	})


### PR DESCRIPTION
Here, let each of the job cleaner's configured retention periods
(`CancelledJobRetentionPeriod`, `CompletedJobRetentionPeriod`,
`DiscardedJobRetentionPeriod`) accept the special value of -1 so that
the cleaner will maintain that type of job indefinitely, effectively
disabling it.

This probably won't be of much use day-to-day for most users, but does
enable us to augment cleaning functionality with special overrides.