### PR TITLE
Fix worker-level stuck job timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix bug in worker-level stuck job detection. [PR #1133](https://github.com/riverqueue/river/pull/1133).
+
 ## [0.30.1] - 2026-01-19
 
 ### Fixed


### PR DESCRIPTION
Fix a bug that came in with #1126 in which we we were correctly
calculating timeout, but then not passing it down to the stuck job
function when starting the stuck detection goroutine.

There is a test that was checking this worked, but due to the nature of
the bug, it was in effect detecting a stuck job after 0s and therefore
passing by accident. I looked into ways to add additional testing here,
but elected not to add more because they'd involve the sort of test I
really hate, which has to wait arbitrarily wait to try and check that
something did not happen, introducing both slowness and intermittency.
After the fix here lands, this is the sort of thing that's not too
likely to regress, and should be noticed quickly in case it does.

Fixes #1125.
