### PR TITLE
Always set `updated_at` when upserting periodic jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set `updated_at` when invoking pilot `PeriodicJobUpsert`. [PR #1045](https://github.com/riverqueue/river/pull/1045).
+
 ## [0.25.0] - 2025-09-14
 
 ⚠️ Internal APIs used for communication between River and River Pro have changed. If using River Pro, make sure to update River and River Pro to latest at the same time to get compatible versions. River v0.25.0 is compatible with River Pro v0.18.0.

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -341,6 +341,7 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 					periodicJobUpsertParams.Jobs = append(periodicJobUpsertParams.Jobs, &riverpilot.PeriodicJobUpsertParams{
 						ID:        periodicJob.ID,
 						NextRunAt: periodicJob.nextRunAt,
+						UpdatedAt: s.Time.NowUTC(),
 					})
 				}
 
@@ -405,6 +406,7 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 							periodicJobUpsertParams.Jobs = append(periodicJobUpsertParams.Jobs, &riverpilot.PeriodicJobUpsertParams{
 								ID:        periodicJob.ID,
 								NextRunAt: periodicJob.nextRunAt,
+								UpdatedAt: s.Time.NowUTC(),
 							})
 						}
 					}

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -763,6 +763,10 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		bundle.pilotMock.PeriodicJobUpsertManyMock = func(ctx context.Context, exec riverdriver.Executor, params *riverpilot.PeriodicJobUpsertManyParams) ([]*riverpilot.PeriodicJob, error) {
 			insertedPeriodicJobIDs = append(insertedPeriodicJobIDs, sliceutil.Map(params.Jobs, func(j *riverpilot.PeriodicJobUpsertParams) string { return j.ID }))
 			require.Equal(t, bundle.schema, params.Schema)
+			for _, job := range params.Jobs {
+				require.NotZero(t, job.NextRunAt)
+				require.NotZero(t, job.UpdatedAt)
+			}
 			return nil, nil
 		}
 


### PR DESCRIPTION
Make sure to set `updated_at` when upserting periodic jobs on calls to
the pilot's `PeriodicJobUpsert`. Not having `updated_at` was resulting
in pilots with database backing to store zero values into their rows.