### PR TITLE
Test against Postgres 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # Run the 4 latest Postgres versions against the latest Go version:
+          # Run the latest Go version against all supported Postgres versions:
+          - go-version: "1.25"
+            postgres-version: 18
           - go-version: "1.25"
             postgres-version: 17
           - go-version: "1.25"
@@ -38,9 +40,11 @@ jobs:
           - go-version: "1.25"
             postgres-version: 14
 
-          # Also run the previous Go version against the latest Postgres version:
+          # Also run the previous Go version (the Go version previous to current
+          # is the only other officially supported Go version) against the
+          # latest Postgres version:
           - go-version: "1.24"
-            postgres-version: 17
+            postgres-version: 18
       fail-fast: false
     timeout-minutes: 5
 


### PR DESCRIPTION
Very small one to add Postgres 18, which was released last week, to the
test matrix.

I didn't drop an old version out because I'm not sure what our policy on
that is yet, but we should probably drop old databases only with more
discretion. I'm not sure we want to go all the way with Postgres formal
policy of support [1] (under which Postgres 13 is still supported until
November), but we should probably be fairly generous since databases are
still hard to upgrade, and maybe do a little user outreach before
dropping old versions.

[1] https://www.postgresql.org/support/versioning/