### PR TITLE
Fix connection pool leak in Listener.Connect on afterConnectExec failure

### DIFF
--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -1066,6 +1066,7 @@ func (l *Listener) Connect(ctx context.Context) error {
 
 	if l.afterConnectExec != "" {
 		if _, err := poolConn.Exec(ctx, l.afterConnectExec); err != nil {
+			poolConn.Release()
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

- When `afterConnectExec` fails in `Listener.Connect()`, the acquired pool connection is not released back to the pool, causing a connection leak
- The `QueryRow` error path 10 lines below already correctly calls `poolConn.Release()`, but the `Exec` error path was missing it
- Added a test that creates a pool with `MaxConns=1`, sets `afterConnectExec` to invalid SQL, and verifies the connection is returned to the pool after the error (without the fix, a subsequent `Acquire` hangs forever)

## Test plan

- [x] New test `TestListener_Connect/ReleasesPoolConnOnAfterConnectExecError` verifies the fix (fails without it, passes with it)
- [x] New test `TestListener_Connect/SuccessfulConnect` verifies normal connect still works
- [x] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)