### PR TITLE
Upgrade golangci-lint to v2.3.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,7 +243,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v2.2.1
+      GOLANGCI_LINT_VERSION: v2.3.0
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.

--- a/client.go
+++ b/client.go
@@ -559,16 +559,16 @@ type QueueConfig struct {
 
 func (c QueueConfig) validate(queueName string, clientFetchCooldown time.Duration, clientFetchPollInterval time.Duration) error {
 	if c.FetchCooldown < 0 {
-		return fmt.Errorf("FetchCooldown cannot be less than zero")
+		return errors.New("FetchCooldown cannot be less than zero")
 	}
 	if c.FetchPollInterval < 0 {
-		return fmt.Errorf("FetchPollInterval cannot be less than zero")
+		return errors.New("FetchPollInterval cannot be less than zero")
 	}
 
 	resolvedFetchCooldown := cmp.Or(c.FetchCooldown, clientFetchCooldown)
 	resolvedFetchPollInterval := cmp.Or(c.FetchPollInterval, clientFetchPollInterval)
 	if resolvedFetchPollInterval < resolvedFetchCooldown {
-		return fmt.Errorf("FetchPollInterval cannot be less than FetchCooldown")
+		return errors.New("FetchPollInterval cannot be less than FetchCooldown")
 	}
 
 	if c.MaxWorkers < 1 || c.MaxWorkers > QueueNumWorkersMax {

--- a/client_test.go
+++ b/client_test.go
@@ -863,7 +863,7 @@ func Test_Client_Common(t *testing.T) {
 		require.True(t, hookInsertBeginCalled.Load())
 	})
 
-	t.Run("WithWorkBeginHookOnJobArgs", func(t *testing.T) { //nolint:dupl
+	t.Run("WithWorkBeginHookOnJobArgs", func(t *testing.T) {
 		t.Parallel()
 
 		_, bundle := setup(t)
@@ -899,7 +899,7 @@ func Test_Client_Common(t *testing.T) {
 		require.True(t, hookWorkBeginCalled.Load())
 	})
 
-	t.Run("WithWorkEndHookOnJobArgs", func(t *testing.T) { //nolint:dupl
+	t.Run("WithWorkEndHookOnJobArgs", func(t *testing.T) {
 		t.Parallel()
 
 		_, bundle := setup(t)

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -495,7 +495,7 @@ func UniqueOptsByStateDefault() []JobState {
 	}
 }
 
-// WorkerMetadata is metadata about workers registerd with a client.
+// WorkerMetadata is metadata about workers registered with a client.
 type WorkerMetadata struct {
 	// JobArgHooks are job args specific hooks returned from a JobArgsWithHooks
 	// implementation.

--- a/worker.go
+++ b/worker.go
@@ -108,7 +108,7 @@ func AddWorker[T JobArgs](workers *Workers, worker Worker[T]) {
 // AddWorkerArgs is the same as AddWorker except that it lets args be passed
 // explicitly rather than being instantiated implicitly. We don't know of any
 // use for this function beyond exercising some args-related edge cases in tests
-// are are difficult/impossible to exercise otherwise, and its use should be
+// are difficult/impossible to exercise otherwise, and its use should be
 // considered internal only.
 func AddWorkerArgs[T JobArgs](workers *Workers, jobArgs T, worker Worker[T]) {
 	if err := workers.add(jobArgs, &workUnitFactoryWrapper[T]{worker: worker}); err != nil {


### PR DESCRIPTION
I have version v2.3.0 locally, and I'm just noticing that I'm starting
to see autocorrections sneak into any changes I make. Here, upgrade so
we're consistent across all environments.