### PR TITLE
Remove impossible `nil` checks

### DIFF
--- a/internal/dbunique/unique_fields.go
+++ b/internal/dbunique/unique_fields.go
@@ -44,12 +44,12 @@ func extractUniqueValues(encodedArgs []byte, uniqueKeys []string) []string {
 // The return values are the JSON keys using the same logic as the `json` struct tag.
 func getSortedUniqueFields(typ reflect.Type, path []string) ([]string, error) {
 	// Handle pointer to struct
-	if typ != nil && typ.Kind() == reflect.Ptr {
+	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 	}
 
 	// Ensure we're dealing with a struct
-	if typ == nil || typ.Kind() != reflect.Struct {
+	if typ.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("expected struct, got %T", typ.Name())
 	}
 


### PR DESCRIPTION
I just noticed while reading the unique field code that we seemed to
have a bug:

    if typ == nil || typ.Kind() != reflect.Struct {
            return nil, fmt.Errorf("expected struct, got %T", typ.Name())
    }

If the first condition of `typ == nil` were to be taken, the line below
would panic on `typ.Name()` because `typ` was `nil`.

The fact that nothing is panicking and no panics have been reported
seems to suggest that this case never actually happens. Indeed, reading
code that calls into this function, there's no place where a `nil` type
could ever be returned (`field.Type` which will always have a type and
`reflect.TypeOf(...)` which would return `nil` in the case of
`reflect.TypeOf(nil)`, but because we've already called `args.Kind()`
before ever getting to this function, that will never be possible).