### PR TITLE
Require use of `JobDeleteManyParams.UnsafeAll` to delete all jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set minimum Go version to Go 1.24. [PR #1032](https://github.com/riverqueue/river/pull/1032).
+- **Breaking change:** `Client.JobDeleteMany` now requires the use of `JobDeleteManyParams.UnsafeAll` to delete all jobs without a filter applied. This is a safety feature to make it more difficult to accidentally delete all non-running jobs. This is a minor breaking change, but on a fairly new feature that's not likely to be used on purpose by very many people yet. [PR #1033](https://github.com/riverqueue/river/pull/1033).
 
 ### Fixed
 

--- a/client.go
+++ b/client.go
@@ -2158,6 +2158,10 @@ func (c *Client[TTx]) jobDeleteMany(ctx context.Context, exec riverdriver.Execut
 	}
 	params.schema = c.config.Schema
 
+	if params.filtersEmpty() && !params.unsafeAll {
+		return nil, errors.New("delete with no filters not allowed to prevent accidental deletion of all jobs; either specify a predicate (e.g. JobDeleteManyParams.IDs, JobDeleteManyParams.Kinds, ...) or call JobDeleteManyParams.All")
+	}
+
 	listParams, err := dblist.JobMakeDriverParams(ctx, params.toDBParams(), c.driver.SQLFragmentColumnIn)
 	if err != nil {
 		return nil, err

--- a/delete_many_params_test.go
+++ b/delete_many_params_test.go
@@ -1,0 +1,30 @@
+package river
+
+import (
+	"testing"
+
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobDeleteManyParams_filtersEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, NewJobDeleteManyParams().filtersEmpty())
+
+	require.False(t, NewJobDeleteManyParams().IDs(123).filtersEmpty())
+	require.False(t, NewJobDeleteManyParams().Kinds("kind").filtersEmpty())
+	require.False(t, NewJobDeleteManyParams().Priorities(1).filtersEmpty())
+	require.False(t, NewJobDeleteManyParams().Queues("queues").filtersEmpty())
+	require.False(t, NewJobDeleteManyParams().States(rivertype.JobStateAvailable).filtersEmpty())
+}
+
+func TestJobDeleteManyParams_UnsafeAll(t *testing.T) {
+	t.Parallel()
+
+	NewJobDeleteManyParams().UnsafeAll()
+
+	require.PanicsWithValue(t, "UnsafeAll no longer meaningful with non-default filters applied", func() {
+		NewJobDeleteManyParams().IDs(123).UnsafeAll()
+	})
+}

--- a/riverdriver/riverdrivertest/driver_client_test.go
+++ b/riverdriver/riverdrivertest/driver_client_test.go
@@ -330,7 +330,7 @@ func ExerciseClient[TTx any](ctx context.Context, t *testing.T,
 		}
 	})
 
-	t.Run("JobDeleteManyMinimal", func(t *testing.T) {
+	t.Run("JobDeleteManyUnsafeAll", func(t *testing.T) {
 		t.Parallel()
 
 		client, bundle := setup(t)
@@ -340,7 +340,7 @@ func ExerciseClient[TTx any](ctx context.Context, t *testing.T,
 			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema})
 		)
 
-		deleteRes, err := client.JobDeleteMany(ctx, river.NewJobDeleteManyParams())
+		deleteRes, err := client.JobDeleteMany(ctx, river.NewJobDeleteManyParams().UnsafeAll())
 		require.NoError(t, err)
 		require.Len(t, deleteRes.Jobs, 2)
 		require.Equal(t, job1.ID, deleteRes.Jobs[0].ID)
@@ -380,7 +380,7 @@ func ExerciseClient[TTx any](ctx context.Context, t *testing.T,
 		require.NoError(t, err)
 	})
 
-	t.Run("JobDeleteManyTxMinimal", func(t *testing.T) {
+	t.Run("JobDeleteManyTxUnsafeAll", func(t *testing.T) {
 		t.Parallel()
 
 		client, bundle := setup(t)
@@ -392,7 +392,7 @@ func ExerciseClient[TTx any](ctx context.Context, t *testing.T,
 
 		tx, execTx := beginTx(ctx, t, bundle)
 
-		deleteRes, err := client.JobDeleteManyTx(ctx, tx, river.NewJobDeleteManyParams())
+		deleteRes, err := client.JobDeleteManyTx(ctx, tx, river.NewJobDeleteManyParams().UnsafeAll())
 		require.NoError(t, err)
 		require.Len(t, deleteRes.Jobs, 2)
 		require.Equal(t, job1.ID, deleteRes.Jobs[0].ID)


### PR DESCRIPTION
Addresses #1031. It's come to light that it's relatively easy to
accidentally delete all non-running jobs by invoking `JobDeleteMany`
with `nil` parameters or parameters with all defaults.

Here, make it a little harder to do so by requiring an invocation to
`JobDeleteManyParams.UnsafeAll` before a blanket delete is allowed.
Calling `UnsafeAll` isn't necessary if any filters are applied.

Fixes #1031.