### PR TITLE
Start testing against Go 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,12 +27,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Run the 4 latest Postgres versions against the latest Go version:
-        go-version:
-          - "1.24"
-        postgres-version: [14, 15, 16, 17]
         include:
-          # Also run previous Go version against the latest Postgres version:
+          # Run the 4 latest Postgres versions against the latest Go version:
+          - go-version: "1.25"
+            postgres-version: 17
+          - go-version: "1.25"
+            postgres-version: 16
+          - go-version: "1.25"
+            postgres-version: 15
+          - go-version: "1.25"
+            postgres-version: 14
+
+          # Also run a couple previous Go versions against the latest Postgres version:
+          - go-version: "1.24"
+            postgres-version: 17
           - go-version: "1.23"
             postgres-version: 17
       fail-fast: false

--- a/cmd/river/rivercli/river_cli_test.go
+++ b/cmd/river/rivercli/river_cli_test.go
@@ -179,8 +179,9 @@ func TestBaseCommandSetIntegration(t *testing.T) {
 
 		buildInfo, _ := debug.ReadBuildInfo()
 
-		require.Equal(t, strings.TrimSpace(fmt.Sprintf(`
-River version (unknown)
+		// `devel` on 1.25, `unknown` on versions previous to that
+		require.Regexp(t, strings.TrimSpace(fmt.Sprintf(`
+River version \((devel|unknown)\)
 Built with %s
 		`, buildInfo.GoVersion)), strings.TrimSpace(bundle.out.String()))
 	})
@@ -195,8 +196,9 @@ Built with %s
 
 		buildInfo, _ := debug.ReadBuildInfo()
 
-		require.Equal(t, strings.TrimSpace(fmt.Sprintf(`
-River version (unknown)
+		// `devel` on 1.25, `unknown` on versions previous to that
+		require.Regexp(t, strings.TrimSpace(fmt.Sprintf(`
+River version \((devel|unknown)\)
 Built with %s
 		`, buildInfo.GoVersion)), strings.TrimSpace(bundle.out.String()))
 	})
@@ -502,8 +504,9 @@ func TestVersion(t *testing.T) {
 
 		buildInfo, _ := debug.ReadBuildInfo()
 
-		require.Equal(t, strings.TrimSpace(fmt.Sprintf(`
-River version (unknown)
+		// `devel` on 1.25, `unknown` on versions previous to that
+		require.Regexp(t, strings.TrimSpace(fmt.Sprintf(`
+River version \((devel|unknown)\)
 Built with %s
 		`, buildInfo.GoVersion)), strings.TrimSpace(bundle.buf.String()))
 	})


### PR DESCRIPTION
Start testing against Go 1.25. I didn't change the `go.mod` version. I
figure it's probably fine to leave that as low as is convenient for us
to maintain as a courtesy to those at companies where it's harder to
upgrade.