### PR TITLE
optimize snooze metadata updates and add benches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `riverlog.Middleware` now supports `MiddlewareConfig.MaxTotalBytes` (default 8 MB) to cap total persisted `river:log` history per job. When the cap is exceeded, oldest log entries are dropped first while retaining the newest entry. Values over 64 MB are clamped to 64 MB. [PR #1157](https://github.com/riverqueue/river/pull/1157).
 - Improved `riverlog` performance and reduced memory amplification when appending to large persisted `river:log` histories. [PR #1157](https://github.com/riverqueue/river/pull/1157).
+- Reduced snooze-path memory amplification by setting `snoozes` in metadata updates before marshaling, avoiding an extra full-payload JSON rewrite. [PR #1159](https://github.com/riverqueue/river/pull/1159).
 
 ## [0.31.0] - 2026-02-21
 

--- a/internal/jobexecutor/job_executor_benchmark_test.go
+++ b/internal/jobexecutor/job_executor_benchmark_test.go
@@ -1,0 +1,121 @@
+package jobexecutor
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func BenchmarkMetadataUpdatesBytesForSnooze(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping benchmark in short mode")
+	}
+
+	testCases := []struct {
+		name        string
+		logSizeByte int
+	}{
+		{name: "Log256KB", logSizeByte: 256 * 1024},
+		{name: "Log2MB", logSizeByte: 2 * 1024 * 1024},
+		{name: "Log8MB", logSizeByte: 8 * 1024 * 1024},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			metadataUpdates := map[string]any{
+				"river:log": json.RawMessage(makeRiverLogArrayWithApproxSize(tc.logSizeByte)),
+			}
+
+			jobMetadata := []byte(`{"snoozes":41}`)
+			snoozesValue := gjson.GetBytes(jobMetadata, "snoozes").Int()
+
+			b.Run("MarshalOnly", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for range b.N {
+					marshaled, err := json.Marshal(metadataUpdates)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(marshaled) == 0 {
+						b.Fatal("expected non-empty metadata updates payload")
+					}
+				}
+			})
+
+			b.Run("MarshalPlusSetSnoozes", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for range b.N {
+					marshaled, err := json.Marshal(metadataUpdates)
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					// Matches snooze result handling in JobExecutor.reportResult.
+					marshaled, err = sjson.SetBytes(marshaled, "snoozes", snoozesValue+1)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(marshaled) == 0 {
+						b.Fatal("expected non-empty metadata updates payload")
+					}
+				}
+			})
+
+			b.Run("SetSnoozesInMapThenMarshal", func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for range b.N {
+					// Matches the optimized reportResult path where snoozes is
+					// added to the map before a single marshal.
+					metadataUpdates["snoozes"] = snoozesValue + 1
+
+					marshaled, err := json.Marshal(metadataUpdates)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(marshaled) == 0 {
+						b.Fatal("expected non-empty metadata updates payload")
+					}
+				}
+			})
+		})
+	}
+}
+
+type benchmarkLogAttempt struct {
+	Attempt int    `json:"attempt"`
+	Log     string `json:"log"`
+}
+
+func makeRiverLogArrayWithApproxSize(targetBytes int) []byte {
+	if targetBytes <= 0 {
+		return []byte("[]")
+	}
+
+	const perEntryLogSize = 1024
+	payload := strings.Repeat("x", perEntryLogSize)
+	numEntries := max(1, targetBytes/perEntryLogSize)
+
+	logs := make([]benchmarkLogAttempt, numEntries)
+	for i := range numEntries {
+		logs[i] = benchmarkLogAttempt{
+			Attempt: i + 1,
+			Log:     payload,
+		}
+	}
+
+	arrayBytes, err := json.Marshal(logs)
+	if err != nil {
+		panic(err)
+	}
+
+	return arrayBytes
+}


### PR DESCRIPTION
Following up on #1157, this is another metadata update optimization aimed specifically at job snoozing when the metadata payload is large.

Snoozed jobs with large `river:log` payloads were still paying an extra full-blob rewrite in `jobexecutor.reportResult`. The code marshaled `MetadataUpdates` and then used `sjson.SetBytes` to increment `snoozes`, which re-encoded the entire JSON payload.

Change snooze handling to set `snoozes` directly in the `res.MetadataUpdates` map before marshaling. This keeps behavior the same while avoiding the second large copy. The method now funnels marshal logic through a small helper used by both snooze and non-snooze paths.

Add focused benchmarks for this hot path, including 256 KB, 2 MB, and 8 MB `river:log` cases with both old-style and optimized approaches. Extend driver benchmarks with large metadata cases for `JobSetStateIfRunningMany` and `JobGetAvailable` to track driver-side amplification in fetch and update paths.

### Benchmark results

`go test ./internal/jobexecutor -run '^$' -bench BenchmarkMetadataUpdatesBytesForSnooze -benchmem -count=1`

Comparison uses:
- **Before** = `marshal_plus_set_snoozes` (old behavior)
- **After** = `set_snoozes_in_map_then_marshal` (new behavior)

| Payload | Time Before (ns/op) | Time After (ns/op) | Time Delta | Mem Before (B/op) | Mem After (B/op) | Mem Delta | Allocs Before | Allocs After | Allocs Delta |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| `log_256kb` | 724,336 | 689,045 | -4.9% | 543,119 | 271,046 | -50.1% | 6 | 6 | 0% |
| `log_2mb` | 5,676,874 | 5,344,169 | -5.9% | 4,749,888 | 2,165,160 | -54.4% | 9 | 7 | -22.2% |
| `log_8mb` | 23,097,605 | 21,641,865 | -6.3% | 18,386,022 | 8,602,858 | -53.2% | 9 | 7 | -22.2% |

Net: this change gives a modest CPU win and a large memory win on snooze metadata updates, especially at larger payload sizes.