### PR TITLE
Clear ID map on periodic jobs bundle clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix snoozed events emitted from `rivertest.Worker` when snooze duration is zero seconds. [PR #1057](https://github.com/riverqueue/river/pull/1057).
 - Rollbacks now use an uncancelled context so as to not leave transactions in an ambiguous state if a transaction in them fails due to context cancellation. [PR #1062](https://github.com/riverqueue/river/pull/1062).
 - Removing periodic jobs with IDs assigned also remove them from ID map. [PR #1070](https://github.com/riverqueue/river/pull/1070).
+- Clear periodic jobs also fully clears all those assigned with an ID. [PR #1083](https://github.com/riverqueue/river/pull/1083).
 - `river:"unique"` annotations on substructs within `JobArgs` structs are now factored into uniqueness `ByArgs` calculations. [PR #1076](https://github.com/riverqueue/river/pull/1076).
 
 ## [0.26.0] - 2025-10-07

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -236,6 +236,8 @@ func (s *PeriodicJobEnqueuer) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.periodicJobIDs = make(map[string]rivertype.PeriodicJobHandle)
+
 	// `nextHandle` is _not_ reset so that even across multiple generations of
 	// jobs, handles aren't reused.
 	s.periodicJobs = make(map[rivertype.PeriodicJobHandle]*PeriodicJob)

--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -551,6 +551,7 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 
 		svc.Clear()
 
+		require.Empty(t, svc.periodicJobIDs)
 		require.Empty(t, svc.periodicJobs)
 
 		handleAfterClear, err := svc.AddSafely(


### PR DESCRIPTION
This is another bug similar to the one fixed in #1070. When clearing
periodic jobs we were only clearing the handle -> job map and not the
secondary map of periodic job IDs.