### PR TITLE
Introduce `Client.JobUpdate` function that can store output incrementally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Basic stuck detection after a job's exceeded its timeout and still not returned after the executor's initiated context cancellation and waited a short margin for the cancellation to take effect. [PR #1097](https://github.com/riverqueue/river/pull/1097).
+- Added `Client.JobUpdate` which can be used to persist job output partway through a running work function instead of having to wait until the job is completed. [PR #1098](https://github.com/riverqueue/river/pull/1098).
 - Add a little more error flavor for when encountering a deadline exceeded error on leadership election suggesting that the user may want to try increasing their database pool size. [PR #1101](https://github.com/riverqueue/river/pull/1101).
 
 ## [0.29.0-rc.1] - 2025-12-04
+
+### Added
 
 - Added `HookPeriodicJobsStart` that can be used to run custom logic when a periodic job enqueuer starts up on a new leader. [PR #1084](https://github.com/riverqueue/river/pull/1084).
 - Added `Client.Notify().RequestResign` and `Client.Notify().RequestResignTx` functions allowing any client to request that the current leader resign. [PR #1085](https://github.com/riverqueue/river/pull/1085).

--- a/internal/jobexecutor/job_executor_test.go
+++ b/internal/jobexecutor/job_executor_test.go
@@ -318,7 +318,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 			require.Equal(t, rivertype.JobStateAvailable, job.State)
 		}
 
-		_, err := bundle.exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
+		_, err := bundle.exec.JobUpdateFull(ctx, &riverdriver.JobUpdateFullParams{
 			ID:            bundle.jobRow.ID,
 			StateDoUpdate: true,
 			State:         rivertype.JobStateRunning,
@@ -373,7 +373,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 
 		// add a unique key so we can verify it's cleared
 		var err error
-		bundle.jobRow, err = bundle.exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
+		bundle.jobRow, err = bundle.exec.JobUpdateFull(ctx, &riverdriver.JobUpdateFullParams{
 			ID:    bundle.jobRow.ID,
 			State: rivertype.JobStateAvailable, // required for encoding but ignored
 		})

--- a/recorded_output_test.go
+++ b/recorded_output_test.go
@@ -145,7 +145,7 @@ func Test_RecordedOutput(t *testing.T) {
 
 		AddWorker(client.config.Workers, WorkFunc(func(ctx context.Context, job *Job[JobArgs]) error {
 			// Record an output of 32MB + 1 byte:
-			err := RecordOutput(ctx, strings.Repeat("x", 32*1024*1024+1))
+			err := RecordOutput(ctx, strings.Repeat("x", maxOutputSizeBytes+1))
 			require.ErrorContains(t, err, "output is too large")
 			return err
 		}))

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -222,6 +222,7 @@ type Executor interface {
 	JobSchedule(ctx context.Context, params *JobScheduleParams) ([]*JobScheduleResult, error)
 	JobSetStateIfRunningMany(ctx context.Context, params *JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error)
 	JobUpdate(ctx context.Context, params *JobUpdateParams) (*rivertype.JobRow, error)
+	JobUpdateFull(ctx context.Context, params *JobUpdateFullParams) (*rivertype.JobRow, error)
 	LeaderAttemptElect(ctx context.Context, params *LeaderElectParams) (bool, error)
 	LeaderAttemptReelect(ctx context.Context, params *LeaderElectParams) (bool, error)
 	LeaderDeleteExpired(ctx context.Context, params *LeaderDeleteExpiredParams) (int, error)
@@ -634,6 +635,13 @@ type JobSetStateIfRunningManyParams struct {
 }
 
 type JobUpdateParams struct {
+	ID              int64
+	MetadataDoMerge bool
+	Metadata        []byte
+	Schema          string
+}
+
+type JobUpdateFullParams struct {
 	ID                  int64
 	AttemptDoUpdate     bool
 	Attempt             int

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -668,6 +668,24 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 	}
 
 	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
+		ID:              params.ID,
+		MetadataDoMerge: params.MetadataDoMerge,
+		Metadata:        string(metadata),
+	})
+	if err != nil {
+		return nil, interpretError(err)
+	}
+
+	return jobRowFromInternal(job)
+}
+
+func (e *Executor) JobUpdateFull(ctx context.Context, params *riverdriver.JobUpdateFullParams) (*rivertype.JobRow, error) {
+	metadata := params.Metadata
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
+
+	job, err := dbsqlc.New().JobUpdateFull(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateFullParams{
 		ID:                  params.ID,
 		Attempt:             int16(min(params.Attempt, math.MaxInt16)), //nolint:gosec
 		AttemptDoUpdate:     params.AttemptDoUpdate,

--- a/riverdriver/riverdrivertest/riverdrivertest.go
+++ b/riverdriver/riverdrivertest/riverdrivertest.go
@@ -3342,13 +3342,51 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 		t.Run("AllArgs", func(t *testing.T) {
 			t.Parallel()
 
+			exec, _ := setup(ctx, t)
+
+			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
+				Metadata: []byte(`{"key1":"val1"}`),
+			})
+
+			updatedJob, err := exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
+				ID:              job.ID,
+				MetadataDoMerge: true,
+				Metadata:        []byte(`{"key2":"val2"}`),
+			})
+			require.NoError(t, err)
+			require.JSONEq(t, `{"key1":"val1","key2":"val2"}`, string(updatedJob.Metadata))
+		})
+
+		t.Run("NoArgs", func(t *testing.T) {
+			t.Parallel()
+
+			exec, _ := setup(ctx, t)
+
+			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
+				Metadata: []byte(`{"key1":"val1"}`),
+			})
+
+			updatedJob, err := exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
+				ID: job.ID,
+			})
+			require.NoError(t, err)
+			require.JSONEq(t, `{"key1":"val1"}`, string(updatedJob.Metadata))
+		})
+	})
+
+	t.Run("JobUpdateFull", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("AllArgs", func(t *testing.T) {
+			t.Parallel()
+
 			exec, bundle := setup(ctx, t)
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{})
 
 			now := time.Now().UTC()
 
-			updatedJob, err := exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
+			updatedJob, err := exec.JobUpdateFull(ctx, &riverdriver.JobUpdateFullParams{
 				ID:                  job.ID,
 				AttemptDoUpdate:     true,
 				Attempt:             7,
@@ -3385,7 +3423,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{})
 
-			updatedJob, err := exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
+			updatedJob, err := exec.JobUpdateFull(ctx, &riverdriver.JobUpdateFullParams{
 				ID: job.ID,
 			})
 			require.NoError(t, err)

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -1574,6 +1574,54 @@ func (q *Queries) JobSetStateIfRunningMany(ctx context.Context, db DBTX, arg *Jo
 }
 
 const jobUpdate = `-- name: JobUpdate :one
+WITH locked_job AS (
+    SELECT id
+    FROM /* TEMPLATE: schema */river_job
+    WHERE river_job.id = $3
+    FOR UPDATE
+)
+UPDATE /* TEMPLATE: schema */river_job
+SET
+    metadata = CASE WHEN $1::boolean THEN metadata || $2::jsonb ELSE metadata END
+FROM
+    locked_job
+WHERE river_job.id = locked_job.id
+RETURNING river_job.id, river_job.args, river_job.attempt, river_job.attempted_at, river_job.attempted_by, river_job.created_at, river_job.errors, river_job.finalized_at, river_job.kind, river_job.max_attempts, river_job.metadata, river_job.priority, river_job.queue, river_job.state, river_job.scheduled_at, river_job.tags, river_job.unique_key, river_job.unique_states
+`
+
+type JobUpdateParams struct {
+	MetadataDoMerge bool
+	Metadata        []byte
+	ID              int64
+}
+
+func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) (*RiverJob, error) {
+	row := db.QueryRow(ctx, jobUpdate, arg.MetadataDoMerge, arg.Metadata, arg.ID)
+	var i RiverJob
+	err := row.Scan(
+		&i.ID,
+		&i.Args,
+		&i.Attempt,
+		&i.AttemptedAt,
+		&i.AttemptedBy,
+		&i.CreatedAt,
+		&i.Errors,
+		&i.FinalizedAt,
+		&i.Kind,
+		&i.MaxAttempts,
+		&i.Metadata,
+		&i.Priority,
+		&i.Queue,
+		&i.State,
+		&i.ScheduledAt,
+		&i.Tags,
+		&i.UniqueKey,
+		&i.UniqueStates,
+	)
+	return &i, err
+}
+
+const jobUpdateFull = `-- name: JobUpdateFull :one
 UPDATE /* TEMPLATE: schema */river_job
 SET
     attempt = CASE WHEN $1::boolean THEN $2 ELSE attempt END,
@@ -1588,7 +1636,7 @@ WHERE id = $17
 RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
 `
 
-type JobUpdateParams struct {
+type JobUpdateFullParams struct {
 	AttemptDoUpdate     bool
 	Attempt             int16
 	AttemptedAtDoUpdate bool
@@ -1610,8 +1658,8 @@ type JobUpdateParams struct {
 
 // A generalized update for any property on a job. This brings in a large number
 // of parameters and therefore may be more suitable for testing than production.
-func (q *Queries) JobUpdate(ctx context.Context, db DBTX, arg *JobUpdateParams) (*RiverJob, error) {
-	row := db.QueryRow(ctx, jobUpdate,
+func (q *Queries) JobUpdateFull(ctx context.Context, db DBTX, arg *JobUpdateFullParams) (*RiverJob, error) {
+	row := db.QueryRow(ctx, jobUpdateFull,
 		arg.AttemptDoUpdate,
 		arg.Attempt,
 		arg.AttemptedAtDoUpdate,

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -657,6 +657,24 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 	}
 
 	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
+		ID:              params.ID,
+		MetadataDoMerge: params.MetadataDoMerge,
+		Metadata:        metadata,
+	})
+	if err != nil {
+		return nil, interpretError(err)
+	}
+
+	return jobRowFromInternal(job)
+}
+
+func (e *Executor) JobUpdateFull(ctx context.Context, params *riverdriver.JobUpdateFullParams) (*rivertype.JobRow, error) {
+	metadata := params.Metadata
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
+
+	job, err := dbsqlc.New().JobUpdateFull(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateFullParams{
 		ID:                  params.ID,
 		AttemptedAtDoUpdate: params.AttemptedAtDoUpdate,
 		Attempt:             int16(min(params.Attempt, math.MaxInt16)), //nolint:gosec

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
@@ -492,9 +492,16 @@ WHERE id = @id
     AND state = 'running'
 RETURNING *;
 
+-- name: JobUpdate :one
+UPDATE /* TEMPLATE: schema */river_job
+SET
+    metadata = CASE WHEN cast(@metadata_do_merge AS boolean) THEN json_patch(metadata, json(cast(@metadata AS blob))) ELSE metadata END
+WHERE id = @id
+RETURNING *;
+
 -- A generalized update for any property on a job. This brings in a large number
 -- of parameters and therefore may be more suitable for testing than production.
--- name: JobUpdate :one
+-- name: JobUpdateFull :one
 UPDATE /* TEMPLATE: schema */river_job
 SET
     attempt = CASE WHEN cast(@attempt_do_update AS boolean) THEN @attempt ELSE attempt END,

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -998,6 +998,24 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 }
 
 func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateParams) (*rivertype.JobRow, error) {
+	metadata := params.Metadata
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
+
+	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
+		ID:              params.ID,
+		MetadataDoMerge: params.MetadataDoMerge,
+		Metadata:        metadata,
+	})
+	if err != nil {
+		return nil, interpretError(err)
+	}
+
+	return jobRowFromInternal(job)
+}
+
+func (e *Executor) JobUpdateFull(ctx context.Context, params *riverdriver.JobUpdateFullParams) (*rivertype.JobRow, error) {
 	attemptedAt := params.AttemptedAt
 	if attemptedAt != nil {
 		attemptedAt = ptrutil.Ptr(attemptedAt.UTC())
@@ -1023,7 +1041,7 @@ func (e *Executor) JobUpdate(ctx context.Context, params *riverdriver.JobUpdateP
 		metadata = []byte("{}")
 	}
 
-	job, err := dbsqlc.New().JobUpdate(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateParams{
+	job, err := dbsqlc.New().JobUpdateFull(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobUpdateFullParams{
 		ID:                  params.ID,
 		Attempt:             int64(params.Attempt),
 		AttemptDoUpdate:     params.AttemptDoUpdate,

--- a/riverlog/river_log_test.go
+++ b/riverlog/river_log_test.go
@@ -162,7 +162,7 @@ func TestMiddleware(t *testing.T) {
 		require.NoError(t, err)
 
 		// Set state back to available and unfinalize the job to make it runnable again.
-		workRes.Job, err = bundle.driver.UnwrapExecutor(bundle.tx).JobUpdate(ctx, &riverdriver.JobUpdateParams{
+		workRes.Job, err = bundle.driver.UnwrapExecutor(bundle.tx).JobUpdateFull(ctx, &riverdriver.JobUpdateFullParams{
 			ID:                  workRes.Job.ID,
 			FinalizedAtDoUpdate: true,
 			FinalizedAt:         nil,

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -157,7 +157,7 @@ func (w *Worker[T, TTx]) workJob(ctx context.Context, tb testing.TB, tx TTx, job
 		}
 	}
 
-	updatedJobRow, err := exec.JobUpdate(ctx, &riverdriver.JobUpdateParams{
+	updatedJobRow, err := exec.JobUpdateFull(ctx, &riverdriver.JobUpdateFullParams{
 		ID:                  job.ID,
 		Attempt:             job.Attempt + 1,
 		AttemptDoUpdate:     true,


### PR DESCRIPTION
Here, take a stab at a solution for #1064. We introduce a new client
function `Client.JobUpdate` that takes any output currently recorded in
context and stores it to the given job row. `JobUpdate` currently only
sets output, but the idea is that it could be expanded in the future in
case it's useful to do so.

The reason that we don't have a `river.PersistOutput` in line with
`river.RecordOutput` is that once we're talking about storing data,
we're dealing with the usual persistence semantics. We need a client
instance with access to an executor, and we probably want to have a
`*Tx` variant like we have for all other functions like this one.

Fixes #1064.