### PR TITLE
Add job cleaner excluded queues that can be configured through pilot

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/riverpilot"
+	"github.com/riverqueue/river/rivershared/riversharedmaintenance"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/dbutil"
@@ -403,9 +404,9 @@ func (c *Config) WithDefaults() *Config {
 
 	return &Config{
 		AdvisoryLockPrefix:          c.AdvisoryLockPrefix,
-		CancelledJobRetentionPeriod: cmp.Or(c.CancelledJobRetentionPeriod, maintenance.CancelledJobRetentionPeriodDefault),
-		CompletedJobRetentionPeriod: cmp.Or(c.CompletedJobRetentionPeriod, maintenance.CompletedJobRetentionPeriodDefault),
-		DiscardedJobRetentionPeriod: cmp.Or(c.DiscardedJobRetentionPeriod, maintenance.DiscardedJobRetentionPeriodDefault),
+		CancelledJobRetentionPeriod: cmp.Or(c.CancelledJobRetentionPeriod, riversharedmaintenance.CancelledJobRetentionPeriodDefault),
+		CompletedJobRetentionPeriod: cmp.Or(c.CompletedJobRetentionPeriod, riversharedmaintenance.CompletedJobRetentionPeriodDefault),
+		DiscardedJobRetentionPeriod: cmp.Or(c.DiscardedJobRetentionPeriod, riversharedmaintenance.DiscardedJobRetentionPeriodDefault),
 		ErrorHandler:                c.ErrorHandler,
 		FetchCooldown:               cmp.Or(c.FetchCooldown, FetchCooldownDefault),
 		FetchPollInterval:           cmp.Or(c.FetchPollInterval, FetchPollIntervalDefault),
@@ -864,6 +865,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 				CancelledJobRetentionPeriod: config.CancelledJobRetentionPeriod,
 				CompletedJobRetentionPeriod: config.CompletedJobRetentionPeriod,
 				DiscardedJobRetentionPeriod: config.DiscardedJobRetentionPeriod,
+				QueuesExcluded:              client.pilot.JobCleanerQueuesExcluded(),
 				Schema:                      config.Schema,
 				Timeout:                     config.JobCleanerTimeout,
 			}, driver.GetExecutor())

--- a/client_test.go
+++ b/client_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivershared/riversharedmaintenance"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
@@ -4610,7 +4611,7 @@ func Test_Client_Maintenance(t *testing.T) {
 		client, bundle := setup(t, config)
 
 		// Normal long retention period.
-		deleteHorizon := time.Now().Add(-maintenance.DiscardedJobRetentionPeriodDefault)
+		deleteHorizon := time.Now().Add(-riversharedmaintenance.DiscardedJobRetentionPeriodDefault)
 
 		// Take care to insert jobs before starting the client because otherwise
 		// there's a race condition where the cleaner could run its initial
@@ -6726,10 +6727,10 @@ func Test_NewClient_Defaults(t *testing.T) {
 	require.Zero(t, client.config.AdvisoryLockPrefix)
 
 	jobCleaner := maintenance.GetService[*maintenance.JobCleaner](client.queueMaintainer)
-	require.Equal(t, maintenance.CancelledJobRetentionPeriodDefault, jobCleaner.Config.CancelledJobRetentionPeriod)
-	require.Equal(t, maintenance.CompletedJobRetentionPeriodDefault, jobCleaner.Config.CompletedJobRetentionPeriod)
-	require.Equal(t, maintenance.DiscardedJobRetentionPeriodDefault, jobCleaner.Config.DiscardedJobRetentionPeriod)
-	require.Equal(t, maintenance.JobCleanerTimeoutDefault, jobCleaner.Config.Timeout)
+	require.Equal(t, riversharedmaintenance.CancelledJobRetentionPeriodDefault, jobCleaner.Config.CancelledJobRetentionPeriod)
+	require.Equal(t, riversharedmaintenance.CompletedJobRetentionPeriodDefault, jobCleaner.Config.CompletedJobRetentionPeriod)
+	require.Equal(t, riversharedmaintenance.DiscardedJobRetentionPeriodDefault, jobCleaner.Config.DiscardedJobRetentionPeriod)
+	require.Equal(t, riversharedmaintenance.JobCleanerTimeoutDefault, jobCleaner.Config.Timeout)
 	require.False(t, jobCleaner.StaggerStartupIsDisabled())
 
 	enqueuer := maintenance.GetService[*maintenance.PeriodicJobEnqueuer](client.queueMaintainer)

--- a/internal/maintenance/job_scheduler.go
+++ b/internal/maintenance/job_scheduler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivershared/riversharedmaintenance"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/randutil"
@@ -71,7 +72,7 @@ func (c *JobSchedulerConfig) mustValidate() *JobSchedulerConfig {
 // which are ready to run over to `available` so that they're eligible to be
 // worked.
 type JobScheduler struct {
-	queueMaintainerServiceBase
+	riversharedmaintenance.QueueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	// exported for test purposes
@@ -105,8 +106,8 @@ func (s *JobScheduler) Start(ctx context.Context) error { //nolint:dupl
 		started()
 		defer stopped() // this defer should come first so it's last out
 
-		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
-		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)
+		s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStopped)
 
 		ticker := timeutil.NewTickerWithInitialTick(ctx, s.config.Interval)
 		for {
@@ -125,7 +126,7 @@ func (s *JobScheduler) Start(ctx context.Context) error { //nolint:dupl
 			}
 
 			if res.NumCompletedJobsScheduled > 0 {
-				s.Logger.InfoContext(ctx, s.Name+logPrefixRanSuccessfully,
+				s.Logger.InfoContext(ctx, s.Name+riversharedmaintenance.LogPrefixRanSuccessfully,
 					slog.Int("num_jobs_scheduled", res.NumCompletedJobsScheduled),
 				)
 			}
@@ -203,7 +204,7 @@ func (s *JobScheduler) runOnce(ctx context.Context) (*schedulerRunOnceResult, er
 			break
 		}
 
-		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(BatchBackoffMin, BatchBackoffMax))
+		serviceutil.CancellableSleep(ctx, randutil.DurationBetween(riversharedmaintenance.BatchBackoffMin, riversharedmaintenance.BatchBackoffMax))
 	}
 
 	return res, nil

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/riverpilot"
+	"github.com/riverqueue/river/rivershared/riversharedmaintenance"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/maputil"
@@ -109,7 +110,7 @@ func (c *PeriodicJobEnqueuerConfig) mustValidate() *PeriodicJobEnqueuerConfig {
 // PeriodicJobEnqueuer inserts jobs configured to run periodically as unique
 // jobs to make sure they'll run as frequently as their period dictates.
 type PeriodicJobEnqueuer struct {
-	queueMaintainerServiceBase
+	riversharedmaintenance.QueueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	// exported for test purposes
@@ -275,8 +276,8 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 		started()
 		defer stopped() // this defer should come first so it's last out
 
-		s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStarted)
-		defer s.Logger.DebugContext(ctx, s.Name+logPrefixRunLoopStopped)
+		s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStopped)
 
 		defer startstop.StopAllParallel(subServices...)
 

--- a/internal/maintenance/queue_maintainer.go
+++ b/internal/maintenance/queue_maintainer.go
@@ -3,35 +3,10 @@ package maintenance
 import (
 	"context"
 	"reflect"
-	"time"
 
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/util/maputil"
-	"github.com/riverqueue/river/rivershared/util/randutil"
-	"github.com/riverqueue/river/rivershared/util/serviceutil"
-)
-
-const (
-	// Maintainers will sleep a brief period of time between batches to give the
-	// database some breathing room.
-	BatchBackoffMax = 1 * time.Second
-	BatchBackoffMin = 50 * time.Millisecond
-
-	// Bulk maintenance tasks like job removal operate in batches so that even
-	// in the event of an enormous backlog of work to do, transactions stay
-	// relatively short and aren't at risk of cancellation. This number is the
-	// batch size, or the number of rows that are handled at a time.
-	//
-	// The specific value is somewhat arbitrary as large enough to make good
-	// progress, but not so large as to make the operation overstay its welcome.
-	// For now it's not configurable because we can likely pick a number that's
-	// suitable for almost everyone.
-	BatchSizeDefault = 1_000
-
-	logPrefixRanSuccessfully = ": Ran successfully"
-	logPrefixRunLoopStarted  = ": Run loop started"
-	logPrefixRunLoopStopped  = ": Run loop stopped"
 )
 
 // QueueMaintainer runs regular maintenance operations against job queues, like
@@ -105,37 +80,6 @@ func GetService[T startstop.Service](maintainer *QueueMaintainer) T {
 func serviceName(service startstop.Service) string {
 	elem := reflect.TypeOf(service).Elem()
 	return elem.PkgPath() + "." + elem.Name()
-}
-
-// queueMaintainerServiceBase is a struct that should be embedded on all queue
-// maintainer services. Its main use is to provide a StaggerStart function that
-// should be called on service start to avoid thundering herd problems.
-type queueMaintainerServiceBase struct {
-	baseservice.BaseService
-
-	staggerStartupDisabled bool
-}
-
-// StaggerStart is called when queue maintainer services start. It jitters by
-// sleeping for a short random period so services don't all perform their first
-// run at exactly the same time.
-func (s *queueMaintainerServiceBase) StaggerStart(ctx context.Context) {
-	if s.staggerStartupDisabled {
-		return
-	}
-
-	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(0*time.Second, 1*time.Second))
-}
-
-// StaggerStartupDisable sets whether the short staggered sleep on start up
-// is disabled. This is useful in tests where the extra sleep involved in a
-// staggered start up is not helpful for test run time.
-func (s *queueMaintainerServiceBase) StaggerStartupDisable(disabled bool) {
-	s.staggerStartupDisabled = disabled
-}
-
-func (s *queueMaintainerServiceBase) StaggerStartupIsDisabled() bool {
-	return s.staggerStartupDisabled
 }
 
 // withStaggerStartupDisable is an interface to a service whose stagger startup

--- a/internal/maintenance/queue_maintainer_test.go
+++ b/internal/maintenance/queue_maintainer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivershared/riversharedmaintenance"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/startstoptest"
@@ -21,7 +22,7 @@ import (
 )
 
 type testService struct {
-	queueMaintainerServiceBase
+	riversharedmaintenance.QueueMaintainerServiceBase
 	startstop.BaseStartStop
 
 	testSignals testServiceTestSignals

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -381,6 +381,8 @@ type JobDeleteBeforeParams struct {
 	DiscardedDoDelete           bool
 	DiscardedFinalizedAtHorizon time.Time
 	Max                         int
+	QueuesExcluded              []string
+	QueuesIncluded              []string
 	Schema                      string
 }
 

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -265,6 +265,8 @@ func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobD
 		DiscardedDoDelete:           params.DiscardedDoDelete,
 		DiscardedFinalizedAtHorizon: params.DiscardedFinalizedAtHorizon,
 		Max:                         int64(params.Max),
+		QueuesExcluded:              params.QueuesExcluded,
+		QueuesIncluded:              params.QueuesIncluded,
 	})
 	if err != nil {
 		return 0, interpretError(err)

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -157,10 +157,19 @@ DELETE FROM /* TEMPLATE: schema */river_job
 WHERE id IN (
     SELECT id
     FROM /* TEMPLATE: schema */river_job
-    WHERE
-        (state = 'cancelled' AND @cancelled_do_delete AND finalized_at < @cancelled_finalized_at_horizon::timestamptz) OR
-        (state = 'completed' AND @completed_do_delete AND finalized_at < @completed_finalized_at_horizon::timestamptz) OR
-        (state = 'discarded' AND @discarded_do_delete AND finalized_at < @discarded_finalized_at_horizon::timestamptz)
+    WHERE (
+            (state = 'cancelled' AND @cancelled_do_delete AND finalized_at < @cancelled_finalized_at_horizon::timestamptz) OR
+            (state = 'completed' AND @completed_do_delete AND finalized_at < @completed_finalized_at_horizon::timestamptz) OR
+            (state = 'discarded' AND @discarded_do_delete AND finalized_at < @discarded_finalized_at_horizon::timestamptz)
+        )
+        AND (
+            @queues_excluded::text[] IS NULL
+            OR NOT (queue = any(@queues_excluded))
+        )
+        AND (
+            @queues_included::text[] IS NULL
+            OR queue = any(@queues_included)
+        )
     ORDER BY id
     LIMIT @max::bigint
 );

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -262,12 +262,21 @@ DELETE FROM /* TEMPLATE: schema */river_job
 WHERE id IN (
     SELECT id
     FROM /* TEMPLATE: schema */river_job
-    WHERE
-        (state = 'cancelled' AND $1 AND finalized_at < $2::timestamptz) OR
-        (state = 'completed' AND $3 AND finalized_at < $4::timestamptz) OR
-        (state = 'discarded' AND $5 AND finalized_at < $6::timestamptz)
+    WHERE (
+            (state = 'cancelled' AND $1 AND finalized_at < $2::timestamptz) OR
+            (state = 'completed' AND $3 AND finalized_at < $4::timestamptz) OR
+            (state = 'discarded' AND $5 AND finalized_at < $6::timestamptz)
+        )
+        AND (
+            $7::text[] IS NULL
+            OR NOT (queue = any($7))
+        )
+        AND (
+            $8::text[] IS NULL
+            OR queue = any($8)
+        )
     ORDER BY id
-    LIMIT $7::bigint
+    LIMIT $9::bigint
 )
 `
 
@@ -278,6 +287,8 @@ type JobDeleteBeforeParams struct {
 	CompletedFinalizedAtHorizon time.Time
 	DiscardedDoDelete           interface{}
 	DiscardedFinalizedAtHorizon time.Time
+	QueuesExcluded              []string
+	QueuesIncluded              []string
 	Max                         int64
 }
 
@@ -289,6 +300,8 @@ func (q *Queries) JobDeleteBefore(ctx context.Context, db DBTX, arg *JobDeleteBe
 		arg.CompletedFinalizedAtHorizon,
 		arg.DiscardedDoDelete,
 		arg.DiscardedFinalizedAtHorizon,
+		arg.QueuesExcluded,
+		arg.QueuesIncluded,
 		arg.Max,
 	)
 }

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -273,6 +273,8 @@ func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobD
 		DiscardedDoDelete:           params.DiscardedDoDelete,
 		DiscardedFinalizedAtHorizon: params.DiscardedFinalizedAtHorizon,
 		Max:                         int64(params.Max),
+		QueuesExcluded:              params.QueuesExcluded,
+		QueuesIncluded:              params.QueuesIncluded,
 	})
 	if err != nil {
 		return 0, interpretError(err)

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
@@ -92,16 +92,34 @@ RETURNING *;
 
 -- name: JobDeleteBefore :execresult
 DELETE FROM /* TEMPLATE: schema */river_job
-WHERE id IN (
-    SELECT id
-    FROM /* TEMPLATE: schema */river_job
-    WHERE
-        (state = 'cancelled' AND finalized_at < cast(@cancelled_finalized_at_horizon AS text)) OR
-        (state = 'completed' AND finalized_at < cast(@completed_finalized_at_horizon AS text)) OR
-        (state = 'discarded' AND finalized_at < cast(@discarded_finalized_at_horizon AS text))
-    ORDER BY id
-    LIMIT @max
-);
+WHERE
+    id IN (
+        SELECT id
+        FROM /* TEMPLATE: schema */river_job
+        WHERE
+            (state = 'cancelled' AND finalized_at < cast(@cancelled_finalized_at_horizon AS text)) OR
+            (state = 'completed' AND finalized_at < cast(@completed_finalized_at_horizon AS text)) OR
+            (state = 'discarded' AND finalized_at < cast(@discarded_finalized_at_horizon AS text))
+        ORDER BY id
+        LIMIT @max
+    )
+    -- This is really awful, but unless the `sqlc.slice` appears as the very
+    -- last parameter in the query things will fail if it includes more than one
+    -- element. The sqlc SQLite driver uses position-based placeholders (?1) for
+    -- most parameters, but unnamed ones with `sqlc.slice` (?), and when
+    -- positional parameters follow unnamed parameters great confusion is the
+    -- result. Making sure `sqlc.slice` is last is the only workaround I could
+    -- find, but it stops working if there are multiple clauses that need a
+    -- positional placeholder plus `sqlc.slice` like this one (the Postgres
+    -- driver supports a `queues_included` parameter that I couldn't support
+    -- here). The non-workaround version is (unfortunately) to never, ever use
+    -- the sqlc driver for SQLite -- it's not a little buggy, it's off the
+    -- charts buggy, and there's little interest from the maintainers in fixing
+    -- any of it. We already started using it though, so plough on.
+    AND (
+        cast(@queues_excluded_empty AS boolean)
+        OR river_job.queue NOT IN (sqlc.slice('queues_excluded'))
+    );
 
 -- name: JobDeleteMany :many
 DELETE FROM /* TEMPLATE: schema */river_job

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -343,11 +343,17 @@ func (e *Executor) JobDelete(ctx context.Context, params *riverdriver.JobDeleteP
 }
 
 func (e *Executor) JobDeleteBefore(ctx context.Context, params *riverdriver.JobDeleteBeforeParams) (int, error) {
+	if len(params.QueuesIncluded) > 0 {
+		return 0, riverdriver.ErrNotImplemented
+	}
+
 	res, err := dbsqlc.New().JobDeleteBefore(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobDeleteBeforeParams{
 		CancelledFinalizedAtHorizon: timeString(params.CancelledFinalizedAtHorizon),
 		CompletedFinalizedAtHorizon: timeString(params.CompletedFinalizedAtHorizon),
 		DiscardedFinalizedAtHorizon: timeString(params.DiscardedFinalizedAtHorizon),
 		Max:                         int64(params.Max),
+		QueuesExcluded:              params.QueuesExcluded,
+		QueuesExcludedEmpty:         len(params.QueuesExcluded) < 1, // not in the Postgres version, but I couldn't find a way around it
 	})
 	if err != nil {
 		return 0, interpretError(err)

--- a/rivershared/riverpilot/pilot.go
+++ b/rivershared/riverpilot/pilot.go
@@ -19,6 +19,11 @@ import (
 type Pilot interface {
 	PilotPeriodicJob
 
+	// JobCleanerQueuesExcluded returns queues that should be excluded from the
+	// main River client's JobCleaner. Empty omitted queues should return nil as
+	// instead of empty array.
+	JobCleanerQueuesExcluded() []string
+
 	JobGetAvailable(
 		ctx context.Context,
 		exec riverdriver.Executor,

--- a/rivershared/riverpilot/standard_pilot.go
+++ b/rivershared/riverpilot/standard_pilot.go
@@ -13,6 +13,8 @@ type StandardPilot struct {
 	seq atomic.Int64
 }
 
+func (p *StandardPilot) JobCleanerQueuesExcluded() []string { return nil }
+
 func (p *StandardPilot) JobGetAvailable(ctx context.Context, exec riverdriver.Executor, state ProducerState, params *riverdriver.JobGetAvailableParams) ([]*rivertype.JobRow, error) {
 	if params.MaxToLock <= 0 {
 		return nil, nil

--- a/rivershared/riversharedmaintenance/river_shared_maintenance.go
+++ b/rivershared/riversharedmaintenance/river_shared_maintenance.go
@@ -1,0 +1,73 @@
+package riversharedmaintenance
+
+import (
+	"context"
+	"time"
+
+	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivershared/util/serviceutil"
+)
+
+const (
+	// Maintainers will sleep a brief period of time between batches to give the
+	// database some breathing room.
+	BatchBackoffMax = 1 * time.Second
+	BatchBackoffMin = 50 * time.Millisecond
+
+	// Bulk maintenance tasks like job removal operate in batches so that even
+	// in the event of an enormous backlog of work to do, transactions stay
+	// relatively short and aren't at risk of cancellation. This number is the
+	// batch size, or the number of rows that are handled at a time.
+	//
+	// The specific value is somewhat arbitrary as large enough to make good
+	// progress, but not so large as to make the operation overstay its welcome.
+	// For now it's not configurable because we can likely pick a number that's
+	// suitable for almost everyone.
+	BatchSizeDefault = 1_000
+
+	LogPrefixRanSuccessfully = ": Ran successfully"
+	LogPrefixRunLoopStarted  = ": Run loop started"
+	LogPrefixRunLoopStopped  = ": Run loop stopped"
+)
+
+// Constants related to JobCleaner.
+const (
+	CancelledJobRetentionPeriodDefault = 24 * time.Hour
+	CompletedJobRetentionPeriodDefault = 24 * time.Hour
+	DiscardedJobRetentionPeriodDefault = 7 * 24 * time.Hour
+
+	JobCleanerIntervalDefault = 30 * time.Second
+	JobCleanerTimeoutDefault  = 30 * time.Second
+)
+
+// QueueMaintainerServiceBase is a struct that should be embedded on all queue
+// maintainer services. Its main use is to provide a StaggerStart function that
+// should be called on service start to avoid thundering herd problems.
+type QueueMaintainerServiceBase struct {
+	baseservice.BaseService
+
+	staggerStartupDisabled bool
+}
+
+// StaggerStart is called when queue maintainer services start. It jitters by
+// sleeping for a short random period so services don't all perform their first
+// run at exactly the same time.
+func (s *QueueMaintainerServiceBase) StaggerStart(ctx context.Context) {
+	if s.staggerStartupDisabled {
+		return
+	}
+
+	serviceutil.CancellableSleep(ctx, randutil.DurationBetween(0*time.Second, 1*time.Second))
+}
+
+// StaggerStartupDisable sets whether the short staggered sleep on start up
+// is disabled. This is useful in tests where the extra sleep involved in a
+// staggered start up is not helpful for test run time.
+func (s *QueueMaintainerServiceBase) StaggerStartupDisable(disabled bool) {
+	s.staggerStartupDisabled = disabled
+}
+
+func (s *QueueMaintainerServiceBase) StaggerStartupIsDisabled() bool {
+	return s.staggerStartupDisabled
+}


### PR DESCRIPTION
Add a new pilot function that lets it dictate that certain queues should
be excluded from the standard cleaning process that manages retention.
Along with the `JobDeleteBefore` driver function picking up a new
`QueuesExcluded` parameter, we also add its inverse of `QueuesIncluded`
which lets us delete jobs from a specific set of queues.