### PR TITLE
Correct uniqueness annotations for fields in substructs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix snoozed events emitted from `rivertest.Worker` when snooze duration is zero seconds. [PR #1057](https://github.com/riverqueue/river/pull/1057).
 - Rollbacks now use an uncancelled context so as to not leave transactions in an ambiguous state if a transaction in them fails due to context cancellation. [PR #1062](https://github.com/riverqueue/river/pull/1062).
 - Removing periodic jobs with IDs assigned also remove them from ID map. [PR #1070](https://github.com/riverqueue/river/pull/1070).
+- `river:"unique"` annotations on substructs within `JobArgs` structs are now factored into uniqueness `ByArgs` calculations. [PR #1076](https://github.com/riverqueue/river/pull/1076).
 
 ## [0.26.0] - 2025-10-07
 

--- a/insert_opts.go
+++ b/insert_opts.go
@@ -114,7 +114,7 @@ type UniqueOpts struct {
 	//
 	// 	type MyJobArgs struct {
 	// 		CustomerID string `json:"customer_id" river:"unique"`
-	// 		TraceID string `json:"trace_id"
+	// 		TraceID    string `json:"trace_id"
 	// 	}
 	//
 	// In this example, only the encoded `customer_id` key will be included in the
@@ -122,6 +122,40 @@ type UniqueOpts struct {
 	//
 	// All keys are sorted alphabetically before hashing to ensure consistent
 	// results.
+	//
+	// River recurses into embedded structs and fields with struct values and
+	// looks for `river:"unique"` annotations on them as well:
+	//
+	// 	type MyJobArgs struct {
+	// 		Customer *Customer `json:"customer"`
+	// 		TraceID  string    `json:"trace_id"
+	// 	}
+	//
+	// 	type Customer struct {
+	// 		ID string `json:"id" river:"unique"`
+	// 	}
+	//
+	// In this example, the `id` value inside a `customer` subboject is used in
+	// the uniqueness check. It'd be the same story if Customer was embedded on
+	// MyJobArgs instead:
+	//
+	// 	type MyJobArgs struct {
+	// 		Customer
+	// 		TraceID string `json:"trace_id"
+	// 	}
+	//
+	// If the struct field itself has a `river:"unique"` annotation, but none on
+	// any fields in the substruct, then the entire JSON encoded value of the
+	// struct is used as a unique value:
+	//
+	// 	type MyJobArgs struct {
+	// 		Customer *Customer `json:"customer" river:"unique"`
+	// 		TraceID  string    `json:"trace_id"
+	// 	}
+	//
+	// 	type Customer struct {
+	// 		ID string `json:"id"`
+	// 	}
 	ByArgs bool
 
 	// ByPeriod defines uniqueness within a given period. On an insert time is

--- a/internal/dbunique/db_unique_test.go
+++ b/internal/dbunique/db_unique_test.go
@@ -123,6 +123,192 @@ func TestUniqueKey(t *testing.T) {
 			expectedJSON: `&kind=worker_1&args={"recipient":"john@example.com","subject":"Another Test Email"}`,
 		},
 		{
+			name: "ByArgsWithSubstructNonPointer",
+			argsFunc: func() rivertype.JobArgs {
+				type EmailAddresses struct {
+					Recipient string `json:"recipient" river:"unique"`
+					BCC       string `json:"bcc"`
+				}
+				type EmailJobArgs struct {
+					JobArgsStaticKind
+
+					Addresses EmailAddresses `json:"addresses"`
+					Subject   string         `json:"subject"   river:"unique"`
+					Body      string         `json:"body"`
+				}
+				return &EmailJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_1"},
+					Addresses: EmailAddresses{
+						Recipient: "john@example.com",
+					},
+					Subject: "Another Test Email",
+					Body:    "This is another test email.",
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_1&args={"addresses":{"recipient":"john@example.com"},"subject":"Another Test Email"}`,
+		},
+		{
+			name: "ByArgsWithSubstructPointer",
+			argsFunc: func() rivertype.JobArgs {
+				type EmailAddresses struct {
+					Recipient string `json:"recipient" river:"unique"`
+					BCC       string `json:"bcc"`
+				}
+				type EmailJobArgs struct {
+					JobArgsStaticKind
+
+					Addresses *EmailAddresses `json:"addresses"`
+					Subject   string          `json:"subject"   river:"unique"`
+					Body      string          `json:"body"`
+				}
+				return &EmailJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_1"},
+					Addresses: &EmailAddresses{
+						Recipient: "john@example.com",
+					},
+					Subject: "Another Test Email",
+					Body:    "This is another test email.",
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_1&args={"addresses":{"recipient":"john@example.com"},"subject":"Another Test Email"}`,
+		},
+		{
+			name: "ByArgsWithEmbeddedSubstruct",
+			argsFunc: func() rivertype.JobArgs {
+				type EmailAddresses struct {
+					Recipient string `json:"recipient" river:"unique"`
+					BCC       string `json:"bcc"`
+				}
+				type EmailJobArgs struct {
+					EmailAddresses
+					JobArgsStaticKind
+
+					Subject string `json:"subject" river:"unique"`
+					Body    string `json:"body"`
+				}
+				return &EmailJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_1"},
+					EmailAddresses: EmailAddresses{
+						Recipient: "john@example.com",
+					},
+					Subject: "Another Test Email",
+					Body:    "This is another test email.",
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_1&args={"recipient":"john@example.com","subject":"Another Test Email"}`,
+		},
+		{
+			name: "ByArgsWithSubstructTagged",
+			argsFunc: func() rivertype.JobArgs {
+				type EmailAddresses struct {
+					Recipient string `json:"recipient" river:"unique"`
+					BCC       string `json:"bcc"`
+				}
+				type EmailJobArgs struct {
+					JobArgsStaticKind
+
+					Addresses EmailAddresses `json:"addresses" river:"unique"`
+					Subject   string         `json:"subject"   river:"unique"`
+					Body      string         `json:"body"`
+				}
+				return &EmailJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_1"},
+					Addresses: EmailAddresses{
+						Recipient: "john@example.com",
+					},
+					Subject: "Another Test Email",
+					Body:    "This is another test email.",
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_1&args={"addresses":{"recipient":"john@example.com"},"subject":"Another Test Email"}`,
+		},
+		{
+			name: "ByArgsWithAllSubstructUntagged",
+			argsFunc: func() rivertype.JobArgs {
+				type EmailAddresses struct {
+					Recipient string `json:"recipient"`
+					BCC       string `json:"bcc"`
+				}
+				type EmailJobArgs struct {
+					JobArgsStaticKind
+
+					Addresses *EmailAddresses `json:"addresses" river:"unique"`
+					Subject   string          `json:"subject"   river:"unique"`
+					Body      string          `json:"body"`
+				}
+				return &EmailJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_1"},
+					Addresses: &EmailAddresses{
+						Recipient: "john@example.com",
+					},
+					Subject: "Another Test Email",
+					Body:    "This is another test email.",
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_1&args={"addresses":{"recipient":"john@example.com","bcc":""},"subject":"Another Test Email"}`,
+		},
+		{
+			name: "ByArgsWithMultiLevelSubstructPointer",
+			argsFunc: func() rivertype.JobArgs {
+				type EmailAddresses struct {
+					Recipient string `json:"recipient" river:"unique"`
+				}
+				type EmailHeaders struct {
+					Addresses *EmailAddresses `json:"addresses" river:"unique"`
+					Subject   string          `json:"subject"   river:"unique"`
+				}
+				type EmailJobArgs struct {
+					JobArgsStaticKind
+
+					Headers *EmailHeaders `json:"headers" river:"unique"`
+					Body    string        `json:"body"`
+				}
+				return &EmailJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_1"},
+					Headers: &EmailHeaders{
+						Addresses: &EmailAddresses{
+							Recipient: "john@example.com",
+						},
+						Subject: "Another Test Email",
+					},
+					Body: "This is another test email.",
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_1&args={"headers":{"addresses":{"recipient":"john@example.com"},"subject":"Another Test Email"}}`,
+		},
+		{
+			name: "ByArgsUnexportedSkipped",
+			argsFunc: func() rivertype.JobArgs {
+				type EmailAddresses struct {
+					Recipient string `json:"recipient" river:"unique"`
+					BCC       string `json:"bcc"`
+				}
+				type EmailJobArgs struct {
+					JobArgsStaticKind
+
+					Subject   string `json:"subject" river:"unique"`
+					Body      string `json:"body"`
+					addresses EmailAddresses
+				}
+				return &EmailJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_1"},
+					Subject:           "Another Test Email",
+					Body:              "This is another test email.",
+					addresses: EmailAddresses{
+						Recipient: "john@example.com",
+					},
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_1&args={"subject":"Another Test Email"}`,
+		},
+		{
 			name: "ByArgsWithNoUniqueFields",
 			argsFunc: func() rivertype.JobArgs {
 				type GenericJobArgs struct {


### PR DESCRIPTION
This one's aimed at fixing #1075. A deficiency in the previous unique
field implementation is that only top-level args fields were considered.
Anything unique annotations in a field substruct or an embedded
substruct were skipped.

Here, we change the reflect algorithm so that it descends into structs
recursively, similar to the behavior of `encoding/json` or other
reflect-based packages. See the new test cases for the specifics of how
this works.

We try to maintain backwards compatibility so that if a substruct is
tagged with `river:"unique"`, but none of the fields in the substruct
are, we use the entire JSON-encoded value of the substruct for
uniqueness calculations, exactly like how it worked before this change.
If previously there were `river:"unique"` annotations on subfields,
behavior will change, but I think this is for the best because as
described in #1075, River was almost certainly not doing what the user
would've expected, thereby possibly creating an accidental bug.