### PR TITLE
Add CLI statement-timeout flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added root River CLI flag `--statement-timeout` so Postgres session statement timeout can be set explicitly for commands like migrations. Explicit flag values take priority over database URL query params, and query params still take priority over built-in defaults. [PR #1142](https://github.com/riverqueue/river/pull/1142).
+
 ### Fixed
 
 - `JobCountByQueueAndState` now returns consistent results across drivers, including requested queues with zero jobs, and deduplicates repeated queue names in input. This resolves an issue with the sqlite driver in River UI reported in [riverqueue/riverui#496](https://github.com/riverqueue/riverui#496). [PR #1140](https://github.com/riverqueue/river/pull/1140).

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,6 +30,11 @@ To run programs locally outside of tests, create and raise a development databas
     createdb river_dev
     go run ./cmd/river migrate-up --database-url postgres:///river_dev --line main
 
+If needed, override Postgres timeouts for long-running migrations with root CLI
+flags:
+
+    go run ./cmd/river --statement-timeout 2m migrate-up --database-url postgres:///river_dev --line main
+
 ## Releasing a new version
 
 1. Fetch changes to the repo and any new tags. Export `VERSION` by incrementing the last tag. Execute `update-mod-version` to add it the project's `go.mod` files:


### PR DESCRIPTION
River CLI Postgres commands had fixed session defaults and no explicit flag for statement timeout. For long-running migrations, callers either accepted the default or had to encode `statement_timeout` into the connection string. This could be difficult in deployed environments where i.e. a database connection string was shared with an application and the user did not want to accidentally affect timeouts for other processes using a shared connection string.

This commit adds a root `--statement-timeout` flag and threads it through command bootstrapping into Postgres pool configuration. Statement timeout now uses explicit precedence: flag value first, then connection-string query parameter, then built-in default. `idle_in_transaction_session_timeout` keeps its existing behavior and remains URL/default driven.