### PR TITLE
Fix river leader leadership.Elector: Error attempting to elect for bun/driver/pgdriver

### DIFF
--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_leader.sql.go
@@ -19,7 +19,7 @@ INSERT INTO /* TEMPLATE: schema */river_leader (
 ) VALUES (
     $1,
     coalesce($2::timestamptz, now()),
-    -- @ttl is inserted as as seconds rather than a duration because ` + "`" + `lib/pq` + "`" + ` doesn't support the latter
+    -- @ttl is inserted as seconds rather than a duration because ` + "`" + `lib/pq` + "`" + ` does not support the latter
     coalesce($2::timestamptz, now()) + make_interval(secs => $3)
 )
 ON CONFLICT (name)

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql
@@ -15,7 +15,7 @@ INSERT INTO /* TEMPLATE: schema */river_leader (
 ) VALUES (
     @leader_id,
     coalesce(sqlc.narg('now')::timestamptz, now()),
-    -- @ttl is inserted as as seconds rather than a duration because `lib/pq` doesn't support the latter
+    -- @ttl is inserted as seconds rather than a duration because `lib/pq` does not support the latter
     coalesce(sqlc.narg('now')::timestamptz, now()) + make_interval(secs => @ttl)
 )
 ON CONFLICT (name)

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_leader.sql.go
@@ -20,7 +20,7 @@ INSERT INTO /* TEMPLATE: schema */river_leader (
 ) VALUES (
     $1,
     coalesce($2::timestamptz, now()),
-    -- @ttl is inserted as as seconds rather than a duration because ` + "`" + `lib/pq` + "`" + ` doesn't support the latter
+    -- @ttl is inserted as seconds rather than a duration because ` + "`" + `lib/pq` + "`" + ` does not support the latter
     coalesce($2::timestamptz, now()) + make_interval(secs => $3)
 )
 ON CONFLICT (name)


### PR DESCRIPTION
Fix `msg="leadership.Elector: Error attempting to elect" attempt=60 client_id=ff0776778fd5_2026_03_08T17_11_23_841380 err="ERROR: there is no parameter $2 (SQLSTATE=42P02)"` error for `bun/driver/pgdriver`.

Issue: https://github.com/riverqueue/river/issues/1162