### PR TITLE
Set periodic job IDs to metadata where present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add maximum bound to each job's `attempted_by` array so that in degenerate cases where a job is run many, many times (say it's snoozed hundreds of times), it doesn't grow to unlimited bounds. [PR #974](https://github.com/riverqueue/river/pull/974).
 - A logger passed in via `river.Config` now overrides the default test-based logger when using `rivertest.NewWorker`. [PR #980](https://github.com/riverqueue/river/pull/980).
 - Cleaner retention periods (`CancelledJobRetentionPeriod`, `CompletedJobRetentionPeriod`, `DiscardedJobRetentionPeriod`) can be configured to -1 to disable them so that the corresponding type of job is retained indefinitely. [PR #990](https://github.com/riverqueue/river/pull/990).
+- Jobs inserted from periodic jobs with IDs now have metadata `river:periodic_job_id` set so they can be traced back to the periodic job that inserted them. [PR #992](https://github.com/riverqueue/river/pull/992).
 
 ### Fixed
 

--- a/internal/rivercommon/river_common.go
+++ b/internal/rivercommon/river_common.go
@@ -17,10 +17,18 @@ const (
 	QueueDefault       = "default"
 )
 
-// MetadataKeyUniqueNonce is a special metadata key used by the SQLite driver to
-// determine whether an upsert is was skipped or not because the `(xmax != 0)`
-// trick we use in Postgres doesn't work in SQLite.
-const MetadataKeyUniqueNonce = "river:unique_nonce"
+const (
+	// MetadataKeyPeriodicJobID is a metadata key inserted with a periodic job
+	// when a configured periodic job has its ID property set. This lets
+	// inserted jobs easily be traced back to the periodic job that created
+	// them.
+	MetadataKeyPeriodicJobID = "river:periodic_job_id"
+
+	// MetadataKeyUniqueNonce is a special metadata key used by the SQLite driver to
+	// determine whether an upsert is was skipped or not because the `(xmax != 0)`
+	// trick we use in Postgres doesn't work in SQLite.
+	MetadataKeyUniqueNonce = "river:unique_nonce"
+)
 
 type ContextKeyClient struct{}
 


### PR DESCRIPTION
Set metadata containing the periodic job ID of inserted jobs that were
inserted based on a periodic job with an ID. This lets inserted jobs be
associated with periodic jobs later after the fact if necessary.