### PR TITLE
Fix periodic enqueue test flakiness

### DIFF
--- a/internal/maintenance/periodic_job_enqueuer_test.go
+++ b/internal/maintenance/periodic_job_enqueuer_test.go
@@ -962,19 +962,25 @@ func TestPeriodicJobEnqueuer(t *testing.T) {
 		}
 
 		_, err := svc.AddManySafely([]*PeriodicJob{
-			{ScheduleFunc: periodicIntervalSchedule(100 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_100ms", false)},
-			{ScheduleFunc: periodicIntervalSchedule(500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_500ms", false)},
-			{ScheduleFunc: periodicIntervalSchedule(1500 * time.Millisecond), ConstructorFunc: jobConstructorFunc("periodic_job_1500ms", false)},
+			{
+				ConstructorFunc: jobConstructorFunc("periodic_job_no_id_start", false),
+				RunOnStart:      true,
+				ScheduleFunc:    periodicIntervalSchedule(10 * time.Second),
+			},
 		})
 		require.NoError(t, err)
 
 		startService(t, svc)
 
 		svc.TestSignals.InsertedJobs.WaitOrTimeout()
-		requireNJobs(t, bundle, "periodic_job_100ms", 1)
-		require.False(t, periodicJobUpsertManyMockCalled)
+
+		requireNJobs(t, bundle, "periodic_job_no_id_start", 1)
 
 		svc.TestSignals.PeriodicJobKeepAliveAndReap.WaitOrTimeout()
+
+		svc.Stop()
+
+		require.False(t, periodicJobUpsertManyMockCalled)
 		require.False(t, periodicJobKeepAliveAndReapMockCalled)
 	})
 


### PR DESCRIPTION
I've been seeing a few failures recently ([1](https://github.com/riverqueue/river/actions/runs/22471420916/job/65089036291) [2](https://github.com/riverqueue/river/actions/runs/23114627657/job/67137937381)) in our periodic enqueuer tests in CI. This fixes two flaky tests by removing timing-sensitive assertions and aligning each test with a single, well-defined phase of the service lifecycle.

The first flake came from a test that mixed startup durable-state reconciliation with the case where a durable periodic job was already due when the service started. With very short schedules, the due job could run again before the test observed Pilot upserts, so the expected startup batch and the post-run batch raced each other under `-race`. The fix splits that coverage into two tests with longer schedules: one that verifies startup state restoration without any job runs, and one that verifies a due durable job runs once and advances `nextRunAt`. Each test now waits explicitly for the relevant startup upsert, job insert, and follow-up upsert before asserting.

The second flake came from `PilotNotInvokedWithoutID`, which used short timer-driven anonymous jobs to prove that periodic work happened before checking that Pilot upsert and keepalive were never called. That made the test depend on scheduler cadence rather than the behavior it was actually trying to verify. The fix replaces that setup with a single anonymous `RunOnStart` job, waits for the keepalive loop to tick, stops the service, and then asserts that Pilot was never invoked. This keeps the original coverage while making the result deterministic.