### PR TITLE
Add additional flavor in leadership when transaction fails to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Basic stuck detection after a job's exceeded its timeout and still not returned after the executor's initiated context cancellation and waited a short margin for the cancellation to take effect. [PR #1097](https://github.com/riverqueue/river/pull/1097).
+- Add a little more error flavor for when encountering a deadline exceeded error on leadership election suggesting that the user may want to try increasing their database pool size. [PR #1101](https://github.com/riverqueue/river/pull/1101).
 
 ## [0.29.0-rc.1] - 2025-12-04
 


### PR DESCRIPTION
Related to #1077, a common problem that users run into is that there
database pool is configured to be too small, and a common place they run
into this is as a River client is trying to elect itself.

Here, add a little bit of custom flavor to a deadline exceeded error
that occurs during leadership election. This is certainly not an
exhaustive way to reveal these errors (it only goes in one spot), but
the idea is that we put it in a common error spot, and it should improve
things incrementally.