### PR TITLE
Inject worker metadata to pilot + testable job args

### DIFF
--- a/rivershared/riverpilot/pilot.go
+++ b/rivershared/riverpilot/pilot.go
@@ -36,7 +36,7 @@ type Pilot interface {
 
 	JobSetStateIfRunningMany(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error)
 
-	PilotInit(archetype *baseservice.Archetype)
+	PilotInit(archetype *baseservice.Archetype, params *PilotInitParams)
 
 	// ProducerInit is called when a producer is started. It should return the ID
 	// of the new producer, a new state object that will be used to track the
@@ -48,6 +48,17 @@ type Pilot interface {
 	ProducerShutdown(ctx context.Context, exec riverdriver.Executor, params *ProducerShutdownParams) error
 
 	QueueMetadataChanged(ctx context.Context, exec riverdriver.Executor, params *QueueMetadataChangedParams) error
+}
+
+// PilotInitParams are parameters for initializing a pilot.
+//
+// API is not stable. DO NOT USE.
+type PilotInitParams struct {
+	// WorkerMetadata is metadata about registered workers as received from the
+	// client's worker bundle. Only available when a client will work jobs (i.e.
+	// has Workers configured), so while it's safe to assume the presence of
+	// this value in places like maintenance services, it's not in all contexts.
+	WorkerMetadata []*rivertype.WorkerMetadata
 }
 
 // PilotPeriodicJob contains pilot functions related to periodic jobs. This is

--- a/rivershared/riverpilot/standard.go
+++ b/rivershared/riverpilot/standard.go
@@ -48,7 +48,7 @@ func (p *StandardPilot) PeriodicJobUpsertMany(ctx context.Context, exec riverdri
 	return nil, nil
 }
 
-func (p *StandardPilot) PilotInit(archetype *baseservice.Archetype) {
+func (p *StandardPilot) PilotInit(archetype *baseservice.Archetype, params *PilotInitParams) {
 	// No-op
 }
 

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -494,3 +494,13 @@ func UniqueOptsByStateDefault() []JobState {
 		JobStateScheduled,
 	}
 }
+
+// WorkerMetadata is metadata about workers registerd with a client.
+type WorkerMetadata struct {
+	// JobArgHooks are job args specific hooks returned from a JobArgsWithHooks
+	// implementation.
+	JobArgHooks []Hook
+
+	// Kind is the kind returned from job args and recognized by worker to work.
+	Kind string
+}

--- a/worker.go
+++ b/worker.go
@@ -105,6 +105,17 @@ func AddWorker[T JobArgs](workers *Workers, worker Worker[T]) {
 	}
 }
 
+// AddWorkerArgs is the same as AddWorker except that it lets args be passed
+// explicitly rather than being instantiated implicitly. We don't know of any
+// use for this function beyond exercising some args-related edge cases in tests
+// are are difficult/impossible to exercise otherwise, and its use should be
+// considered internal only.
+func AddWorkerArgs[T JobArgs](workers *Workers, jobArgs T, worker Worker[T]) {
+	if err := workers.add(jobArgs, &workUnitFactoryWrapper[T]{worker: worker}); err != nil {
+		panic(err)
+	}
+}
+
 // AddWorkerSafely registers a worker on the provided Workers bundle. Unlike AddWorker,
 // AddWorkerSafely does not panic and instead returns an error if the worker
 // is already registered or if its configuration is invalid.

--- a/worker_test.go
+++ b/worker_test.go
@@ -45,6 +45,16 @@ func TestWork(t *testing.T) {
 			return nil
 		}))
 	})
+
+	type OtherJobArgs struct {
+		testutil.JobArgsReflectKind[OtherJobArgs]
+	}
+
+	var jobArgs OtherJobArgs
+	AddWorkerArgs(workers, jobArgs, WorkFunc(func(ctx context.Context, job *Job[OtherJobArgs]) error {
+		return nil
+	}))
+	require.Contains(t, workers.workersMap, (OtherJobArgs{}).Kind())
 }
 
 type configurableArgs struct {


### PR DESCRIPTION
Here, add a mechanism that has the client inject worker metadata into
pilots. This gives pilots information about what jobs/workers are
registered, and helps in cases where say we want pilots to be able to
examine things like `Hooks()` implementations on each worker.

I also ended up adding a function for `river.AddWorkerArgs` that lets a
concrete args object be injected into the registration process rather
than one that's implicitly allocated. I'm a little partial on this one
because it'd be better if it wasn't necessary, but it cleans up tests
somewhat that are trying to test specific things on args like `Hooks()`,
and make tests on features like that _possible_ when there's no
workaround available like storing information that'll be persisted to a
job's metadata (there's otherwise no good way to carry them out, with
the only way I can think of a global variable)