### PR TITLE
Allow removing periodic jobs by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Periodic jobs with IDs may now be removed by ID using the new `PeriodicJobBundle.RemoveByID` and `PeriodicJobBundle.RemoveManyByID`. [PR #1071](https://github.com/riverqueue/river/pull/1071).
+
 ### Fixed
 
 - Fix snoozed events emitted from `rivertest.Worker` when snooze duration is zero seconds. [PR #1057](https://github.com/riverqueue/river/pull/1057).

--- a/periodic_job.go
+++ b/periodic_job.go
@@ -190,6 +190,21 @@ func (b *PeriodicJobBundle) Remove(periodicJobHandle rivertype.PeriodicJobHandle
 	b.periodicJobEnqueuer.Remove(periodicJobHandle)
 }
 
+// RemoveByID removes a periodic job by ID, cancelling all scheduled runs.
+//
+// Adding or removing periodic jobs has no effect unless this client is elected
+// leader because only the leader enqueues periodic jobs. To make sure that a
+// new periodic job is fully enabled or disabled, it should be added or removed
+// from _every_ active River client across all processes.
+//
+// Has no effect if no jobs with the given ID is configured.
+//
+// Returns true if a job with the given ID existed (and was removed), and false
+// otherwise.
+func (b *PeriodicJobBundle) RemoveByID(id string) bool {
+	return b.periodicJobEnqueuer.RemoveByID(id)
+}
+
 // RemoveMany removes many periodic jobs, cancelling all scheduled runs.
 //
 // Requires the use of the periodic job handles that were returned when the jobs
@@ -201,6 +216,19 @@ func (b *PeriodicJobBundle) Remove(periodicJobHandle rivertype.PeriodicJobHandle
 // from _every_ active River client across all processes.
 func (b *PeriodicJobBundle) RemoveMany(periodicJobHandles []rivertype.PeriodicJobHandle) {
 	b.periodicJobEnqueuer.RemoveMany(periodicJobHandles)
+}
+
+// RemoveManyByID removes many periodic jobs by ID, cancelling all scheduled
+// runs.
+//
+// Adding or removing periodic jobs has no effect unless this client is elected
+// leader because only the leader enqueues periodic jobs. To make sure that a
+// new periodic job is fully enabled or disabled, it should be added or removed
+// from _every_ active River client across all processes.
+//
+// Has no effect if no jobs with the given IDs are configured.
+func (b *PeriodicJobBundle) RemoveManyByID(ids []string) {
+	b.periodicJobEnqueuer.RemoveManyByID(ids)
 }
 
 // An empty set of periodic job opts used as a default when none are specified.


### PR DESCRIPTION
Here, we add two new functions to `PeriodicJobBundle`:

* `RemoveByID`
* `RemoveManyByID`

These are in addition to the existing `Remove` and `RemoveMany`.

The new variants are useful in cases where durable jobs are in use.
Tracking jobs by ID rather than handle may be more convenient, and
provides a stable identifier across multiple runs. IDs were added after
jobs could be added or removed dynamically, so even where durable jobs
aren't in use, it may still be more convenient to remove them by ID.

Unlike `Remove`, I've made `RemoveByID` return a boolean indicating
whether the removal happened or not. We may want to add this to `Remove`
as well given it's a useful feature, but I didn't do so for now as
adding a return value could be considered a minor breaking change.

Notably in the case of durable periodic jobs, removing a job by ID
doesn't immediately remove it from the database. This still relies on
the existing system of allowing unconfigured durable periodic jobs
records to be pruned over time. We'll see if a database removal has to
be a hard requirement from those requesting this feature, but not
needing a database call makes things considerably simpler because
(1) there's no risk of contention if a job is removed across multiple
clients, and (2) no error return is necessary.