### PR TITLE
Add shared `structtag` package for use across features

### DIFF
--- a/internal/dbunique/db_unique.go
+++ b/internal/dbunique/db_unique.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 
+	"github.com/riverqueue/river/rivershared/structtag"
 	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
@@ -64,14 +65,14 @@ func buildUniqueKeyString(timeGen rivertype.TimeGenerator, uniqueOpts *UniqueOpt
 	if uniqueOpts.ByArgs {
 		var encodedArgsForUnique []byte
 		// Get unique JSON keys from the JobArgs struct:
-		uniqueFields, err := getSortedUniqueFieldsCached(params.Args)
+		uniqueFields, err := structtag.SortedFieldsWithTag(params.Args, "unique")
 		if err != nil {
 			return "", err
 		}
 
 		if len(uniqueFields) > 0 {
 			// Extract unique values from the EncodedArgs JSON
-			uniqueValues := extractUniqueValues(params.EncodedArgs, uniqueFields)
+			uniqueValues := structtag.ExtractValues(params.EncodedArgs, uniqueFields)
 
 			// Assemble the JSON object using bytes.Buffer
 			// Better to overallocate a bit than to allocate multiple times, so just

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -21,6 +21,9 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.2.0 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/rivershared/go.sum
+++ b/rivershared/go.sum
@@ -32,6 +32,14 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/match v1.2.0 h1:0pt8FlkOwjN2fPt4bIl4BoNxb98gGHN2ObFEDkrfZnM=
+github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=

--- a/rivershared/structtag/struct_tag_test.go
+++ b/rivershared/structtag/struct_tag_test.go
@@ -1,0 +1,235 @@
+package structtag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/rivershared/util/testutil"
+	"github.com/riverqueue/river/rivertype"
+)
+
+func TestExtractValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		encodedArgs    []byte
+		uniqueKeys     []string
+		expectedValues []string
+	}{
+		{
+			name:           "SimpleStringFields",
+			encodedArgs:    []byte(`{"name":"alice","email":"alice@example.com","age":30}`),
+			uniqueKeys:     []string{"name", "email"},
+			expectedValues: []string{`"alice"`, `"alice@example.com"`},
+		},
+		{
+			name:           "NumericField",
+			encodedArgs:    []byte(`{"name":"bob","count":42}`),
+			uniqueKeys:     []string{"count"},
+			expectedValues: []string{"42"},
+		},
+		{
+			name:           "BooleanField",
+			encodedArgs:    []byte(`{"active":true,"disabled":false}`),
+			uniqueKeys:     []string{"active", "disabled"},
+			expectedValues: []string{"true", "false"},
+		},
+		{
+			name:           "NestedField",
+			encodedArgs:    []byte(`{"user":{"name":"charlie","address":{"city":"NYC"}}}`),
+			uniqueKeys:     []string{"user.name", "user.address.city"},
+			expectedValues: []string{`"charlie"`, `"NYC"`},
+		},
+		{
+			name:           "MissingField",
+			encodedArgs:    []byte(`{"name":"dave"}`),
+			uniqueKeys:     []string{"name", "missing"},
+			expectedValues: []string{`"dave"`, "undefined"},
+		},
+		{
+			name:           "NullValue",
+			encodedArgs:    []byte(`{"name":null}`),
+			uniqueKeys:     []string{"name"},
+			expectedValues: []string{"null"},
+		},
+		{
+			name:           "ObjectValue",
+			encodedArgs:    []byte(`{"user":{"id":1,"name":"eve"}}`),
+			uniqueKeys:     []string{"user"},
+			expectedValues: []string{`{"id":1,"name":"eve"}`},
+		},
+		{
+			name:           "ArrayValue",
+			encodedArgs:    []byte(`{"tags":["a","b","c"]}`),
+			uniqueKeys:     []string{"tags"},
+			expectedValues: []string{`["a","b","c"]`},
+		},
+		{
+			name:           "EmptyKeys",
+			encodedArgs:    []byte(`{"name":"frank"}`),
+			uniqueKeys:     []string{},
+			expectedValues: []string{},
+		},
+		{
+			name:           "AllMissing",
+			encodedArgs:    []byte(`{}`),
+			uniqueKeys:     []string{"a", "b"},
+			expectedValues: []string{"undefined", "undefined"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualValues := ExtractValues(tt.encodedArgs, tt.uniqueKeys)
+			require.Equal(t, tt.expectedValues, actualValues)
+		})
+	}
+}
+
+func TestSortedFieldsWithTag(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		argsFunc       func() rivertype.JobArgs
+		tagValue       string
+		expectedFields []string
+	}{
+		{
+			name: "SimpleUniqueFields",
+			argsFunc: func() rivertype.JobArgs {
+				type SimpleArgs struct {
+					testutil.JobArgsReflectKind[SimpleArgs]
+
+					Name  string `json:"name"  river:"unique"`
+					Email string `json:"email" river:"unique"`
+					Age   int    `json:"age"`
+				}
+
+				return SimpleArgs{}
+			},
+			tagValue:       "unique",
+			expectedFields: []string{"email", "name"},
+		},
+		{
+			name: "NestedStructWithUniqueFields",
+			argsFunc: func() rivertype.JobArgs {
+				type Inner struct {
+					FieldA string `json:"field_a" river:"unique"`
+					FieldB int    `json:"field_b"`
+				}
+
+				type NestedOuter struct {
+					testutil.JobArgsReflectKind[NestedOuter]
+
+					InnerField Inner  `json:"inner_field"`
+					FieldC     string `json:"field_c"     river:"unique"`
+					FieldD     int    `json:"field_d"     river:"unique,otheroption"`
+				}
+
+				return NestedOuter{}
+			},
+			tagValue:       "unique",
+			expectedFields: []string{"field_c", "field_d", "inner_field.field_a"},
+		},
+		{
+			name: "NoUniqueFields",
+			argsFunc: func() rivertype.JobArgs {
+				type NoUniqueArgs struct {
+					testutil.JobArgsReflectKind[NoUniqueArgs]
+
+					Name string `json:"name"`
+					Age  int    `json:"age"`
+				}
+
+				return NoUniqueArgs{}
+			},
+			tagValue:       "unique",
+			expectedFields: nil,
+		},
+		{
+			name: "NoJSONTagUsesFieldName",
+			argsFunc: func() rivertype.JobArgs {
+				type NoJSONTagArgs struct {
+					testutil.JobArgsReflectKind[NoJSONTagArgs]
+
+					Name string `river:"unique"`
+				}
+
+				return NoJSONTagArgs{}
+			},
+			tagValue:       "unique",
+			expectedFields: []string{"Name"},
+		},
+		{
+			name: "DifferentTagValue",
+			argsFunc: func() rivertype.JobArgs {
+				type DifferentTagArgs struct {
+					testutil.JobArgsReflectKind[DifferentTagArgs]
+
+					Field1 string `json:"field1" river:"special"`
+					Field2 string `json:"field2" river:"unique"`
+				}
+
+				return DifferentTagArgs{}
+			},
+			tagValue:       "special",
+			expectedFields: []string{"field1"},
+		},
+		{
+			name: "AnonymousEmbeddedStruct",
+			argsFunc: func() rivertype.JobArgs {
+				type EmbeddedBase struct {
+					BaseField string `json:"base_field" river:"unique"`
+				}
+
+				type WithEmbeddedArgs struct {
+					testutil.JobArgsReflectKind[WithEmbeddedArgs]
+					EmbeddedBase
+
+					OwnField string `json:"own_field" river:"unique"`
+				}
+
+				return WithEmbeddedArgs{}
+			},
+			tagValue:       "unique",
+			expectedFields: []string{"base_field", "own_field"},
+		},
+		{
+			name: "DeeplyNestedStruct",
+			argsFunc: func() rivertype.JobArgs {
+				type DeepNested struct {
+					Value string `json:"value" river:"unique"`
+				}
+
+				type MiddleLevel struct {
+					Deep DeepNested `json:"deep"`
+				}
+
+				type DeepNestedArgs struct {
+					testutil.JobArgsReflectKind[DeepNestedArgs]
+
+					Middle MiddleLevel `json:"middle"`
+				}
+
+				return DeepNestedArgs{}
+			},
+			tagValue:       "unique",
+			expectedFields: []string{"middle.deep.value"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualFields, err := SortedFieldsWithTag(tt.argsFunc(), tt.tagValue)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedFields, actualFields)
+		})
+	}
+}


### PR DESCRIPTION
Here, introduce a new `rivershared/structtag` package, extracted from
some of the previous implementation of `dbunique`. We modify the
previous implementation so that it can handle `river` tag values with
any arbitrary value (previously, only `unique` worked) so that we can
reuse the implementation or other features.