### PR TITLE
Prepare release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2025-09-14
+
+⚠️ Internal APIs used for communication between River and River Pro have changed. If using River Pro, make sure to update River and River Pro to latest at the same time to get compatible versions. River v0.25.0 is compatible with River Pro v0.18.0.
+
 ### Changed
 
 - Set minimum Go version to Go 1.24. [PR #1032](https://github.com/riverqueue/river/pull/1032).

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,12 +7,12 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lmittmann/tint v1.1.2
-	github.com/riverqueue/river v0.24.0
-	github.com/riverqueue/river/riverdriver v0.24.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.24.0
-	github.com/riverqueue/river/riverdriver/riversqlite v0.24.0
-	github.com/riverqueue/river/rivershared v0.24.0
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river v0.25.0
+	github.com/riverqueue/river/riverdriver v0.25.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.25.0
+	github.com/riverqueue/river/riverdriver/riversqlite v0.25.0
+	github.com/riverqueue/river/rivershared v0.25.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	modernc.org/sqlite v1.38.2

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.24.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.24.0
-	github.com/riverqueue/river/rivershared v0.24.0
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river/riverdriver v0.25.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.25.0
+	github.com/riverqueue/river/rivershared v0.25.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.24.0
-	github.com/riverqueue/river/riverdriver v0.24.0
-	github.com/riverqueue/river/rivershared v0.24.0
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river v0.25.0
+	github.com/riverqueue/river/riverdriver v0.25.0
+	github.com/riverqueue/river/rivershared v0.25.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.24.0 // indirect
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.25.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/riverdriver/riverdrivertest/go.mod
+++ b/riverdriver/riverdrivertest/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.24.0
-	github.com/riverqueue/river/riverdriver v0.24.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.24.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.24.0
-	github.com/riverqueue/river/riverdriver/riversqlite v0.24.0
-	github.com/riverqueue/river/rivershared v0.24.0
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river v0.25.0
+	github.com/riverqueue/river/riverdriver v0.25.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.25.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.25.0
+	github.com/riverqueue/river/riverdriver/riversqlite v0.25.0
+	github.com/riverqueue/river/rivershared v0.25.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,9 +7,9 @@ toolchain go1.24.1
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.24.0
-	github.com/riverqueue/river/rivershared v0.24.0
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river/riverdriver v0.25.0
+	github.com/riverqueue/river/rivershared v0.25.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/riverdriver/riversqlite/go.mod
+++ b/riverdriver/riversqlite/go.mod
@@ -5,10 +5,10 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/riverqueue/river v0.24.0
-	github.com/riverqueue/river/riverdriver v0.24.0
-	github.com/riverqueue/river/rivershared v0.24.0
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river v0.25.0
+	github.com/riverqueue/river/riverdriver v0.25.0
+	github.com/riverqueue/river/rivershared v0.25.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -6,10 +6,10 @@ toolchain go1.24.1
 
 require (
 	github.com/jackc/pgx/v5 v5.7.6
-	github.com/riverqueue/river v0.24.0
-	github.com/riverqueue/river/riverdriver v0.24.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.24.0
-	github.com/riverqueue/river/rivertype v0.24.0
+	github.com/riverqueue/river v0.25.0
+	github.com/riverqueue/river/riverdriver v0.25.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.25.0
+	github.com/riverqueue/river/rivertype v0.25.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.28.0


### PR DESCRIPTION
Largely contains a few minor changes and some bug fixes. Brings minimum
version of Go to 1.24.0. See changelog for details.

[skip ci]