### PR TITLE
Fix missing ticker.Stop() in pollForSettingChanges

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -857,6 +857,7 @@ func (p *producer) pollForSettingChanges(ctx context.Context, wg *sync.WaitGroup
 	defer wg.Done()
 
 	ticker := time.NewTicker(p.config.QueuePollInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary

- `pollForSettingChanges` creates a `time.NewTicker` but never calls `Stop()` on it when the context is cancelled, leaking the ticker's internal runtime timer
- Other functions in the same file (`heartbeatLogLoop`, `reportQueueStatusLoop`) correctly use `defer ticker.Stop()` — this aligns with that pattern
- Note: `pollForSettingChanges` only runs when no notifier is configured (poll-only mode), so this only affects non-LISTEN/NOTIFY setups

## Test plan

- [x] Existing `TestProducer_PollOnly` exercises this code path
- [x] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)