### PR TITLE
don't double-log fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't double log fetch errors. [PR #1025](https://github.com/riverqueue/river/pull/1025).
+
 ## [0.24.0] - 2025-08-16
 
 ⚠️ Version 0.24.0 has a breaking change in `HookWorkEnd.WorkEnd` in that a new `JobRow` parameter has been added to the function's signature. Any intergration defining a custom `HookWorkEnd` hook should update its implementation so the hook continues to be called correctly.

--- a/producer.go
+++ b/producer.go
@@ -632,7 +632,7 @@ func (p *producer) innerFetchLoop(workCtx context.Context, fetchResultCh chan pr
 		select {
 		case result := <-fetchResultCh:
 			if result.err != nil {
-				p.Logger.ErrorContext(workCtx, p.Name+": Error fetching jobs", slog.String("err", result.err.Error()))
+				p.Logger.ErrorContext(workCtx, p.Name+": Error fetching jobs", slog.String("err", result.err.Error()), slog.String("queue", p.config.Queue))
 			} else if len(result.jobs) > 0 {
 				p.startNewExecutors(workCtx, result.jobs)
 
@@ -756,7 +756,6 @@ func (p *producer) dispatchWork(workCtx context.Context, count int, fetchResultC
 		Schema:         p.config.Schema,
 	})
 	if err != nil {
-		p.Logger.ErrorContext(ctx, p.Name+": Error fetching jobs", slog.String("err", err.Error()), slog.String("queue", p.config.Queue))
 		fetchResultCh <- producerFetchResult{err: err}
 		return
 	}


### PR DESCRIPTION
While digging into some Pro errors that were surfacing, I realized we were logging these fetch errors twice with the same message each time they occur (albeit with slightly different attrs). This removes one in favor of keeping all logging on the channel receive side.