### PR TITLE
Prepare version v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2025-11-21
+
 ### Fixed
 
 - Unique args: Handle embedded fields that are not structs. [PR #1088](https://github.com/riverqueue/river/pull/1088).

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,12 +7,12 @@ toolchain go1.25.2
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lmittmann/tint v1.1.2
-	github.com/riverqueue/river v0.27.0
-	github.com/riverqueue/river/riverdriver v0.27.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.0
-	github.com/riverqueue/river/riverdriver/riversqlite v0.27.0
-	github.com/riverqueue/river/rivershared v0.27.0
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river v0.27.1
+	github.com/riverqueue/river/riverdriver v0.27.1
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.1
+	github.com/riverqueue/river/riverdriver/riversqlite v0.27.1
+	github.com/riverqueue/river/rivershared v0.27.1
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	modernc.org/sqlite v1.40.0

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.27.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.0
-	github.com/riverqueue/river/rivershared v0.27.0
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river/riverdriver v0.27.1
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.1
+	github.com/riverqueue/river/rivershared v0.27.1
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.25.2
 
 require (
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.25.2
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.27.0
-	github.com/riverqueue/river/riverdriver v0.27.0
-	github.com/riverqueue/river/rivershared v0.27.0
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river v0.27.1
+	github.com/riverqueue/river/riverdriver v0.27.1
+	github.com/riverqueue/river/rivershared v0.27.1
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.0 // indirect
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/riverdriver/riverdrivertest/go.mod
+++ b/riverdriver/riverdrivertest/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.27.0
-	github.com/riverqueue/river/riverdriver v0.27.0
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.27.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.0
-	github.com/riverqueue/river/riverdriver/riversqlite v0.27.0
-	github.com/riverqueue/river/rivershared v0.27.0
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river v0.27.1
+	github.com/riverqueue/river/riverdriver v0.27.1
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.27.1
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.1
+	github.com/riverqueue/river/riverdriver/riversqlite v0.27.1
+	github.com/riverqueue/river/rivershared v0.27.1
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,9 +7,9 @@ toolchain go1.25.2
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.27.0
-	github.com/riverqueue/river/rivershared v0.27.0
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river/riverdriver v0.27.1
+	github.com/riverqueue/river/rivershared v0.27.1
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/riverdriver/riversqlite/go.mod
+++ b/riverdriver/riversqlite/go.mod
@@ -5,10 +5,10 @@ go 1.24.0
 toolchain go1.25.2
 
 require (
-	github.com/riverqueue/river v0.27.0
-	github.com/riverqueue/river/riverdriver v0.27.0
-	github.com/riverqueue/river/rivershared v0.27.0
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river v0.27.1
+	github.com/riverqueue/river/riverdriver v0.27.1
+	github.com/riverqueue/river/rivershared v0.27.1
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -6,10 +6,10 @@ toolchain go1.25.2
 
 require (
 	github.com/jackc/pgx/v5 v5.7.6
-	github.com/riverqueue/river v0.27.0
-	github.com/riverqueue/river/riverdriver v0.27.0
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.0
-	github.com/riverqueue/river/rivertype v0.27.0
+	github.com/riverqueue/river v0.27.1
+	github.com/riverqueue/river/riverdriver v0.27.1
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.27.1
+	github.com/riverqueue/river/rivertype v0.27.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.29.0


### PR DESCRIPTION
Prepare version v0.27.1, containing a couple bug fixes around use of
unique annotations on structs.

[skip ci]