### PR TITLE
Add client mechanism to tell leader to remove periodic from any client

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -25,12 +25,14 @@ const (
 	NotificationTopicControl    NotificationTopic = "river_control"
 	NotificationTopicInsert     NotificationTopic = "river_insert"
 	NotificationTopicLeadership NotificationTopic = "river_leadership"
+	NotificationTopicPeriodic   NotificationTopic = "river_periodic" // "periodic" instead of "periodic_job" because we must keep topic names short
 )
 
 var notificationTopicAll = []NotificationTopic{ //nolint:gochecknoglobals
 	NotificationTopicControl,
 	NotificationTopicInsert,
 	NotificationTopicLeadership,
+	NotificationTopicPeriodic,
 }
 
 // NotificationTopicLongest is just the longest notification topic. This is used
@@ -360,6 +362,8 @@ func (n *Notifier) waitOnce(ctx context.Context) error {
 				return
 			}
 
+			fmt.Printf("--- notifier got notification: %+v\n\n", notification.Payload)
+
 			select {
 			case n.notificationBuf <- notification:
 			default:
@@ -471,6 +475,8 @@ func (n *Notifier) Listen(ctx context.Context, topic NotificationTopic, notifyFu
 	// By the time this function is run (i.e. after an interrupt), a lock on
 	// `n.mu` has been reacquired, and modifying subscription state is safe.
 	removeSub := func() { n.removeSubscription(ctx, sub) }
+
+	fmt.Printf("--- existingTopic: %+v\n\n", existingTopic)
 
 	if !existingTopic {
 		// If already waiting, send an interrupt to the wait function to run a


### PR DESCRIPTION
This is once again in pursuit of solving a particular user's use case.
We currently have mechanisms that to add and remove periodic jobs to a
client, but these functions are only effective on the client which is
elected leader. In a multi-node system this can make things difficult
because it means that all operations have to be run on every known
client.

Here, introduce a system whereby the periodic job enqueuer starts
listening on a Postgres channel and we give the client a way of
notifying.

When it comes to sending notification, the most obvious place to send a
removal would be when you do a `client.PeriodicJobs().RemoveByID(...)`.
However, I'm reluctant to add a notification there because Postgres
notifications have such specific semantics about being runnable in or
out of a transaction. If we sent it in `RemoveByID` then we'd also need
to add a `RemoveByIDTx`, and things really get messy quickly from there.

So here I'm proposing something much more generic, which is the addition
of a top level `Notify` to the River client. So we get:

    client.Notify(ctx, NotifyKindPeriodicJobRemove, "my_periodic_job")

The idea is that we make this generic enough so that we could add other
sorts of notifications in the future (brought in very carefully on a
case by case basis). The payload argument is of type `any` so that it
could take specific multi-field structs for more complex operations.