### PR TITLE
Fix EventKindJobSnoozed detection in `rivertest.Worker`

### DIFF
--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -243,20 +243,24 @@ func completerResultToWorkResult(tb testing.TB, completerResult jobcompleter.Com
 	tb.Helper()
 
 	var kind river.EventKind
-	switch completerResult.Job.State {
-	case rivertype.JobStateCancelled:
-		kind = river.EventKindJobCancelled
-	case rivertype.JobStateCompleted:
-		kind = river.EventKindJobCompleted
-	case rivertype.JobStateScheduled:
+	if completerResult.Snoozed {
 		kind = river.EventKindJobSnoozed
-	case rivertype.JobStateAvailable, rivertype.JobStateDiscarded, rivertype.JobStateRetryable, rivertype.JobStateRunning:
-		kind = river.EventKindJobFailed
-	case rivertype.JobStatePending:
-		panic("test worker internal error: completion subscriber unexpectedly received job in pending state, river bug")
-	default:
-		// linter exhaustive rule prevents this from being reached
-		panic("test worker internal error: unreachable state to distribute, river bug")
+	} else {
+		switch completerResult.Job.State {
+		case rivertype.JobStateCancelled:
+			kind = river.EventKindJobCancelled
+		case rivertype.JobStateCompleted:
+			kind = river.EventKindJobCompleted
+		case rivertype.JobStateScheduled:
+			kind = river.EventKindJobSnoozed
+		case rivertype.JobStateAvailable, rivertype.JobStateDiscarded, rivertype.JobStateRetryable, rivertype.JobStateRunning:
+			kind = river.EventKindJobFailed
+		case rivertype.JobStatePending:
+			panic("test worker internal error: completion subscriber unexpectedly received job in pending state, river bug")
+		default:
+			// linter exhaustive rule prevents this from being reached
+			panic("test worker internal error: unreachable state to distribute, river bug")
+		}
 	}
 
 	return &WorkResult{


### PR DESCRIPTION
TLDR: https://github.com/riverqueue/river/pull/1037 added `CompleterJobUpdated.Snoozed`, which needs to be checked first when determining EventKind.

---

Background: This is a continuation of #1038. I updated to v0.25.0 (now v0.26.0) which should fix the issue, but noticed my tests were still failing. I finally spent some time digging today and realized it's now solely a bug in `rivertest`, a mismatch in behavior between `distributeJobEvent`, which was updated in #1037, and `rivertest`'s `completerResultToWorkResult`, which was left alone.

I wanted to simply reopen #1038 and leave a comment but noticed I don't have the permission to do so, and I don't want a create a new issue, hence the PR. Please feel free to close this PR and open your own since you may want to add tests and stuff.

And here's a minimal, runnable test demonstrating the issue:

```go
package main_test

import (
	"context"
	"fmt"
	"os"
	"testing"
	"time"

	"github.com/jackc/pgx/v5/pgxpool"
	"github.com/riverqueue/river"
	"github.com/riverqueue/river/riverdriver/riverpgxv5"
	"github.com/riverqueue/river/rivermigrate"
	"github.com/riverqueue/river/rivertest"
	"github.com/stretchr/testify/require"
	"github.com/testcontainers/testcontainers-go/modules/postgres"
)

type WorkFuncArgs struct{}

func (WorkFuncArgs) Kind() string { return "work_func" }

var _pool *pgxpool.Pool

func TestMain(m *testing.M) {
	ctx := context.Background()
	ctr, err := postgres.Run(ctx,
		"postgres:17-alpine",
		postgres.BasicWaitStrategies(),
		postgres.WithSQLDriver("pgx"),
	)
	if err != nil {
		panic(err)
	}
	dsn, err := ctr.ConnectionString(ctx)
	if err != nil {
		panic(err)
	}
	config, err := pgxpool.ParseConfig(dsn)
	if err != nil {
		panic(err)
	}
	pool, err := pgxpool.NewWithConfig(ctx, config)
	if err != nil {
		panic(err)
	}

	migrator, err := rivermigrate.New(riverpgxv5.New(pool), &rivermigrate.Config{})
	if err != nil {
		panic(err)
	}
	_, err = migrator.Migrate(ctx, rivermigrate.DirectionUp, nil)
	if err != nil {
		panic(err)
	}

	_pool = pool

	code := m.Run()
	_ = ctr.Terminate(ctx)
	os.Exit(code)
}

func TestShortSnooze(t *testing.T) {
	for i := range 10 {
		t.Run(fmt.Sprintf("snooze %ds", i), func(t *testing.T) {
			ctx := context.Background()
			workFunc := river.WorkFunc(func(ctx context.Context, j *river.Job[WorkFuncArgs]) error {
				return river.JobSnooze(time.Duration(i) * time.Second)
			})
			worker := rivertest.NewWorker(t, riverpgxv5.New(_pool), &river.Config{}, workFunc)
			tx, err := _pool.Begin(ctx)
			require.NoError(t, err)
			t.Cleanup(func() {
				_ = tx.Rollback(ctx)
			})
			result, err := worker.Work(ctx, t, tx, WorkFuncArgs{}, nil)
			require.NoError(t, err)
			require.Equal(t, river.EventKindJobSnoozed, result.EventKind)
		})
	}
}
```

Without the fix:

<details>
<summary>Output</summary>

```
--- FAIL: TestShortSnooze (0.02s)
    --- FAIL: TestShortSnooze/snooze_0s (0.01s)
        main_test.go:79:
            	Error Trace:	/Users/zmwang/Work/riverqueue-short-snooze-bug/main_test.go:79
            	Error:      	Not equal:
            	            	expected: "job_snoozed"
            	            	actual  : "job_failed"

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,2 +1,2 @@
            	            	-(river.EventKind) (len=11) "job_snoozed"
            	            	+(river.EventKind) (len=10) "job_failed"

            	Test:       	TestShortSnooze/snooze_0s
    --- FAIL: TestShortSnooze/snooze_1s (0.00s)
        main_test.go:79:
            	Error Trace:	/Users/zmwang/Work/riverqueue-short-snooze-bug/main_test.go:79
            	Error:      	Not equal:
            	            	expected: "job_snoozed"
            	            	actual  : "job_failed"

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,2 +1,2 @@
            	            	-(river.EventKind) (len=11) "job_snoozed"
            	            	+(river.EventKind) (len=10) "job_failed"

            	Test:       	TestShortSnooze/snooze_1s
    --- FAIL: TestShortSnooze/snooze_2s (0.00s)
        main_test.go:79:
            	Error Trace:	/Users/zmwang/Work/riverqueue-short-snooze-bug/main_test.go:79
            	Error:      	Not equal:
            	            	expected: "job_snoozed"
            	            	actual  : "job_failed"

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,2 +1,2 @@
            	            	-(river.EventKind) (len=11) "job_snoozed"
            	            	+(river.EventKind) (len=10) "job_failed"

            	Test:       	TestShortSnooze/snooze_2s
    --- FAIL: TestShortSnooze/snooze_3s (0.00s)
        main_test.go:79:
            	Error Trace:	/Users/zmwang/Work/riverqueue-short-snooze-bug/main_test.go:79
            	Error:      	Not equal:
            	            	expected: "job_snoozed"
            	            	actual  : "job_failed"

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,2 +1,2 @@
            	            	-(river.EventKind) (len=11) "job_snoozed"
            	            	+(river.EventKind) (len=10) "job_failed"

            	Test:       	TestShortSnooze/snooze_3s
    --- FAIL: TestShortSnooze/snooze_4s (0.00s)
        main_test.go:79:
            	Error Trace:	/Users/zmwang/Work/riverqueue-short-snooze-bug/main_test.go:79
            	Error:      	Not equal:
            	            	expected: "job_snoozed"
            	            	actual  : "job_failed"

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,2 +1,2 @@
            	            	-(river.EventKind) (len=11) "job_snoozed"
            	            	+(river.EventKind) (len=10) "job_failed"

            	Test:       	TestShortSnooze/snooze_4s
    --- FAIL: TestShortSnooze/snooze_5s (0.00s)
        main_test.go:79:
            	Error Trace:	/Users/zmwang/Work/riverqueue-short-snooze-bug/main_test.go:79
            	Error:      	Not equal:
            	            	expected: "job_snoozed"
            	            	actual  : "job_failed"

            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,2 +1,2 @@
            	            	-(river.EventKind) (len=11) "job_snoozed"
            	            	+(river.EventKind) (len=10) "job_failed"

            	Test:       	TestShortSnooze/snooze_5s
FAIL
FAIL	github.com/zmwangx/riverqueue-short-snooze-bug	1.691s
FAIL
```

</details>

With the fix the tests should pass.