### PR TITLE
Add hook for when the periodic job enqueuer starts up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `HookPeriodicJobsStart` that can be used to run custom logic when a periodic job enqueuer starts up on a new leader. [PR #1084](https://github.com/riverqueue/river/pull/1084).
 - Added `Client.Notify().RequestResign` and `Client.Notify().RequestResignTx` functions allowing any client to request that the current leader resign. [PR #1085](https://github.com/riverqueue/river/pull/1085).
 
 ## [0.28.0] - 2025-11-23
@@ -14,13 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `riverlog.LoggerSafely` which provides a non-panic variant of `riverlog.Logger` for use when code may or may not have a context logger available. [PR #1093](https://github.com/riverqueue/river/pull/1093).
-
-## [0.27.1] - 2025-11-21
-
-### Fixed
-
-- Unique args: Handle embedded fields that are not structs. [PR #1088](https://github.com/riverqueue/river/pull/1088).
-- Fix stack overflow when handling `river:"unique"` annotations on recursive types. [PR #1090](https://github.com/riverqueue/river/pull/1090).
 
 ## [0.27.0] - 2025-11-14
 

--- a/hook_defaults_funcs.go
+++ b/hook_defaults_funcs.go
@@ -23,6 +23,16 @@ func (f HookInsertBeginFunc) InsertBegin(ctx context.Context, params *rivertype.
 
 func (f HookInsertBeginFunc) IsHook() bool { return true }
 
+// HookPeriodicJobsStartFunc is a convenience helper for implementing
+// rivertype.HookPeriodicJobsStart using a simple function instead of a struct.
+type HookPeriodicJobsStartFunc func(ctx context.Context, params *rivertype.HookPeriodicJobsStartParams) error
+
+func (f HookPeriodicJobsStartFunc) IsHook() bool { return true }
+
+func (f HookPeriodicJobsStartFunc) Start(ctx context.Context, params *rivertype.HookPeriodicJobsStartParams) error {
+	return f(ctx, params)
+}
+
 // HookWorkBeginFunc is a convenience helper for implementing
 // rivertype.HookWorkBegin using a simple function instead of a struct.
 type HookWorkBeginFunc func(ctx context.Context, job *rivertype.JobRow) error

--- a/hook_defaults_funcs_test.go
+++ b/hook_defaults_funcs_test.go
@@ -11,6 +11,9 @@ var (
 	_ rivertype.Hook            = HookInsertBeginFunc(func(ctx context.Context, params *rivertype.JobInsertParams) error { return nil })
 	_ rivertype.HookInsertBegin = HookInsertBeginFunc(func(ctx context.Context, params *rivertype.JobInsertParams) error { return nil })
 
+	_ rivertype.Hook                  = HookPeriodicJobsStartFunc(func(ctx context.Context, params *rivertype.HookPeriodicJobsStartParams) error { return nil })
+	_ rivertype.HookPeriodicJobsStart = HookPeriodicJobsStartFunc(func(ctx context.Context, params *rivertype.HookPeriodicJobsStartParams) error { return nil })
+
 	_ rivertype.Hook          = HookWorkBeginFunc(func(ctx context.Context, job *rivertype.JobRow) error { return nil })
 	_ rivertype.HookWorkBegin = HookWorkBeginFunc(func(ctx context.Context, job *rivertype.JobRow) error { return nil })
 )

--- a/internal/hooklookup/hook_lookup.go
+++ b/internal/hooklookup/hook_lookup.go
@@ -13,9 +13,10 @@ import (
 type HookKind string
 
 const (
-	HookKindInsertBegin HookKind = "insert_begin"
-	HookKindWorkBegin   HookKind = "work_begin"
-	HookKindWorkEnd     HookKind = "work_end"
+	HookKindInsertBegin       HookKind = "insert_begin"
+	HookKindPeriodicJobsStart HookKind = "periodic_job_start"
+	HookKindWorkBegin         HookKind = "work_begin"
+	HookKindWorkEnd           HookKind = "work_end"
 )
 
 //
@@ -80,6 +81,12 @@ func (c *hookLookup) ByHookKind(kind HookKind) []rivertype.Hook {
 	case HookKindInsertBegin:
 		for _, hook := range c.hooks {
 			if typedHook, ok := hook.(rivertype.HookInsertBegin); ok {
+				c.hooksByKind[kind] = append(c.hooksByKind[kind], typedHook)
+			}
+		}
+	case HookKindPeriodicJobsStart:
+		for _, hook := range c.hooks {
+			if typedHook, ok := hook.(rivertype.HookPeriodicJobsStart); ok {
 				c.hooksByKind[kind] = append(c.hooksByKind[kind], typedHook)
 			}
 		}

--- a/periodic_job_test.go
+++ b/periodic_job_test.go
@@ -69,7 +69,7 @@ func TestPeriodicJobBundle(t *testing.T) {
 			nil,
 		)
 
-		internalPeriodicJob := periodicJobBundle.toInternal(periodicJob)
+		internalPeriodicJob := periodicJobBundle.mapper.toInternal(periodicJob)
 
 		insertParams1, err := internalPeriodicJob.ConstructorFunc()
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestPeriodicJobBundle(t *testing.T) {
 			nil,
 		)
 
-		internalPeriodicJob := periodicJobBundle.toInternal(periodicJob)
+		internalPeriodicJob := periodicJobBundle.mapper.toInternal(periodicJob)
 
 		_, err := internalPeriodicJob.ConstructorFunc()
 		require.ErrorIs(t, err, maintenance.ErrNoJobToInsert)

--- a/rivershared/riverpilot/pilot.go
+++ b/rivershared/riverpilot/pilot.go
@@ -112,6 +112,8 @@ type PilotPeriodicJob interface {
 	PeriodicJobUpsertMany(ctx context.Context, exec riverdriver.Executor, params *PeriodicJobUpsertManyParams) ([]*PeriodicJob, error)
 }
 
+// TODO: Get rid of this in favor of rivertype.PeriodicJob the next time we're
+// making River <-> River Pro API contract changes.
 type PeriodicJob struct {
 	ID        string
 	CreatedAt time.Time


### PR DESCRIPTION
This one's an alternative (and hopefully a better one) to #1078. #1078
works for removing a periodic job from a leader, but doesn't cover the
case where a new periodic job might need to be added dynamically from
any possible client.

Here, we add the new hook `HookPeriodicJobsStart` which runs when the
periodic job enqueuer starts up on a newly elected leader. This gives
the hook quite a bit of power to dynamically adjust all currently
configured periodic jobs on the enqueuer. For example, it may clear all
of them and then add them back from scratch using a canonical set of
periodic job records from elsewhere which it knows should exist.

This will need to be paired with another feature that would allow users
to force a leader reelection (which I haven't written yet). So when they
determine that a periodic job overhaul is necessary, they'll knock the
current leader offline and then use `HookPeriodicJobsStart` to configure
the right set of periodic jobs.

A modification we make here is to make it possible to get a client from
context in the hook similar to how it's possible in a worker right now.
This is because the hook implementation will often want access to a
client instance, but it's very awkward getting access to a client
otherwise because you define your hooks before a client is available,
thereby creating a chicken and egg problem.