### PR TITLE
Cleanly handle jobs being snoozed with zero duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't double log fetch errors. [PR #1025](https://github.com/riverqueue/river/pull/1025).
+- When snoozing a job with zero duration so that it's retried immediately, subscription events no longer appear incorrectly with a kind of `rivertype.EventKindJobFailed`. Instead they're assigned `rivertype.EventKindJobSnoozed` just like they would have with a non-zero snooze duration. [PR #1037](https://github.com/riverqueue/river/pull/1037).
 
 ## [0.24.0] - 2025-08-16
 

--- a/error.go
+++ b/error.go
@@ -32,6 +32,13 @@ type JobSnoozeError = rivertype.JobSnoozeError
 // incrementing the job's MaxAttempts by 1, meaning that jobs can be repeatedly
 // snoozed without ever being discarded.
 //
+// A special duration of zero can be used to make the job immediately available
+// to be reworked. This may be useful in cases like where a long-running job is
+// being interrupted on shutdown. Instead of returning a context cancelled error
+// that'd schedule a retry for the future and count towards maximum attempts,
+// the work function can return JobSnooze(0) and the job will be retried
+// immediately the next time a client starts up.
+//
 // Panics if duration is < 0.
 func JobSnooze(duration time.Duration) error {
 	return &rivertype.JobSnoozeError{Duration: duration}

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -535,6 +535,7 @@ type JobSetStateIfRunningParams struct {
 	MetadataUpdates []byte
 	ScheduledAt     *time.Time
 	Schema          string // added by completer
+	Snoozed         bool
 	State           rivertype.JobState
 }
 
@@ -599,6 +600,7 @@ func JobSetStateSnoozed(id int64, scheduledAt time.Time, attempt int, metadataUp
 		MetadataDoMerge: len(metadataUpdates) > 0,
 		MetadataUpdates: metadataUpdates,
 		ScheduledAt:     &scheduledAt,
+		Snoozed:         true,
 		State:           rivertype.JobStateScheduled,
 	}
 }
@@ -610,6 +612,7 @@ func JobSetStateSnoozedAvailable(id int64, scheduledAt time.Time, attempt int, m
 		MetadataDoMerge: len(metadataUpdates) > 0,
 		MetadataUpdates: metadataUpdates,
 		ScheduledAt:     &scheduledAt,
+		Snoozed:         true,
 		State:           rivertype.JobStateAvailable,
 	}
 }

--- a/riverdriver/river_driver_interface_test.go
+++ b/riverdriver/river_driver_interface_test.go
@@ -25,6 +25,7 @@ func TestJobSetStateCancelled(t *testing.T) {
 		require.Nil(t, result.MetadataUpdates)
 		require.False(t, result.MetadataDoMerge)
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateCancelled, result.State)
 	})
 
@@ -43,6 +44,7 @@ func TestJobSetStateCancelled(t *testing.T) {
 		require.Equal(t, metadata, result.MetadataUpdates)
 		require.True(t, result.MetadataDoMerge)
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateCancelled, result.State)
 	})
 }
@@ -63,6 +65,7 @@ func TestJobSetStateCompleted(t *testing.T) {
 		require.False(t, result.MetadataDoMerge)
 		require.Nil(t, result.MetadataUpdates)
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateCompleted, result.State)
 	})
 
@@ -79,6 +82,7 @@ func TestJobSetStateCompleted(t *testing.T) {
 		require.True(t, result.MetadataDoMerge)
 		require.Equal(t, metadata, result.MetadataUpdates)
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateCompleted, result.State)
 	})
 }
@@ -100,6 +104,7 @@ func TestJobSetStateDiscarded(t *testing.T) {
 		require.False(t, result.MetadataDoMerge)
 		require.Nil(t, result.MetadataUpdates)
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateDiscarded, result.State)
 	})
 
@@ -118,6 +123,7 @@ func TestJobSetStateDiscarded(t *testing.T) {
 		require.Equal(t, metadata, result.MetadataUpdates)
 		require.True(t, result.MetadataDoMerge)
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateDiscarded, result.State)
 	})
 }
@@ -139,6 +145,7 @@ func TestJobSetStateErrorAvailable(t *testing.T) {
 		require.NotNil(t, result.ScheduledAt)
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateAvailable, result.State)
 	})
 
@@ -156,6 +163,7 @@ func TestJobSetStateErrorAvailable(t *testing.T) {
 		require.NotNil(t, result.ScheduledAt)
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, errData, result.ErrData)
 	})
 }
@@ -177,6 +185,7 @@ func TestJobSetStateErrorRetryable(t *testing.T) {
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Equal(t, errData, result.ErrData)
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateRetryable, result.State)
 	})
 
@@ -194,6 +203,7 @@ func TestJobSetStateErrorRetryable(t *testing.T) {
 		require.NotNil(t, result.ScheduledAt)
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Empty(t, result.Schema)
+		require.False(t, result.Snoozed)
 		require.Equal(t, errData, result.ErrData)
 	})
 }
@@ -216,6 +226,7 @@ func TestJobSetStateSnoozed(t *testing.T) { //nolint:dupl
 		require.NotNil(t, result.ScheduledAt)
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Empty(t, result.Schema)
+		require.True(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateScheduled, result.State)
 	})
 
@@ -234,6 +245,7 @@ func TestJobSetStateSnoozed(t *testing.T) { //nolint:dupl
 		require.NotNil(t, result.ScheduledAt)
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Empty(t, result.Schema)
+		require.True(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateScheduled, result.State)
 	})
 }
@@ -256,6 +268,7 @@ func TestJobSetStateSnoozedAvailable(t *testing.T) { //nolint:dupl
 		require.NotNil(t, result.ScheduledAt)
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Empty(t, result.Schema)
+		require.True(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateAvailable, result.State)
 	})
 
@@ -275,6 +288,7 @@ func TestJobSetStateSnoozedAvailable(t *testing.T) { //nolint:dupl
 		require.NotNil(t, result.ScheduledAt)
 		require.True(t, result.ScheduledAt.Equal(scheduledAt))
 		require.Empty(t, result.Schema)
+		require.True(t, result.Snoozed)
 		require.Equal(t, rivertype.JobStateAvailable, result.State)
 	})
 }

--- a/subscription_manager_test.go
+++ b/subscription_manager_test.go
@@ -78,8 +78,8 @@ func Test_SubscriptionManager(t *testing.T) {
 			{Job: job2, JobStats: makeStats(201, 202, 203)}, // cancelled, should be skipped
 		}
 		bundle.subscribeCh <- []jobcompleter.CompleterJobUpdated{
-			{Job: job3, JobStats: makeStats(301, 302, 303)}, // retryable, should be skipped
-			{Job: job4, JobStats: makeStats(401, 402, 403)}, // snoozed/scheduled, should be sent
+			{Job: job3, JobStats: makeStats(301, 302, 303)},                // retryable, should be skipped
+			{Job: job4, JobStats: makeStats(401, 402, 403), Snoozed: true}, // snoozed/scheduled, should be sent
 		}
 
 		received := riversharedtest.WaitOrTimeoutN(t, sub, 2)


### PR DESCRIPTION
As I was going through to see if we could recommend snoozing jobs with a
zero duration as a way of returning an error that'd cause them to be
retried immediately but without logging error noise, I found that
snoozes with zero duration do work, but had a bug in the subscription
manager that'd cause them to be emitted as `EventKindJobFailed` instead
of `EventKindJobSnoozed`

Here, go through and fix that problem, and making sure to add adequate
test coverage for it.

I also add a formal documentation to `river.JobSnooze` that suggests the
function can be used for a noise-less retry even in cases where no
snooze time is required.