### PR TITLE
Don't convert errors to strings before logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The job rescuer now sets `river:rescue_count` with an integer count of how many times the job has been rescued by the `JobRescuer` maintenance process when it's considered stuck. [PR #1047](https://github.com/riverqueue/river/pull/1047).
 
+### Changed
+
+- Errors returned from job workers are now logged in full using a `slog.Any` attribute. Before, only their error text was logged. [PR #1051](https://github.com/riverqueue/river/pull/1051)
+
 ### Fixed
 
 - Set `updated_at` when invoking pilot `PeriodicJobUpsert`. [PR #1045](https://github.com/riverqueue/river/pull/1045).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Errors returned from job workers are now logged in full using a `slog.Any` attribute. Before, only their error text was logged. [PR #1051](https://github.com/riverqueue/river/pull/1051)
+- Errors returned from job workers are now logged in full using a `slog.Any` attribute. Previously, only their error text was logged. [PR #1051](https://github.com/riverqueue/river/pull/1051).
 
 ### Fixed
 

--- a/riverlog/river_log.go
+++ b/riverlog/river_log.go
@@ -180,7 +180,7 @@ func (m *Middleware) Work(ctx context.Context, job *rivertype.JobRow, doInner fu
 		}))
 		if err != nil {
 			m.Logger.ErrorContext(ctx, m.Name+": Error marshaling log data",
-				slog.String("error", err.Error()),
+				slog.Any("error", err),
 			)
 		}
 


### PR DESCRIPTION
Currently by calling `.Error()` on job worker errors before logging them, data is being thrown away that cannot be used by slog handlers.

I use a structured error library where errors can contain metadata like status codes or user IDs. In my slog handler I can extract these values and e.g. send this on to an error tracking service

But, this metadata isn't present in the basic `.Error()` output and so it's being thrown away by this line which converts the error to a string.

Instead I think you can use the `slog.Any` attribute type instead, by default this will have the same behaviour as the current code (printing out the error text), but allows custom slog handlers to extract the original error type