### PR TITLE
Unique args: Handle embedded field that is *not* a struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Unique args: Handle embedded fields that are not structs. [PR #1088](https://github.com/riverqueue/river/pull/1088).
+
 ## [0.27.0] - 2025-11-14
 
 ### Added

--- a/internal/dbunique/db_unique_test.go
+++ b/internal/dbunique/db_unique_test.go
@@ -201,6 +201,22 @@ func TestUniqueKey(t *testing.T) {
 			expectedJSON: `&kind=worker_1&args={"recipient":"john@example.com","subject":"Another Test Email"}`,
 		},
 		{
+			name: "ByArgsWithEmbeddedNonStruct",
+			argsFunc: func() rivertype.JobArgs {
+				type MyString string
+				type TaskJobArgs struct {
+					JobArgsStaticKind
+					MyString // anonymous non-struct field; needs to be a custom type because it has to be capitalized to be exported
+				}
+				return TaskJobArgs{
+					JobArgsStaticKind: JobArgsStaticKind{kind: "worker_7"},
+					MyString:          "my_string_in_anonymous_field",
+				}
+			},
+			uniqueOpts:   UniqueOpts{ByArgs: true},
+			expectedJSON: `&kind=worker_7&args={"MyString":"my_string_in_anonymous_field"}`,
+		},
+		{
 			name: "ByArgsWithSubstructTagged",
 			argsFunc: func() rivertype.JobArgs {
 				type EmailAddresses struct {


### PR DESCRIPTION
Aims to fix #1087.

One thing I hadn't accounted for is that it's actually possible to have
an embedded type that's *not* a struct. e.g.

    type MyStruct struct {
        string // embedded non-struct
    }

The simplified example above is *not* because we short circuit unless
properties are exported (and `string` is not exported because it starts
with a lower case letter), but if we have a similar case with a custom
type (e.g. `type MyString string`) then we can reproduce the error
described in #1087.

Fix the problem by making sure to check that a field is really a struct
before recursing back into `getSortedUniqueFields`. We're able to
simplify the function somewhat by handling all structs (anonymous or
not) in one spot since the logic is so similar.

Fixes #1087.