### PR TITLE
Remove IDs from ID map when periodic jobs with IDs are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix snoozed events emitted from `rivertest.Worker` when snooze duration is zero seconds. [PR #1057](https://github.com/riverqueue/river/pull/1057).
 - Rollbacks now use an uncancelled context so as to not leave transactions in an ambiguous state if a transaction in them fails due to context cancellation. [PR #1062](https://github.com/riverqueue/river/pull/1062).
+- Removing periodic jobs with IDs assigned also remove them from ID map. [PR #1070](https://github.com/riverqueue/river/pull/1070).
 
 ## [0.26.0] - 2025-10-07
 

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -585,6 +585,23 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		require.Len(t, svc.periodicJobs, 1)
 	})
 
+	t.Run("RemoveWithID", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t)
+
+		handles, err := svc.AddManySafely([]*PeriodicJob{
+			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false), ID: "periodic_job_500ms"},
+			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), ID: "periodic_job_500ms_start", RunOnStart: true},
+		})
+		require.NoError(t, err)
+
+		svc.Remove(handles[1])
+
+		require.Len(t, svc.periodicJobIDs, 1)
+		require.Len(t, svc.periodicJobs, 1)
+	})
+
 	t.Run("RemoveManyAfterStart", func(t *testing.T) {
 		t.Parallel()
 
@@ -606,6 +623,24 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc.RemoveMany([]rivertype.PeriodicJobHandle{handles[1], handles[2]})
 
+		require.Len(t, svc.periodicJobs, 1)
+	})
+
+	t.Run("RemoveManyWithID", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t)
+
+		handles, err := svc.AddManySafely([]*PeriodicJob{
+			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false), ID: "periodic_job_500ms"},
+			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_other", false), ID: "periodic_job_500ms_other"},
+			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms_start", false), ID: "periodic_job_500ms_start", RunOnStart: true},
+		})
+		require.NoError(t, err)
+
+		svc.RemoveMany([]rivertype.PeriodicJobHandle{handles[1], handles[2]})
+
+		require.Len(t, svc.periodicJobIDs, 1)
 		require.Len(t, svc.periodicJobs, 1)
 	})
 


### PR DESCRIPTION
While implementing another feature I found a little bug in the periodic
job enqueuer in which when removing periodic jobs that have IDs assigned
(i.e. for durable jobs), the IDs weren't being removed from the enqueuer's
internal ID map. Here, fix the problem.