### PR TITLE
Stop subservices and embedded `baseservice.Service` on periodic jobs enqueuer start error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rollbacks now use an uncancelled context so as to not leave transactions in an ambiguous state if a transaction in them fails due to context cancellation. [PR #1062](https://github.com/riverqueue/river/pull/1062).
 - Removing periodic jobs with IDs assigned also remove them from ID map. [PR #1070](https://github.com/riverqueue/river/pull/1070).
 - `river:"unique"` annotations on substructs within `JobArgs` structs are now factored into uniqueness `ByArgs` calculations. [PR #1076](https://github.com/riverqueue/river/pull/1076).
+- Stop subservices and embedded `baseservice.Service` on error in the event of a periodic job enqueuer start error. [PR #1081](https://github.com/riverqueue/river/pull/1081).
 
 ## [0.26.0] - 2025-10-07
 

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -310,7 +310,12 @@ func (s *PeriodicJobEnqueuer) Start(ctx context.Context) error {
 	subServices := []startstop.Service{
 		startstop.StartStopFunc(s.periodicJobKeepAliveAndReapPeriodically),
 	}
+	stopServicesOnError := func() {
+		startstop.StopAllParallel(subServices...)
+	}
 	if err := startstop.StartAll(ctx, subServices...); err != nil {
+		stopServicesOnError()
+		stopped()
 		return err
 	}
 


### PR DESCRIPTION
Just a small one where in the very rare event of a start error from the
periodic jobs enqueuer, make sure to stop all subservices and stop the
`baseservice.Service`. In practice this won't matter much because
there's only one subservice currently that can error, but it might
matter in the future in case more subservices are added.