### PR TITLE
When operating outside of transaction, add/remove versions immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic stuck detection after a job's exceeded its timeout and still not returned after the executor's initiated context cancellation and waited a short margin for the cancellation to take effect. [PR #1097](https://github.com/riverqueue/river/pull/1097).
 - Added `Client.JobUpdate` which can be used to persist job output partway through a running work function instead of having to wait until the job is completed. [PR #1098](https://github.com/riverqueue/river/pull/1098).
 - Add a little more error flavor for when encountering a deadline exceeded error on leadership election suggesting that the user may want to try increasing their database pool size. [PR #1101](https://github.com/riverqueue/river/pull/1101).
+- When migrating without an outer transaction, insert/delete version rows immediately after executing migration SQL so that in case a later migration fails, the migrator knows where to restart from. [PR #1106](https://github.com/riverqueue/river/pull/1106).
 
 ## [0.29.0-rc.1] - 2025-12-04
 


### PR DESCRIPTION
We had a problem reported recently wherein a user who was executing
migrations in tight contention with each other hit a problem where
because a transaction is only in operation right around the immediate
SQL of each migration, it's easily possible to get all the side effects
of a transaction without actually adding/removing any versions. In the
event of such a failure, the database is left in an irreconcilable
state. Neither migrating up or down can fix the problem, with the only
option being manual intervention.

Here, when running without an outer transaction, run version insertion
or deletion immediately so that it happens immediately inside the inner
transaction, thereby preventing this problem.

All `MigrateTx` test exercise was completely stripped out so I added a
couple basic tests back in so that this code has some coverage.