### PR TITLE
docs: fix typo in README - remove duplicate word "client"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ river.AddWorker(workers, &SortWorker{})
 A River [`Client`] provides an interface for job insertion and manages job
 processing and [maintenance services]. A client's created with a database pool,
 [driver], and config struct containing a `Workers` bundle and other settings.
-Here's a client `Client` working one queue (`"default"`) with up to 100 worker
+Here's a `Client` working one queue (`"default"`) with up to 100 worker
 goroutines at a time:
 
 ```go


### PR DESCRIPTION
Fix a tiny typo in `docs/README.md` where "client" was accidentally duplicated.

**Changed:** "Here's a client `Client` working" → "Here's a `Client` working"

I know this is extremely minor and perhaps unnecessary, but I happened to spot it while reading the docs and couldn't help myself. 😅
