### PR TITLE
Eliminate TODO stored to error trace from job rescuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Cleanly error on invalid schema names in `Config.Schema`. [PR #952](https://github.com/riverqueue/river/pull/952).
+- Jobs rescued by `JobRescuer` no longer have their trace set to "TODO". This becomes an empty string instead. [PR #1010](https://github.com/riverqueue/river/pull/1010).
 
 ## [0.23.1] - 2025-06-04
 

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -187,8 +187,8 @@ func (s *JobRescuer) runOnce(ctx context.Context) (*rescuerRunOnceResult, error)
 			errorData, err := json.Marshal(rivertype.AttemptError{
 				At:      now,
 				Attempt: max(job.Attempt, 0),
-				Error:   "Stuck job rescued by Rescuer",
-				Trace:   "TODO",
+				Error:   "Stuck job rescued by JobRescuer",
+				Trace:   "",
 			})
 			if err != nil {
 				return nil, fmt.Errorf("error marshaling error JSON: %w", err)

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -251,6 +251,9 @@ type AttemptError struct {
 
 	// Trace contains a stack trace from a job that panicked. The trace is
 	// produced by invoking `debug.Trace()`.
+	//
+	// In the case of a non-panic or an error produced as a stuck job was
+	// rescued, this value will be an empty string.
 	Trace string `json:"trace"`
 }
 


### PR DESCRIPTION
Here, eliminate a TODO that's stored to an error's `trace` when a job is
rescued by `JobRescuer`. I've changed this to an empty string instead
and documented that it'll be an empty string.