### PR TITLE
Add test case checking for snoozed event kind on zero duration snooze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix snoozed events emitted from `rivertest.Worker` when snooze duration is zero seconds. [PR #1057](https://github.com/riverqueue/river/pull/1057).
+
 ## [0.26.0] - 2025-10-07
 
 ⚠️ Internal APIs used for communication between River and River Pro have changed. If using River Pro, make sure to update River and River Pro to latest at the same time to get compatible versions. River v0.26.0 is compatible with River Pro v0.19.0.

--- a/rivertest/worker_test.go
+++ b/rivertest/worker_test.go
@@ -222,13 +222,28 @@ func TestWorker_Work(t *testing.T) {
 		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 	})
 
-	t.Run("ReturnsASnoozeEventKindWhenSnoozed", func(t *testing.T) {
+	t.Run("ReturnsASnoozeEventKindWhenSnoozedNonZeroDuration", func(t *testing.T) {
 		t.Parallel()
 
 		bundle := setup(t)
 
 		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
 			return river.JobSnooze(time.Hour)
+		})
+		tw := NewWorker(t, bundle.driver, bundle.config, worker)
+
+		res, err := tw.Work(ctx, t, bundle.tx, testArgs{Value: "test"}, nil)
+		require.NoError(t, err)
+		require.Equal(t, river.EventKindJobSnoozed, res.EventKind)
+	})
+
+	t.Run("ReturnsASnoozeEventKindWhenSnoozedZeroDuration", func(t *testing.T) {
+		t.Parallel()
+
+		bundle := setup(t)
+
+		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
+			return river.JobSnooze(0)
 		})
 		tw := NewWorker(t, bundle.driver, bundle.config, worker)
 


### PR DESCRIPTION
Quick follow up to add regression coverage for #1057. We already had a
test case in there that checks for snooze events being emitted on a more
normal snooze with non-zero snooze duration, but the problem being fixed
only occurs on zero duration snoozes. Here, add one more test case that
covers that as well.

I also looked into extracting the event-kind-from-job-completer-result
logic so that it could be shared between client and test worker and
prevent this sort of problem down the line, but it's unfortunately made
quite difficult because `river.EventKind*` lives in `river` instead of
`rivertype`, which means that it can't be referenced without making the
top-level `river` a dependency. And if `river` becomes a dependency, a
cyclic dependency is introduced.

Also added a changelog for #1057.