### PR TITLE
Add `riverlog.LoggerSafely` for access outside work body without panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `riverlog.LoggerSafely` which provides a non-panic variant of `riverlog.Logger` for use when code may or may not have a context logger available. [PR #1093](https://github.com/riverqueue/river/pull/1093).
+
 ## [0.27.1] - 2025-11-21
 
 ### Fixed

--- a/riverlog/river_log_test.go
+++ b/riverlog/river_log_test.go
@@ -16,10 +16,56 @@ import (
 	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivertest"
 	"github.com/riverqueue/river/rivertype"
 )
+
+func TestLogger(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.WithValue(ctx, contextKey{}, riversharedtest.Logger(t))
+
+		Logger(ctx).InfoContext(ctx, "Hello from logger")
+	})
+
+	t.Run("PanicIfNotSet", func(t *testing.T) {
+		t.Parallel()
+
+		require.PanicsWithValue(t, "no logger in context; do you have riverlog.Middleware configured?", func() {
+			Logger(ctx).InfoContext(ctx, "This will panic")
+		})
+	})
+}
+
+func TestLoggerSafely(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.WithValue(ctx, contextKey{}, riversharedtest.Logger(t))
+
+		logger, ok := LoggerSafely(ctx)
+		require.True(t, ok)
+		logger.InfoContext(ctx, "Hello from logger")
+	})
+
+	t.Run("PanicIfNotSet", func(t *testing.T) {
+		t.Parallel()
+
+		_, ok := LoggerSafely(ctx)
+		require.False(t, ok)
+	})
+}
 
 var _ rivertype.WorkerMiddleware = &Middleware{}
 


### PR DESCRIPTION
Here, add a "safe" variant of `riverlog.Logger`: `rigerlog.LoggerSafely`.

While it'd be rare to not know whether you had a logger or not from
inside a `Work` function, `Work` functions might call into other Go
modules in your project, those modules might be reused in non-`Work`
contexts, and it might not always be clear whether a logger should be
available or not.

This function lets users do a conditional check before logging:

    if logger, ok := riverlog.LoggerSafely(ctx); ok {
        logger.InfoContext(ctx, "Hello from logger")
    }

I went with the "safely" naming according to our conventions elsewhere,
but one thing I'm not sure about is that `ClientFromContextSafely` which
is a similar function, returns an error instead of `ok` boolean. Here we
break with that convention somewhat, but I think the boolean version is
more ergonomic. Another option might be to give this a slightly
alternative naming convention like `LoggerOK` or `LoggerMaybe`.

Fixes #1092.