### PR TITLE
Schedule jobs in smaller batches when it appears the database is degraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Jobs inserted from periodic jobs with IDs now have metadata `river:periodic_job_id` set so they can be traced back to the periodic job that inserted them. [PR #992](https://github.com/riverqueue/river/pull/992).
 - The unused function `WorkerDefaults.Hooks` has been removed. This is technically a breaking change, but this function was a vestigal refactoring artifact that was never used by anything, so in practice it shouldn't be breaking. [PR #997](https://github.com/riverqueue/river/pull/997).
 - Periodic job records are upserted immediately through a pilot when a client is started rather than the first time their associated job would run. This doesn't mean they're run immediately (they'll only run if `RunOnStart` is enabled), but rather just tracked immediately. [PR #998](https://github.com/riverqueue/river/pull/998).
+- The job scheduler still schedules jobs in batches of up to 10,000, but when it encounters a series of consecutive timeouts it assumes that the database is in a degraded state and switches to doing work in a smaller batch size of 1,000 jobs. [PR #1013](https://github.com/riverqueue/river/pull/1013).
 
 ### Fixed
 

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -1,0 +1,111 @@
+package circuitbreaker
+
+import (
+	"time"
+
+	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// CircuitBreakerOptions are options for CircuitBreaker.
+type CircuitBreakerOptions struct {
+	// Limit is the maximum number of trips/actions allowed within Window
+	// before the circuit breaker opens.
+	Limit int
+
+	// Window is the window of time during which Limit number of trips/actions
+	// can occur before the circuit breaker opens. The window is sliding, and
+	// actions are reaped as they fall outside of Window compared to the current
+	// time.
+	Window time.Duration
+}
+
+func (o *CircuitBreakerOptions) mustValidate() *CircuitBreakerOptions {
+	if o.Limit < 1 {
+		panic("CircuitBreakerOptions.Limit must be greater than 0")
+	}
+	if o.Window < 1 {
+		panic("CircuitBreakerOptions.Window must be greater than 0")
+	}
+	return o
+}
+
+// CircuitBreaker is a basic implementation of the circuit breaker pattern. Trip
+// is called a number of times until the circuit breaker reaches its defined
+// limit inside its allowed window at which point the circuit breaker
+// opens. Once open, this version of the circuit breaker does not close again
+// and stays open indefinitely. The window of time in question is sliding, and
+// actions are repeaed as they fall outside of it compared to the current time
+// (and don't count towards the breaker's limit).
+type CircuitBreaker struct {
+	open          bool
+	opts          *CircuitBreakerOptions
+	timeGenerator rivertype.TimeGenerator
+	trips         []time.Time
+}
+
+func NewCircuitBreaker(opts *CircuitBreakerOptions) *CircuitBreaker {
+	return &CircuitBreaker{
+		opts:          opts.mustValidate(),
+		timeGenerator: &baseservice.UnStubbableTimeGenerator{},
+	}
+}
+
+// Limit returns the configured limit of the circuit breaker.
+func (b *CircuitBreaker) Limit() int {
+	return b.opts.Limit
+}
+
+// Open returns true if the circuit breaker is open (i.e. is broken).
+func (b *CircuitBreaker) Open() bool {
+	return b.open
+}
+
+// ResetIfNotOpen resets the circuit breaker to its empty state if it's not
+// already open. i.e. As if no calls to Trip have been invoked at all. If the
+// circuit breaker is open, it has no effect.
+//
+// This may be useful for example in cases where we're trying to track a number
+// of consecutive failures before deciding to open. In the case of a success, we
+// want to indicate that the series of consecutive failures has ended, so we
+// call ResetIfNotOpen to trip it.
+//
+// Returns true if the breaker was reset (i.e. it had not been open), and false
+// otherwise.
+func (b *CircuitBreaker) ResetIfNotOpen() bool {
+	if !b.open {
+		b.trips = nil
+	}
+	return !b.open
+}
+
+// Trip "trips" the circuit breaker by counting an action towards opening it. If
+// the action causes the breaker to reach its limit within its window, the
+// breaker opens and the function returns true.
+func (b *CircuitBreaker) Trip() bool {
+	if b.open {
+		return true
+	}
+
+	var (
+		horizonIndex = -1
+		now          = b.timeGenerator.NowUTC()
+	)
+	for i := len(b.trips) - 1; i >= 0; i-- {
+		if b.trips[i].Before(now.Add(-b.opts.Window)) {
+			horizonIndex = i
+			break
+		}
+	}
+
+	if horizonIndex != -1 {
+		b.trips = b.trips[horizonIndex+1:]
+	}
+
+	b.trips = append(b.trips, now)
+	if len(b.trips) >= b.opts.Limit {
+		b.open = true
+	}
+
+	return b.open
+}

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -1,0 +1,154 @@
+package circuitbreaker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/rivershared/riversharedtest"
+)
+
+func TestCircuitBreaker(t *testing.T) {
+	t.Parallel()
+
+	const (
+		limit  = 5
+		window = 1 * time.Minute // use a wide window to avoid timing problems
+	)
+
+	setup := func() *CircuitBreaker {
+		breaker := NewCircuitBreaker(&CircuitBreakerOptions{
+			Limit:  limit,
+			Window: window,
+		})
+		return breaker
+	}
+
+	stubTime := func(breaker *CircuitBreaker) *riversharedtest.TimeStub {
+		timeStub := &riversharedtest.TimeStub{}
+		breaker.timeGenerator = timeStub
+		return timeStub
+	}
+
+	t.Run("Configured", func(t *testing.T) {
+		t.Parallel()
+
+		breaker := setup()
+
+		require.Equal(t, limit, breaker.Limit())
+	})
+
+	t.Run("BreakerOpens", func(t *testing.T) {
+		t.Parallel()
+
+		breaker := setup()
+
+		for range limit - 1 {
+			require.False(t, breaker.Trip())
+			require.False(t, breaker.Open())
+		}
+
+		require.True(t, breaker.Trip())
+		require.True(t, breaker.Open())
+
+		require.True(t, breaker.Trip())
+		require.True(t, breaker.Open())
+	})
+
+	t.Run("WindowEdge", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			breaker  = setup()
+			timeStub = stubTime(breaker)
+			now      = time.Now()
+		)
+
+		timeStub.StubNowUTC(now)
+		for range limit - 2 {
+			require.False(t, breaker.Trip())
+		}
+
+		timeStub.StubNowUTC(now.Add(window - 1*time.Second))
+		require.False(t, breaker.Trip())
+
+		timeStub.StubNowUTC(now.Add(window))
+		require.True(t, breaker.Trip())
+	})
+
+	t.Run("TripsFallOutOfWindow", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			breaker  = setup()
+			timeStub = stubTime(breaker)
+			now      = time.Now()
+		)
+
+		timeStub.StubNowUTC(now)
+		require.False(t, breaker.Trip())
+
+		timeStub.StubNowUTC(now.Add(window - 1*time.Second))
+		for range limit - 2 {
+			require.False(t, breaker.Trip())
+		}
+
+		// Does *not* trip because the first trip is reaped as it's fallen out
+		// of the window.
+		timeStub.StubNowUTC(now.Add(window + 1*time.Second))
+		require.False(t, breaker.Trip())
+	})
+
+	t.Run("MultipleFallOut", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			breaker  = setup()
+			timeStub = stubTime(breaker)
+			now      = time.Now()
+		)
+
+		timeStub.StubNowUTC(now)
+		for range limit - 1 {
+			require.False(t, breaker.Trip())
+		}
+
+		// Similar to the above, but multiple trips fall out of the window at once.
+		timeStub.StubNowUTC(now.Add(window + 1*time.Second))
+		require.False(t, breaker.Trip())
+	})
+
+	t.Run("ResetIfNotOpen", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			breaker  = setup()
+			timeStub = stubTime(breaker)
+			now      = time.Now()
+		)
+
+		timeStub.StubNowUTC(now)
+		for range limit - 1 {
+			require.False(t, breaker.Trip())
+		}
+
+		require.True(t, breaker.ResetIfNotOpen())
+
+		// We're allowed to go right up the limit again because the call to
+		// ResetIfNotOpen reset everything.
+		timeStub.StubNowUTC(now)
+		for range limit - 1 {
+			require.False(t, breaker.Trip())
+		}
+
+		// One more trip breaks the circuit.
+		require.True(t, breaker.Trip())
+
+		// ResetIfNotOpen has no effect anymore because the circuit is open.
+		require.False(t, breaker.ResetIfNotOpen())
+
+		// Circuit still open.
+		require.True(t, breaker.Trip())
+	})
+}

--- a/rivertype/time_generator.go
+++ b/rivertype/time_generator.go
@@ -3,7 +3,7 @@ package rivertype
 import "time"
 
 // TimeGenerator generates a current time in UTC. In test environments it's
-// implemented by riverinternaltest.timeStub which lets the current time be
+// implemented by riversharedtest.TimeStub which lets the current time be
 // stubbed. Otherwise, it's implemented as UnStubbableTimeGenerator which
 // doesn't allow stubbing.
 type TimeGenerator interface {


### PR DESCRIPTION
The job scheduler currently tries to work in batches that are quite
large, trying to schedule 10,000 jobs at once. Normally this is fine
because there's far fewer than 10,000 jobs to schedule, or if there are
many jobs you're generally on a large Postgres instance where scheduling
a lot of jobs at once should be fine.

However, in a situation where Postgres is severely degraded, it might be
possible that get yourself in a situation where the scheduler can never
succeed. It tries to schedule 10k jobs, fails due to timeout, tries
again, fails again, etc. Jobs accumulate and the situation keeps getting
worse. You can see an example of this in #995, where the users in
question ran out of IOPS on their DB and saw their situation steadily
degrade.

Here, put in a partial stab at an approach for ameliorating this. We add
a circuit breaker to the scheduler such that if its scheduling operation
fails three times in a row due to timeout, the circuit breaks, and the
scheduler switches from its default batch of 10k to a much reduced batch
of 1,000 jobs. The timeout must occur three times in a row for this to
occur. If timeouts are intermittent (i.e. in the case of an only
partially degraded database), the breaker is allowed to reset, and
operations continue to use the 10k limit.

An executive decision I made here is to have the circuit breaker stay
open once it trips, so after the scheduler switches to a reduced batch
of 1k, it'll continue using the 1k batch until the program restarts. The
reason I designed it this way is that in my experience after a database
becomes degraded, it tends to stay degraded over the long term. We could
have it so that it switches back to 10k job batches after some time, but
more likely than not those 10k operations will just start failing again,
and make things worse by putting more load on the database while they
do. I could see tweaking or reexamining this behavior in the future, but
I don't think either way we could go here is that much more correct than
the other.

I've only applied this to the job scheduler for this initial design, but
I'd like to eventually bring this to all/most of the other maintenance
services, many of which haven't had a huge amount of thought put into
how their batch size works since they were first introduced.