### PR TITLE
Initialize `nil` migration opts earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix possible nil pointer panic when using nil `opts` in `Migrator.MigrateTx`. [PR #1117](https://github.com/riverqueue/river/pull/1117).
+
 ## [0.29.0] - 2025-12-22
 
 ### Added

--- a/rivermigrate/river_migrate.go
+++ b/rivermigrate/river_migrate.go
@@ -385,6 +385,10 @@ func (m *Migrator[TTx]) ValidateTx(ctx context.Context, tx TTx) (*ValidateResult
 
 // migrateDown runs down migrations.
 func (m *Migrator[TTx]) migrateDown(ctx context.Context, exec riverdriver.Executor, direction Direction, opts *MigrateOpts, inOuterTx bool) (*MigrateResult, error) {
+	if opts == nil {
+		opts = &MigrateOpts{}
+	}
+
 	existingMigrations, err := m.existingMigrations(ctx, exec)
 	if err != nil {
 		return nil, err
@@ -434,6 +438,10 @@ func (m *Migrator[TTx]) migrateDown(ctx context.Context, exec riverdriver.Execut
 
 // migrateUp runs up migrations.
 func (m *Migrator[TTx]) migrateUp(ctx context.Context, exec riverdriver.Executor, direction Direction, opts *MigrateOpts, inOuterTx bool) (*MigrateResult, error) {
+	if opts == nil {
+		opts = &MigrateOpts{}
+	}
+
 	existingMigrations, err := m.existingMigrations(ctx, exec)
 	if err != nil {
 		return nil, err
@@ -493,10 +501,6 @@ func (m *Migrator[TTx]) validate(ctx context.Context, exec riverdriver.Executor)
 // Common code shared between the up and down migration directions that walks
 // through each target migration and applies it, logging appropriately.
 func (m *Migrator[TTx]) applyMigrations(ctx context.Context, exec riverdriver.Executor, direction Direction, opts *MigrateOpts, inOuterTx bool, sortedTargetMigrations []Migration) (*MigrateResult, error) {
-	if opts == nil {
-		opts = &MigrateOpts{}
-	}
-
 	var maxSteps int
 	switch {
 	case opts.MaxSteps != 0:


### PR DESCRIPTION
The migration functions are supposed to allow you to call them with
nil options, but I noticed in some cases it's not working properly for
`MigrateTx` and it's possible to raise a nil pointer panic.

Here, initialize a nil `opts` earlier to prevent the problem. This makes
the code more obvious/conventional anyway in that it's easier to see
that nil options is supposed to be supported.