### PR TITLE
Have stuck detection account for worker-level timeouts as well as client-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stuck job detection now accounts for worker-level timeouts as well as client-level timeouts. [PR #1125](https://github.com/riverqueue/river/pull/1125).
+
 ## [0.30.0] - 2026-01-11
 
 ### Fixed

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -2,7 +2,6 @@ package execution
 
 import (
 	"context"
-	"time"
 
 	"github.com/riverqueue/river/rivertype"
 )
@@ -12,19 +11,6 @@ import (
 type ContextKeyInsideTestWorker struct{}
 
 type Func func(ctx context.Context) error
-
-// MaybeApplyTimeout returns a context that will be cancelled after the given
-// timeout. If the timeout is <= 0, the context will not be timed out, but it
-// will still have a cancel function returned. In either case the cancel
-// function should be called after execution (in a defer).
-func MaybeApplyTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	// No timeout if a -1 was specified.
-	if timeout > 0 {
-		return context.WithTimeout(ctx, timeout)
-	}
-
-	return context.WithCancel(ctx)
-}
 
 // MiddlewareChain chains together the given middleware functions, returning a
 // single function that applies them all in reverse order.


### PR DESCRIPTION
As reported by #1125, the stuck job detection mechanism currently only
considers client-level timeouts and without properly accounting for the
possibility of worker-level overrides.

Here, make sure to account for worker-level timeouts as well by hosting
the job timeout calculation further up in the executor logic.

Fixes #1125.