### PR TITLE
JobRescuer: set the rescue count as an int in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The job rescuer now sets `river:rescue_count` with an integer count of how many times the job has been rescued by the `JobRescuer` maintenance process when it's considered stuck. [PR #1047](https://github.com/riverqueue/river/pull/1047).
+
 ### Fixed
 
 - Set `updated_at` when invoking pilot `PeriodicJobUpsert`. [PR #1045](https://github.com/riverqueue/river/pull/1045).

--- a/delete_many_params_test.go
+++ b/delete_many_params_test.go
@@ -3,8 +3,9 @@ package river
 import (
 	"testing"
 
-	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/rivertype"
 )
 
 func TestJobDeleteManyParams_filtersEmpty(t *testing.T) {

--- a/internal/rivercommon/river_common.go
+++ b/internal/rivercommon/river_common.go
@@ -24,6 +24,9 @@ const (
 	// them.
 	MetadataKeyPeriodicJobID = "river:periodic_job_id"
 
+	// MetadataKeyRescueCount records how many times the job has been rescued.
+	MetadataKeyRescueCount = "river:rescue_count"
+
 	// MetadataKeyUniqueNonce is a special metadata key used by the SQLite driver to
 	// determine whether an upsert is was skipped or not because the `(xmax != 0)`
 	// trick we use in Postgres doesn't work in SQLite.

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -1216,6 +1216,16 @@ SET
     errors = array_append(errors, updated_job.error),
     finalized_at = updated_job.finalized_at,
     scheduled_at = updated_job.scheduled_at,
+    metadata = river_job.metadata || jsonb_build_object(
+        'river:rescue_count',
+        coalesce(
+            CASE
+                WHEN jsonb_typeof(river_job.metadata -> 'river:rescue_count') = 'number'
+                    THEN (river_job.metadata ->> 'river:rescue_count')::int
+            END,
+            0
+        ) + 1
+    ),
     state = updated_job.state
 FROM (
     SELECT

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -481,6 +481,16 @@ SET
     errors = array_append(errors, updated_job.error),
     finalized_at = updated_job.finalized_at,
     scheduled_at = updated_job.scheduled_at,
+    metadata = river_job.metadata || jsonb_build_object(
+        'river:rescue_count',
+        coalesce(
+            CASE
+                WHEN jsonb_typeof(river_job.metadata -> 'river:rescue_count') = 'number'
+                    THEN (river_job.metadata ->> 'river:rescue_count')::int
+            END,
+            0
+        ) + 1
+    ),
     state = updated_job.state
 FROM (
     SELECT

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -1183,6 +1183,16 @@ SET
     errors = array_append(errors, updated_job.error),
     finalized_at = updated_job.finalized_at,
     scheduled_at = updated_job.scheduled_at,
+    metadata = river_job.metadata || jsonb_build_object(
+        'river:rescue_count',
+        coalesce(
+            CASE
+                WHEN jsonb_typeof(river_job.metadata -> 'river:rescue_count') = 'number'
+                    THEN (river_job.metadata ->> 'river:rescue_count')::int
+            END,
+            0
+        ) + 1
+    ),
     state = updated_job.state
 FROM (
     SELECT

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
@@ -361,6 +361,17 @@ SET
     errors = json_insert(coalesce(errors, json('[]')), '$[#]', json(cast(@error AS blob))),
     finalized_at = cast(sqlc.narg('finalized_at') as text),
     scheduled_at = @scheduled_at,
+    metadata = json_set(
+        metadata,
+        '$."river:rescue_count"',
+        coalesce(
+            CASE json_type(metadata, '$."river:rescue_count"')
+                WHEN 'integer' THEN json_extract(metadata, '$."river:rescue_count"')
+                WHEN 'real' THEN json_extract(metadata, '$."river:rescue_count"')
+            END,
+            0
+        ) + 1
+    ),
     state = @state
 WHERE id = @id;
 

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
@@ -1021,6 +1021,17 @@ SET
     errors = json_insert(coalesce(errors, json('[]')), '$[#]', json(cast(?1 AS blob))),
     finalized_at = cast(?2 as text),
     scheduled_at = ?3,
+    metadata = json_set(
+        metadata,
+        '$."river:rescue_count"',
+        coalesce(
+            CASE json_type(metadata, '$."river:rescue_count"')
+                WHEN 'integer' THEN json_extract(metadata, '$."river:rescue_count"')
+                WHEN 'real' THEN json_extract(metadata, '$."river:rescue_count"')
+            END,
+            0
+        ) + 1
+    ),
     state = ?4
 WHERE id = ?5
 `

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -1036,7 +1036,7 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		FinalizedAtDoUpdate: params.FinalizedAtDoUpdate,
 		FinalizedAt:         finalizedAt,
 		MaxAttemptsDoUpdate: params.MaxAttemptsDoUpdate,
-		MaxAttempts:         int64(min(params.MaxAttempts, math.MaxInt64)), //nolint:gosec
+		MaxAttempts:         int64(min(params.MaxAttempts, math.MaxInt64)),
 		MetadataDoUpdate:    params.MetadataDoUpdate,
 		Metadata:            metadata,
 		StateDoUpdate:       params.StateDoUpdate,


### PR DESCRIPTION
When rescuing a "stuck" job, set or increment a `river:rescued` metadata key on the job to indicate that it was rescued by the rescuer.