### PR TITLE
Prepare version 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Basic stuck detection after a job's exceeded its timeout and still not returned after the executor's initiated context cancellation and waited a short margin for the cancellation to take effect. [PR #1097](https://github.com/riverqueue/river/pull/1097).
-- Added `Client.JobUpdate` which can be used to persist job output partway through a running work function instead of having to wait until the job is completed. [PR #1098](https://github.com/riverqueue/river/pull/1098).
-- Add a little more error flavor for when encountering a deadline exceeded error on leadership election suggesting that the user may want to try increasing their database pool size. [PR #1101](https://github.com/riverqueue/river/pull/1101).
-- When migrating without an outer transaction, insert/delete version rows immediately after executing migration SQL so that in case a later migration fails, the migrator knows where to restart from. [PR #1106](https://github.com/riverqueue/river/pull/1106).
-
-## [0.29.0-rc.1] - 2025-12-04
+## [0.29.0] - 2025-12-22
 
 ### Added
 
 - Added `HookPeriodicJobsStart` that can be used to run custom logic when a periodic job enqueuer starts up on a new leader. [PR #1084](https://github.com/riverqueue/river/pull/1084).
 - Added `Client.Notify().RequestResign` and `Client.Notify().RequestResignTx` functions allowing any client to request that the current leader resign. [PR #1085](https://github.com/riverqueue/river/pull/1085).
+- Basic stuck detection after a job's exceeded its timeout and still not returned after the executor's initiated context cancellation and waited a short margin for the cancellation to take effect. [PR #1097](https://github.com/riverqueue/river/pull/1097).
+- Added `Client.JobUpdate` which can be used to persist job output partway through a running work function instead of having to wait until the job is completed. [PR #1098](https://github.com/riverqueue/river/pull/1098).
+
+### Changed
+
+- Add a little more error flavor for when encountering a deadline exceeded error on leadership election suggesting that the user may want to try increasing their database pool size. [PR #1101](https://github.com/riverqueue/river/pull/1101).
+- When migrating without an outer transaction, insert/delete version rows immediately after executing migration SQL so that in case a later migration fails, the migrator knows where to restart from. [PR #1106](https://github.com/riverqueue/river/pull/1106).
 
 ## [0.28.0] - 2025-11-23
 

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -7,12 +7,12 @@ toolchain go1.25.2
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lmittmann/tint v1.1.2
-	github.com/riverqueue/river v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver/riversqlite v0.29.0-rc.1
-	github.com/riverqueue/river/rivershared v0.29.0-rc.1
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river v0.29.0
+	github.com/riverqueue/river/riverdriver v0.29.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0
+	github.com/riverqueue/river/riverdriver/riversqlite v0.29.0
+	github.com/riverqueue/river/rivershared v0.29.0
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	modernc.org/sqlite v1.41.0

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0-rc.1
-	github.com/riverqueue/river/rivershared v0.29.0-rc.1
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river/riverdriver v0.29.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0
+	github.com/riverqueue/river/rivershared v0.29.0
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.25.2
 
 require (
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -7,10 +7,10 @@ toolchain go1.25.2
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver v0.29.0-rc.1
-	github.com/riverqueue/river/rivershared v0.29.0-rc.1
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river v0.29.0
+	github.com/riverqueue/river/riverdriver v0.29.0
+	github.com/riverqueue/river/rivershared v0.29.0
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -20,7 +20,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0-rc.1 // indirect
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/riverdriver/riverdrivertest/go.mod
+++ b/riverdriver/riverdrivertest/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/lib/pq v1.10.9
-	github.com/riverqueue/river v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver/riversqlite v0.29.0-rc.1
-	github.com/riverqueue/river/rivershared v0.29.0-rc.1
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river v0.29.0
+	github.com/riverqueue/river/riverdriver v0.29.0
+	github.com/riverqueue/river/riverdriver/riverdatabasesql v0.29.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0
+	github.com/riverqueue/river/riverdriver/riversqlite v0.29.0
+	github.com/riverqueue/river/rivershared v0.29.0
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -7,9 +7,9 @@ toolchain go1.25.2
 require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/jackc/puddle/v2 v2.2.2
-	github.com/riverqueue/river/riverdriver v0.29.0-rc.1
-	github.com/riverqueue/river/rivershared v0.29.0-rc.1
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river/riverdriver v0.29.0
+	github.com/riverqueue/river/rivershared v0.29.0
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/riverdriver/riversqlite/go.mod
+++ b/riverdriver/riversqlite/go.mod
@@ -5,10 +5,10 @@ go 1.24.0
 toolchain go1.25.2
 
 require (
-	github.com/riverqueue/river v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver v0.29.0-rc.1
-	github.com/riverqueue/river/rivershared v0.29.0-rc.1
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river v0.29.0
+	github.com/riverqueue/river/riverdriver v0.29.0
+	github.com/riverqueue/river/rivershared v0.29.0
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -6,10 +6,10 @@ toolchain go1.25.2
 
 require (
 	github.com/jackc/pgx/v5 v5.7.6
-	github.com/riverqueue/river v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver v0.29.0-rc.1
-	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0-rc.1
-	github.com/riverqueue/river/rivertype v0.29.0-rc.1
+	github.com/riverqueue/river v0.29.0
+	github.com/riverqueue/river/riverdriver v0.29.0
+	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0
+	github.com/riverqueue/river/rivertype v0.29.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.31.0


### PR DESCRIPTION
Prepare version 0.29.0. We pull the changes from RC1 into the main
0.29.0 release.

[skip ci]