### PR TITLE
Unique args: Guard against recursive types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Unique args: Handle embedded fields that are not structs. [PR #1088](https://github.com/riverqueue/river/pull/1088).
+- Fix stack overflow when handling `river:"unique"` annotations on recursive types. [PR #1090](https://github.com/riverqueue/river/pull/1090).
 
 ## [0.27.0] - 2025-11-14
 


### PR DESCRIPTION
Also reported over in #1087, the unique module will overflow if
encountering a recursive type as it looks for unique keys to consider.

Here, try to be a little smarter about this, but not overly so by only
processing each type once. This means that inner recursive types always
just get treatment as a fully encoded JSON blob, but that's about as
good of a way to handle them as I can think of anyway.

Take this example:

    type RecursiveType struct {
            NotUnique string         `river:"-"`
            Recursive *RecursiveType `river:"unique"` // inner recursive type ignored by River
            String    string         `river:"unique"`
    }
    type TaskJobArgs struct {
            JobArgsStaticKind

            Recursive RecursiveType `river:"unique"`
    }
    return TaskJobArgs{
            JobArgsStaticKind: JobArgsStaticKind{kind: "worker_7"},
            Recursive: RecursiveType{
                    Recursive: &RecursiveType{
                            String: "level2",
                    },
                    String: "level1",
            },
    }

Generated output is:

    &kind=worker_7&args={"Recursive":{"Recursive":{"NotUnique":"","Recursive":null,"String":"level2"},"String":"level1"}}

Notably, we see "NotUnique" show up in the inner recursive type because
River has given up processing that and just treated the entire inner
"Recursive" as a JSON value. The outer type does not have "NotUnique"
because River saw the `river:"-"` annotation and knew not to treat it as
unique.