### PR TITLE
JobUpdate: add max attempts and metadata attrs

### DIFF
--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -645,6 +645,10 @@ type JobUpdateParams struct {
 	Errors              [][]byte
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
+	MaxAttemptsDoUpdate bool
+	MaxAttempts         int
+	MetadataDoUpdate    bool
+	Metadata            []byte
 	Schema              string
 	StateDoUpdate       bool
 	State               rivertype.JobState

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -1610,8 +1610,10 @@ SET
     attempted_by = CASE WHEN $5::boolean THEN $6 ELSE attempted_by END,
     errors = CASE WHEN $7::boolean THEN $8::jsonb[] ELSE errors END,
     finalized_at = CASE WHEN $9::boolean THEN $10 ELSE finalized_at END,
-    state = CASE WHEN $11::boolean THEN $12::/* TEMPLATE: schema */river_job_state ELSE state END
-WHERE id = $13
+    max_attempts = CASE WHEN $11::boolean THEN $12 ELSE max_attempts END,
+    metadata = CASE WHEN $13::boolean THEN $14::jsonb ELSE metadata END,
+    state = CASE WHEN $15::boolean THEN $16::/* TEMPLATE: schema */river_job_state ELSE state END
+WHERE id = $17
 RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 `
 
@@ -1626,6 +1628,10 @@ type JobUpdateParams struct {
 	Errors              []string
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
+	MaxAttemptsDoUpdate bool
+	MaxAttempts         int16
+	MetadataDoUpdate    bool
+	Metadata            string
 	StateDoUpdate       bool
 	State               RiverJobState
 	ID                  int64
@@ -1645,6 +1651,10 @@ func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) 
 		pq.Array(arg.Errors),
 		arg.FinalizedAtDoUpdate,
 		arg.FinalizedAt,
+		arg.MaxAttemptsDoUpdate,
+		arg.MaxAttempts,
+		arg.MetadataDoUpdate,
+		arg.Metadata,
 		arg.StateDoUpdate,
 		arg.State,
 		arg.ID,

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -662,6 +662,11 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 }
 
 func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateParams) (*rivertype.JobRow, error) {
+	metadata := params.Metadata
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
+
 	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
 		ID:                  params.ID,
 		Attempt:             int16(min(params.Attempt, math.MaxInt16)), //nolint:gosec
@@ -674,6 +679,10 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		Errors:              sliceutil.Map(params.Errors, func(e []byte) string { return string(e) }),
 		FinalizedAtDoUpdate: params.FinalizedAtDoUpdate,
 		FinalizedAt:         params.FinalizedAt,
+		MaxAttemptsDoUpdate: params.MaxAttemptsDoUpdate,
+		MaxAttempts:         int16(min(params.MaxAttempts, math.MaxInt16)), //nolint:gosec
+		MetadataDoUpdate:    params.MetadataDoUpdate,
+		Metadata:            string(metadata),
 		StateDoUpdate:       params.StateDoUpdate,
 		State:               dbsqlc.RiverJobState(cmp.Or(params.State, rivertype.JobStateAvailable)), // can't send empty job state, so provider default value that may not be set
 	})

--- a/riverdriver/riverdrivertest/riverdrivertest.go
+++ b/riverdriver/riverdrivertest/riverdrivertest.go
@@ -3352,6 +3352,10 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 				Errors:              [][]byte{[]byte(`{"error":"message"}`)},
 				FinalizedAtDoUpdate: true,
 				FinalizedAt:         &now,
+				MaxAttemptsDoUpdate: true,
+				MaxAttempts:         99,
+				MetadataDoUpdate:    true,
+				Metadata:            []byte(`{"foo":"bar"}`),
 				StateDoUpdate:       true,
 				State:               rivertype.JobStateDiscarded,
 			})
@@ -3361,6 +3365,8 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			require.Equal(t, []string{"worker1"}, updatedJob.AttemptedBy)
 			require.Equal(t, "message", updatedJob.Errors[0].Error)
 			require.WithinDuration(t, now, *updatedJob.FinalizedAt, bundle.driver.TimePrecision())
+			require.Equal(t, 99, updatedJob.MaxAttempts)
+			require.JSONEq(t, `{"foo":"bar"}`, string(updatedJob.Metadata))
 			require.Equal(t, rivertype.JobStateDiscarded, updatedJob.State)
 		})
 
@@ -3380,6 +3386,8 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 			require.Empty(t, updatedJob.AttemptedBy)
 			require.Empty(t, updatedJob.Errors)
 			require.Nil(t, updatedJob.FinalizedAt)
+			require.Equal(t, job.MaxAttempts, updatedJob.MaxAttempts)
+			require.Equal(t, job.Metadata, updatedJob.Metadata)
 			require.Equal(t, job.State, updatedJob.State)
 		})
 	})

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -697,6 +697,8 @@ SET
     attempted_by = CASE WHEN @attempted_by_do_update::boolean THEN @attempted_by ELSE attempted_by END,
     errors = CASE WHEN @errors_do_update::boolean THEN @errors::jsonb[] ELSE errors END,
     finalized_at = CASE WHEN @finalized_at_do_update::boolean THEN @finalized_at ELSE finalized_at END,
+    max_attempts = CASE WHEN @max_attempts_do_update::boolean THEN @max_attempts ELSE max_attempts END,
+    metadata = CASE WHEN @metadata_do_update::boolean THEN @metadata::jsonb ELSE metadata END,
     state = CASE WHEN @state_do_update::boolean THEN @state::/* TEMPLATE: schema */river_job_state ELSE state END
 WHERE id = @id
 RETURNING *;

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -1571,8 +1571,10 @@ SET
     attempted_by = CASE WHEN $5::boolean THEN $6 ELSE attempted_by END,
     errors = CASE WHEN $7::boolean THEN $8::jsonb[] ELSE errors END,
     finalized_at = CASE WHEN $9::boolean THEN $10 ELSE finalized_at END,
-    state = CASE WHEN $11::boolean THEN $12::/* TEMPLATE: schema */river_job_state ELSE state END
-WHERE id = $13
+    max_attempts = CASE WHEN $11::boolean THEN $12 ELSE max_attempts END,
+    metadata = CASE WHEN $13::boolean THEN $14::jsonb ELSE metadata END,
+    state = CASE WHEN $15::boolean THEN $16::/* TEMPLATE: schema */river_job_state ELSE state END
+WHERE id = $17
 RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 `
 
@@ -1587,6 +1589,10 @@ type JobUpdateParams struct {
 	Errors              [][]byte
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
+	MaxAttemptsDoUpdate bool
+	MaxAttempts         int16
+	MetadataDoUpdate    bool
+	Metadata            []byte
 	StateDoUpdate       bool
 	State               RiverJobState
 	ID                  int64
@@ -1606,6 +1612,10 @@ func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) 
 		arg.Errors,
 		arg.FinalizedAtDoUpdate,
 		arg.FinalizedAt,
+		arg.MaxAttemptsDoUpdate,
+		arg.MaxAttempts,
+		arg.MetadataDoUpdate,
+		arg.Metadata,
 		arg.StateDoUpdate,
 		arg.State,
 		arg.ID,

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -651,6 +651,11 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 }
 
 func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateParams) (*rivertype.JobRow, error) {
+	metadata := params.Metadata
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
+
 	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
 		ID:                  params.ID,
 		AttemptedAtDoUpdate: params.AttemptedAtDoUpdate,
@@ -663,6 +668,10 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		Errors:              params.Errors,
 		FinalizedAtDoUpdate: params.FinalizedAtDoUpdate,
 		FinalizedAt:         params.FinalizedAt,
+		MaxAttemptsDoUpdate: params.MaxAttemptsDoUpdate,
+		MaxAttempts:         int16(min(params.MaxAttempts, math.MaxInt16)), //nolint:gosec
+		MetadataDoUpdate:    params.MetadataDoUpdate,
+		Metadata:            metadata,
 		StateDoUpdate:       params.StateDoUpdate,
 		State:               dbsqlc.RiverJobState(cmp.Or(params.State, rivertype.JobStateAvailable)), // can't send empty job state, so provider default value that may not be set
 	})

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
@@ -491,6 +491,8 @@ SET
     attempted_by = CASE WHEN cast(@attempted_by_do_update AS boolean) THEN @attempted_by ELSE attempted_by END,
     errors = CASE WHEN cast(@errors_do_update AS boolean) THEN @errors ELSE errors END,
     finalized_at = CASE WHEN cast(@finalized_at_do_update AS boolean) THEN @finalized_at ELSE finalized_at END,
+    max_attempts = CASE WHEN cast(@max_attempts_do_update AS boolean) THEN @max_attempts ELSE max_attempts END,
+    metadata = CASE WHEN cast(@metadata_do_update AS boolean) THEN json(cast(@metadata AS blob)) ELSE metadata END,
     state = CASE WHEN cast(@state_do_update AS boolean) THEN @state ELSE state END
 WHERE id = @id
 RETURNING *;

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
@@ -1492,8 +1492,10 @@ SET
     attempted_by = CASE WHEN cast(?5 AS boolean) THEN ?6 ELSE attempted_by END,
     errors = CASE WHEN cast(?7 AS boolean) THEN ?8 ELSE errors END,
     finalized_at = CASE WHEN cast(?9 AS boolean) THEN ?10 ELSE finalized_at END,
-    state = CASE WHEN cast(?11 AS boolean) THEN ?12 ELSE state END
-WHERE id = ?13
+    max_attempts = CASE WHEN cast(?11 AS boolean) THEN ?12 ELSE max_attempts END,
+    metadata = CASE WHEN cast(?13 AS boolean) THEN json(cast(?14 AS blob)) ELSE metadata END,
+    state = CASE WHEN cast(?15 AS boolean) THEN ?16 ELSE state END
+WHERE id = ?17
 RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 `
 
@@ -1508,6 +1510,10 @@ type JobUpdateParams struct {
 	Errors              []byte
 	FinalizedAtDoUpdate bool
 	FinalizedAt         *time.Time
+	MaxAttemptsDoUpdate bool
+	MaxAttempts         int64
+	MetadataDoUpdate    bool
+	Metadata            []byte
 	StateDoUpdate       bool
 	State               string
 	ID                  int64
@@ -1527,6 +1533,10 @@ func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) 
 		arg.Errors,
 		arg.FinalizedAtDoUpdate,
 		arg.FinalizedAt,
+		arg.MaxAttemptsDoUpdate,
+		arg.MaxAttempts,
+		arg.MetadataDoUpdate,
+		arg.Metadata,
 		arg.StateDoUpdate,
 		arg.State,
 		arg.ID,

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -1018,6 +1018,11 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		finalizedAt = ptrutil.Ptr(finalizedAt.UTC())
 	}
 
+	metadata := params.Metadata
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
+
 	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
 		ID:                  params.ID,
 		Attempt:             int64(params.Attempt),
@@ -1030,6 +1035,10 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		Errors:              errors,
 		FinalizedAtDoUpdate: params.FinalizedAtDoUpdate,
 		FinalizedAt:         finalizedAt,
+		MaxAttemptsDoUpdate: params.MaxAttemptsDoUpdate,
+		MaxAttempts:         int64(min(params.MaxAttempts, math.MaxInt64)), //nolint:gosec
+		MetadataDoUpdate:    params.MetadataDoUpdate,
+		Metadata:            metadata,
 		StateDoUpdate:       params.StateDoUpdate,
 		State:               string(params.State),
 	})


### PR DESCRIPTION
Adding these extra fields to `JobUpdate` to facilitate internal testing.