### PR TITLE
Replace `SlogMessageOnlyHandler` with attribute replacement scheme

### DIFF
--- a/example_batch_insert_test.go
+++ b/example_batch_insert_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -45,7 +46,7 @@ func Example_batchInsert() {
 	river.AddWorker(workers, &BatchInsertWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_client_from_context_test.go
+++ b/example_client_from_context_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -53,7 +54,7 @@ func ExampleClientFromContext_pgx() {
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
 		ID:     "ClientFromContextClient",
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},

--- a/example_complete_job_within_tx_test.go
+++ b/example_complete_job_within_tx_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -71,7 +72,7 @@ func Example_completeJobWithinTx() {
 	river.AddWorker(workers, &TransactionalWorker{dbPool: dbPool})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_cron_job_test.go
+++ b/example_cron_job_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/robfig/cron/v3"
@@ -52,7 +53,7 @@ func Example_cronJob() {
 	}
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		PeriodicJobs: []*river.PeriodicJob{
 			river.NewPeriodicJob(
 				schedule,

--- a/example_custom_insert_opts_test.go
+++ b/example_custom_insert_opts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -69,7 +70,7 @@ func Example_customInsertOpts() {
 	river.AddWorker(workers, &SometimesHighPriorityWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 			"high_priority":    {MaxWorkers: 100},

--- a/example_error_handler_test.go
+++ b/example_error_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -74,7 +75,7 @@ func Example_errorHandler() {
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
 		ErrorHandler: &CustomErrorHandler{},
-		Logger:       slog.New(&slogutil.SlogMessageOnlyHandler{Level: 9}), // Suppress logging so example output is cleaner (9 > slog.LevelError).
+		Logger:       slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(9), ReplaceAttr: slogutil.NoLevelTime})), // Suppress logging so example output is cleaner (9 > slog.LevelError).
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},

--- a/example_global_hooks_test.go
+++ b/example_global_hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -73,7 +74,7 @@ func Example_globalHooks() {
 			&InsertBeginHook{},
 			&WorkBeginHook{},
 		},
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_global_middleware_test.go
+++ b/example_global_middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -68,7 +69,7 @@ func Example_globalMiddleware() {
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
 		// Order is significant. See output below.
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Middleware: []rivertype.Middleware{
 			&JobBothInsertAndWorkMiddleware{},
 			&JobInsertMiddleware{},

--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -66,7 +66,7 @@ func Example_gracefulShutdown() {
 	river.AddWorker(workers, &WaitsForCancelOnlyWorker{jobStarted: jobStarted})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTimeJobID})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
@@ -168,5 +168,5 @@ func Example_gracefulShutdown() {
 	// Received SIGINT/SIGTERM; initiating soft stop (try to wait for jobs to finish)
 	// Received SIGINT/SIGTERM again; initiating hard stop (cancel everything)
 	// Job cancelled
-	// jobexecutor.JobExecutor: Job errored; retrying
+	// msg="jobexecutor.JobExecutor: Job errored; retrying" error="context canceled" job_kind=waits_for_cancel_only
 }

--- a/example_insert_and_work_test.go
+++ b/example_insert_and_work_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"sort"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -48,7 +49,7 @@ func Example_insertAndWork() {
 	river.AddWorker(workers, &SortWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_job_args_hooks_test.go
+++ b/example_job_args_hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -91,7 +92,7 @@ func Example_jobArgsHooks() {
 	river.AddWorker(workers, &JobWithHooksWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_job_cancel_from_client_test.go
+++ b/example_job_cancel_from_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -53,7 +54,7 @@ func Example_jobCancelFromClient() {
 	river.AddWorker(workers, &SleepingWorker{jobChan: jobChan})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTimeJobID})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
@@ -99,5 +100,5 @@ func Example_jobCancelFromClient() {
 	}
 
 	// Output:
-	// jobexecutor.JobExecutor: job cancelled remotely
+	// msg="jobexecutor.JobExecutor: job cancelled remotely"
 }

--- a/example_job_cancel_test.go
+++ b/example_job_cancel_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -49,7 +50,7 @@ func Example_jobCancel() { //nolint:dupl
 	river.AddWorker(workers, &CancellingWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},

--- a/example_job_snooze_test.go
+++ b/example_job_snooze_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -51,7 +52,7 @@ func Example_jobSnooze() { //nolint:dupl
 	river.AddWorker(workers, &SnoozingWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},

--- a/example_periodic_job_test.go
+++ b/example_periodic_job_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -45,7 +46,7 @@ func Example_periodicJob() {
 	river.AddWorker(workers, &PeriodicJobWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		PeriodicJobs: []*river.PeriodicJob{
 			river.NewPeriodicJob(
 				river.PeriodicInterval(15*time.Minute),

--- a/example_queue_pause_test.go
+++ b/example_queue_pause_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -56,7 +57,7 @@ func Example_queuePause() {
 	river.AddWorker(workers, &ReportingWorker{jobWorkedCh: jobWorkedCh})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			unreliableQueue: {MaxWorkers: 10},
 			reliableQueue:   {MaxWorkers: 10},

--- a/example_scheduled_job_test.go
+++ b/example_scheduled_job_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -46,7 +47,7 @@ func Example_scheduledJob() {
 	river.AddWorker(workers, &ScheduledWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_subscription_test.go
+++ b/example_subscription_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -53,7 +54,7 @@ func Example_subscription() {
 	river.AddWorker(workers, &SubscriptionWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: 9}), // Suppress logging so example output is cleaner (9 > slog.LevelError).
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(9), ReplaceAttr: slogutil.NoLevelTime})), // Suppress logging so example output is cleaner (9 > slog.LevelError).
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_unique_job_test.go
+++ b/example_unique_job_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -76,7 +77,7 @@ func Example_uniqueJob() {
 	river.AddWorker(workers, &ReconcileAccountWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/example_work_func_test.go
+++ b/example_work_func_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -40,7 +41,7 @@ func Example_workFunc() {
 	}))
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/riverdriver/riverdatabasesql/example_client_from_context_database_sql_test.go
+++ b/riverdriver/riverdatabasesql/example_client_from_context_database_sql_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -55,7 +56,7 @@ func ExampleClientFromContext_databaseSQL() {
 
 	riverClient, err := river.NewClient(riverdatabasesql.New(db), &river.Config{
 		ID:     "ClientFromContextClientSQL",
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},

--- a/riverdriver/riverdrivertest/example_libsql_test.go
+++ b/riverdriver/riverdrivertest/example_libsql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"os"
 
 	_ "github.com/tursodatabase/libsql-client-go/libsql"
 
@@ -36,7 +37,7 @@ func Example_libSQL() { //nolint:dupl
 	river.AddWorker(workers, &SortWorker{})
 
 	riverClient, err := river.NewClient(driver, &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/riverdriver/riverdrivertest/example_sqlite_test.go
+++ b/riverdriver/riverdrivertest/example_sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"os"
 	"sort"
 
 	_ "modernc.org/sqlite"
@@ -56,7 +57,7 @@ func Example_sqlite() { //nolint:dupl
 	river.AddWorker(workers, &SortWorker{})
 
 	riverClient, err := river.NewClient(driver, &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
@@ -99,7 +100,7 @@ func migrateDB(ctx context.Context, driver riverdriver.Driver[*sql.Tx]) error {
 	// We're using an in-memory SQLite database here, so we need to migrate it
 	// up before use. This won't generally be needed outside of tests.
 	migrator, err := rivermigrate.New(driver, &rivermigrate.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 	})
 	if err != nil {
 		return err

--- a/riverlog/example_new_middleware_custom_context_test.go
+++ b/riverlog/example_new_middleware_custom_context_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -54,7 +55,7 @@ func ExampleNewMiddlewareCustomContext() {
 	river.AddWorker(workers, &CustomContextLoggingWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},

--- a/riverlog/river_log_test.go
+++ b/riverlog/river_log_test.go
@@ -69,7 +69,7 @@ func TestMiddleware(t *testing.T) {
 		var (
 			driver     = riverpgxv5.New(nil)
 			middleware = NewMiddleware(func(w io.Writer) slog.Handler {
-				return &slogutil.SlogMessageOnlyHandler{Out: w}
+				return slog.NewTextHandler(w, &slog.HandlerOptions{ReplaceAttr: slogutil.NoLevelTime})
 			}, config)
 			clientConfig = &river.Config{
 				Middleware: []rivertype.Middleware{middleware},
@@ -100,7 +100,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, []logAttempt{
 			{
 				Attempt: 1,
-				Log:     "Logged from worker\n",
+				Log:     `msg="Logged from worker"` + "\n",
 			},
 		},
 			metadataWithLog.RiverLog,
@@ -135,11 +135,11 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, []logAttempt{
 			{
 				Attempt: 1,
-				Log:     "Logged from worker\n",
+				Log:     `msg="Logged from worker"` + "\n",
 			},
 			{
 				Attempt: 2,
-				Log:     "Logged from worker\n",
+				Log:     `msg="Logged from worker"` + "\n",
 			},
 		},
 			metadataWithLog.RiverLog,
@@ -160,7 +160,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, []logAttempt{
 			{
 				Attempt: 1,
-				Log:     "Logged from worker\n",
+				Log:     `msg="Logged from worker"` + "\n",
 			},
 		},
 			metadataWithLog.RiverLog,
@@ -183,7 +183,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, []logAttempt{
 			{
 				Attempt: 1,
-				Log:     "Logged from worker\n",
+				Log:     `msg="Logged from worker"` + "\n",
 			},
 		},
 			metadataWithLog.RiverLog,
@@ -205,7 +205,7 @@ func TestMiddleware(t *testing.T) {
 		t.Parallel()
 
 		testWorker, bundle := setup(t, &MiddlewareConfig{
-			MaxSizeBytes: 11,
+			MaxSizeBytes: 16,
 		})
 
 		workRes, err := testWorker.Work(ctx, t, bundle.tx, loggingArgs{Message: "Logged from worker"}, nil)
@@ -217,7 +217,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, []logAttempt{
 			{
 				Attempt: 1,
-				Log:     "Logged from",
+				Log:     `msg="Logged from`,
 			},
 		},
 			metadataWithLog.RiverLog,

--- a/rivershared/util/slogutil/slog_util.go
+++ b/rivershared/util/slogutil/slog_util.go
@@ -1,16 +1,35 @@
 package slogutil
 
 import (
-	"context"
-	"fmt"
-	"io"
 	"log/slog"
-	"os"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 )
+
+// Standard functions suitable for use with slog.HandlerOptions.ReplaceAttr that
+// remove certain log keys for better test output stability. Prefer NoLevelTime
+// unless you also have `job_id` in output, then use the latter.
+var (
+	NoLevelTime      = removeReplaceAttrFunc(slog.LevelKey, slog.TimeKey)           //nolint:gochecknoglobals
+	NoLevelTimeJobID = removeReplaceAttrFunc(slog.LevelKey, slog.TimeKey, "job_id") //nolint:gochecknoglobals
+)
+
+// Produces a function suitable for use with slog.HandlerOptions.ReplaceAttr
+// that removes the given attrKeys from all log entries. Generally used to
+// remove keys like level and time for more stable logging for tests.
+func removeReplaceAttrFunc(attrKeys ...string) func(groups []string, attr slog.Attr) slog.Attr {
+	return func(groups []string, attr slog.Attr) slog.Attr {
+		if len(groups) < 1 {
+			if slices.Contains(attrKeys, attr.Key) {
+				return slog.Attr{}
+			}
+		}
+		return attr
+	}
+}
 
 // SliceInt64 is a type that implements slog.LogValue and which will format a
 // slice for inclusion in logging, but lazily so that no work is done unless a
@@ -32,29 +51,3 @@ type SliceString []string
 func (s SliceString) LogValue() slog.Value {
 	return slog.StringValue(strings.Join(s, ","))
 }
-
-// SlogMessageOnlyHandler is a trivial slog handler that prints only messages.
-// All attributes and groups are ignored. It's useful in example tests where it
-// produces output that's normalized so we match against it (normally, all log
-// lines include timestamps so it's not possible to have reproducible output).
-type SlogMessageOnlyHandler struct {
-	Level slog.Level
-	Out   io.Writer
-}
-
-func (h *SlogMessageOnlyHandler) Enabled(ctx context.Context, level slog.Level) bool {
-	return level >= h.Level
-}
-
-func (h *SlogMessageOnlyHandler) Handle(ctx context.Context, record slog.Record) error {
-	w := h.Out
-	if w == nil {
-		w = os.Stdout
-	}
-
-	fmt.Fprintf(w, "%s\n", record.Message)
-	return nil
-}
-
-func (h *SlogMessageOnlyHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
-func (h *SlogMessageOnlyHandler) WithGroup(name string) slog.Handler       { return h }

--- a/rivertest/example_require_inserted_test.go
+++ b/rivertest/example_require_inserted_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -49,7 +50,7 @@ func Example_requireInserted() {
 	)
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger:   slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger:   slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Schema:   schema, // only necessary for the example test
 		TestOnly: true,   // suitable only for use in tests; remove for live environments
 		Workers:  workers,

--- a/rivertest/example_require_many_inserted_test.go
+++ b/rivertest/example_require_many_inserted_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -67,7 +68,7 @@ func Example_requireManyInserted() {
 	)
 
 	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger:  slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger:  slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Schema:  schema, // only necessary for the example test
 		Workers: workers,
 	})


### PR DESCRIPTION
Here, replace with the utility `SlogMessageOnlyHandler` that we use in
example tests with a `ReplaceAttr` implementation instead so that we use
a standard `TextHandler` with a `ReplaceAttr`:

``` diff
-		Logger: slog.New(&slogutil.SlogMessageOnlyHandler{Level: slog.LevelWarn}),
+		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTimeJobID})),
```

The major benefit of this approach is that in case of an error (where
the error detail gets put in a key of the output log), we don't end up
hiding the detail and making the error difficult to debug without
removing the message-only handler.

It also has the nominal advantage of being a little more standard, i.e.
Uses normal `slog` handlers instead of a custom one, and is a little
more succinct to write.