### PR TITLE
Quote schema name in operations to support special characters and spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `riverlog.Middleware` now supports `MiddlewareConfig.MaxTotalBytes` (default 8 MB) to cap total persisted `river:log` history per job. When the cap is exceeded, oldest log entries are dropped first while retaining the newest entry. Values over 64 MB are clamped to 64 MB. [PR #1157](https://github.com/riverqueue/river/pull/1157).
 - Improved `riverlog` performance and reduced memory amplification when appending to large persisted `river:log` histories. [PR #1157](https://github.com/riverqueue/river/pull/1157).
 - Reduced snooze-path memory amplification by setting `snoozes` in metadata updates before marshaling, avoiding an extra full-payload JSON rewrite. [PR #1159](https://github.com/riverqueue/river/pull/1159).
+- Schema names are now quoted in SQL operations, enabling the use of spaces and other odd characters. [PR #1175](https://github.com/riverqueue/river/pull/1175).
 
 ### Fixed
 

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverdatabasesql/internal/dbsqlc"
 	"github.com/riverqueue/river/rivershared/sqlctemplate"
 	"github.com/riverqueue/river/rivershared/uniquestates"
+	"github.com/riverqueue/river/rivershared/util/dbutil"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/savepointutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
@@ -143,7 +144,7 @@ func (e *Executor) Exec(ctx context.Context, sql string, args ...any) error {
 func (e *Executor) IndexDropIfExists(ctx context.Context, params *riverdriver.IndexDropIfExistsParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	_, err := e.dbtx.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS "+maybeSchema+params.Index)
@@ -164,7 +165,7 @@ func (e *Executor) IndexExists(ctx context.Context, params *riverdriver.IndexExi
 func (e *Executor) IndexReindex(ctx context.Context, params *riverdriver.IndexReindexParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	_, err := e.dbtx.ExecContext(ctx, "REINDEX INDEX CONCURRENTLY "+maybeSchema+params.Index)
@@ -972,12 +973,12 @@ func (e *Executor) QueryRow(ctx context.Context, sql string, args ...any) riverd
 }
 
 func (e *Executor) SchemaCreate(ctx context.Context, params *riverdriver.SchemaCreateParams) error {
-	_, err := e.dbtx.ExecContext(ctx, "CREATE SCHEMA "+params.Schema)
+	_, err := e.dbtx.ExecContext(ctx, "CREATE SCHEMA "+dbutil.SafeIdentifier(params.Schema))
 	return interpretError(err)
 }
 
 func (e *Executor) SchemaDrop(ctx context.Context, params *riverdriver.SchemaDropParams) error {
-	_, err := e.dbtx.ExecContext(ctx, "DROP SCHEMA "+params.Schema+" CASCADE")
+	_, err := e.dbtx.ExecContext(ctx, "DROP SCHEMA "+dbutil.SafeIdentifier(params.Schema)+" CASCADE")
 	return interpretError(err)
 }
 
@@ -996,7 +997,7 @@ func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExi
 	// Different from other operations because the schemaAndTable name is a parameter.
 	schemaAndTable := params.Table
 	if params.Schema != "" {
-		schemaAndTable = params.Schema + "." + schemaAndTable
+		schemaAndTable = dbutil.SafeIdentifier(params.Schema) + "." + schemaAndTable
 	}
 
 	exists, err := dbsqlc.New().TableExists(ctx, e.dbtx, schemaAndTable)
@@ -1006,7 +1007,7 @@ func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExi
 func (e *Executor) TableTruncate(ctx context.Context, params *riverdriver.TableTruncateParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	// Uses raw SQL so we can truncate multiple tables at once.
@@ -1240,7 +1241,7 @@ func queueFromInternal(internal *dbsqlc.RiverQueue) *rivertype.Queue {
 
 func schemaTemplateParam(ctx context.Context, schema string) context.Context {
 	if schema != "" {
-		schema += "."
+		schema = dbutil.SafeIdentifier(schema) + "."
 	}
 
 	return sqlctemplate.WithReplacements(ctx, map[string]sqlctemplate.Replacement{

--- a/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
@@ -113,6 +113,6 @@ func TestSchemaTemplateParam(t *testing.T) {
 			nil,
 		)
 		require.NoError(t, err)
-		require.Equal(t, "SELECT 1 FROM custom_schema.river_job", updatedSQL)
+		require.Equal(t, `SELECT 1 FROM "custom_schema".river_job`, updatedSQL)
 	})
 }

--- a/riverdriver/riverdrivertest/riverdrivertest.go
+++ b/riverdriver/riverdrivertest/riverdrivertest.go
@@ -36,6 +36,7 @@ func Exercise[TTx any](ctx context.Context, t *testing.T,
 	exerciseSQLFragments(ctx, t, executorWithTx)
 	exerciseExecutorTx(ctx, t, driverWithSchema, executorWithTx)
 	exerciseSchemaIntrospection(ctx, t, driverWithSchema, executorWithTx)
+	exerciseSchemaName(ctx, t, driverWithSchema)
 	exerciseJobInsert(ctx, t, driverWithSchema, executorWithTx)
 	exerciseJobRead(ctx, t, executorWithTx)
 	exerciseJobUpdate(ctx, t, executorWithTx)

--- a/riverdriver/riverdrivertest/schema_name.go
+++ b/riverdriver/riverdrivertest/schema_name.go
@@ -1,0 +1,99 @@
+package riverdrivertest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/riverdbtest"
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/rivermigrate"
+	"github.com/riverqueue/river/rivershared/riversharedtest"
+	"github.com/riverqueue/river/rivershared/util/randutil"
+	"github.com/riverqueue/river/rivertype"
+)
+
+func exerciseSchemaName[TTx any](ctx context.Context, t *testing.T,
+	driverWithSchema func(ctx context.Context, t *testing.T, opts *riverdbtest.TestSchemaOpts) (riverdriver.Driver[TTx], string),
+) {
+	t.Helper()
+
+	t.Run("SchemaNameWithSpace", func(t *testing.T) {
+		t.Parallel()
+
+		driver, _ := driverWithSchema(ctx, t, nil)
+
+		// In SQLite schemas are files assigned to particular names, so this
+		// check isn't relevant in the same way.
+		if driver.DatabaseName() != databaseNamePostgres {
+			t.Skip("Skipping; schema names with spaces only relevant for Postgres")
+		}
+
+		// Schemas should get cleaned up, but still need some randomness in case
+		// multiple tests are running in parallel.
+		schema := "river test schema " + randutil.Hex(8)
+
+		exec := driver.GetExecutor()
+
+		require.NoError(t, exec.SchemaCreate(ctx, &riverdriver.SchemaCreateParams{Schema: schema}))
+		t.Cleanup(func() {
+			require.NoError(t, exec.SchemaDrop(ctx, &riverdriver.SchemaDropParams{Schema: schema}))
+		})
+
+		migrator, err := rivermigrate.New(driver, &rivermigrate.Config{
+			Logger: riversharedtest.Logger(t),
+			Schema: schema,
+		})
+		require.NoError(t, err)
+
+		_, err = migrator.Migrate(ctx, rivermigrate.DirectionUp, nil)
+		require.NoError(t, err)
+
+		// Insert a job and verify it can be read back.
+		insertedJobs, err := exec.JobInsertFastMany(ctx, &riverdriver.JobInsertFastManyParams{
+			Jobs: []*riverdriver.JobInsertFastParams{{
+				EncodedArgs: []byte(`{}`),
+				Kind:        "test_kind",
+				MaxAttempts: 25,
+				Metadata:    []byte(`{}`),
+				Priority:    1,
+				Queue:       "default",
+				State:       rivertype.JobStateAvailable,
+			}},
+			Schema: schema,
+		})
+		require.NoError(t, err)
+		require.Len(t, insertedJobs, 1)
+
+		fetchedJob, err := exec.JobGetByID(ctx, &riverdriver.JobGetByIDParams{
+			ID:     insertedJobs[0].Job.ID,
+			Schema: schema,
+		})
+		require.NoError(t, err)
+		require.Equal(t, insertedJobs[0].Job.ID, fetchedJob.ID)
+		require.Equal(t, "test_kind", fetchedJob.Kind)
+
+		// Verify the table exists in the schema.
+		exists, err := exec.TableExists(ctx, &riverdriver.TableExistsParams{
+			Schema: schema,
+			Table:  "river_job",
+		})
+		require.NoError(t, err)
+		require.True(t, exists)
+
+		// Migrate back down.
+		_, err = migrator.Migrate(ctx, rivermigrate.DirectionDown, &rivermigrate.MigrateOpts{
+			TargetVersion: -1,
+		})
+		require.NoError(t, err)
+
+		// Verify tables are gone.
+		exists, err = exec.TableExists(ctx, &riverdriver.TableExistsParams{
+			Schema: schema,
+			Table:  "river_job",
+		})
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+}

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverpgxv5/internal/dbsqlc"
 	"github.com/riverqueue/river/rivershared/sqlctemplate"
 	"github.com/riverqueue/river/rivershared/uniquestates"
+	"github.com/riverqueue/river/rivershared/util/dbutil"
 	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
@@ -151,7 +152,7 @@ func (e *Executor) Exec(ctx context.Context, sql string, args ...any) error {
 func (e *Executor) IndexDropIfExists(ctx context.Context, params *riverdriver.IndexDropIfExistsParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	_, err := e.dbtx.Exec(ctx, "DROP INDEX CONCURRENTLY IF EXISTS "+maybeSchema+params.Index)
@@ -172,7 +173,7 @@ func (e *Executor) IndexExists(ctx context.Context, params *riverdriver.IndexExi
 func (e *Executor) IndexReindex(ctx context.Context, params *riverdriver.IndexReindexParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	_, err := e.dbtx.Exec(ctx, "REINDEX INDEX CONCURRENTLY "+maybeSchema+params.Index)
@@ -957,12 +958,12 @@ func (e *Executor) QueryRow(ctx context.Context, sql string, args ...any) riverd
 }
 
 func (e *Executor) SchemaCreate(ctx context.Context, params *riverdriver.SchemaCreateParams) error {
-	_, err := e.dbtx.Exec(ctx, "CREATE SCHEMA "+params.Schema)
+	_, err := e.dbtx.Exec(ctx, "CREATE SCHEMA "+dbutil.SafeIdentifier(params.Schema))
 	return interpretError(err)
 }
 
 func (e *Executor) SchemaDrop(ctx context.Context, params *riverdriver.SchemaDropParams) error {
-	_, err := e.dbtx.Exec(ctx, "DROP SCHEMA "+params.Schema+" CASCADE")
+	_, err := e.dbtx.Exec(ctx, "DROP SCHEMA "+dbutil.SafeIdentifier(params.Schema)+" CASCADE")
 	return interpretError(err)
 }
 
@@ -981,7 +982,7 @@ func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExi
 	// Different from other operations because the schemaAndTable name is a parameter.
 	schemaAndTable := params.Table
 	if params.Schema != "" {
-		schemaAndTable = params.Schema + "." + schemaAndTable
+		schemaAndTable = dbutil.SafeIdentifier(params.Schema) + "." + schemaAndTable
 	}
 
 	exists, err := dbsqlc.New().TableExists(ctx, e.dbtx, schemaAndTable)
@@ -991,7 +992,7 @@ func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExi
 func (e *Executor) TableTruncate(ctx context.Context, params *riverdriver.TableTruncateParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	// Uses raw SQL so we can truncate multiple tables at once.
@@ -1303,7 +1304,7 @@ func schemaCopyFrom(ctx context.Context, schema string) context.Context {
 
 func schemaTemplateParam(ctx context.Context, schema string) context.Context {
 	if schema != "" {
-		schema += "."
+		schema = dbutil.SafeIdentifier(schema) + "."
 	}
 
 	return sqlctemplate.WithReplacements(ctx, map[string]sqlctemplate.Replacement{

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver_test.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver_test.go
@@ -236,7 +236,7 @@ func TestSchemaTemplateParam(t *testing.T) {
 			nil,
 		)
 		require.NoError(t, err)
-		require.Equal(t, "SELECT 1 FROM custom_schema.river_job", updatedSQL)
+		require.Equal(t, `SELECT 1 FROM "custom_schema".river_job`, updatedSQL)
 	})
 }
 

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -199,7 +199,7 @@ func (e *Executor) Exec(ctx context.Context, sql string, args ...any) error {
 func (e *Executor) IndexDropIfExists(ctx context.Context, params *riverdriver.IndexDropIfExistsParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	_, err := e.dbtx.ExecContext(ctx, "DROP INDEX IF EXISTS "+maybeSchema+params.Index)
@@ -214,7 +214,7 @@ func (e *Executor) IndexExists(ctx context.Context, params *riverdriver.IndexExi
 func (e *Executor) IndexReindex(ctx context.Context, params *riverdriver.IndexReindexParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	_, err := e.dbtx.ExecContext(ctx, "REINDEX "+maybeSchema+params.Index)
@@ -1452,7 +1452,7 @@ func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExi
 func (e *Executor) TableTruncate(ctx context.Context, params *riverdriver.TableTruncateParams) error {
 	var maybeSchema string
 	if params.Schema != "" {
-		maybeSchema = params.Schema + "."
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
 	}
 
 	// SQLite doesn't have a `TRUNCATE` command, but `DELETE FROM` is optimized
@@ -1672,7 +1672,7 @@ func migrationFromInternal(internal *dbsqlc.RiverMigration) *riverdriver.Migrati
 
 func schemaTemplateParam(ctx context.Context, schema string) context.Context {
 	if schema != "" {
-		schema += "."
+		schema = dbutil.SafeIdentifier(schema) + "."
 	}
 
 	return sqlctemplate.WithReplacements(ctx, map[string]sqlctemplate.Replacement{

--- a/riverdriver/riversqlite/river_sqlite_driver_test.go
+++ b/riverdriver/riversqlite/river_sqlite_driver_test.go
@@ -92,6 +92,6 @@ func TestSchemaTemplateParam(t *testing.T) {
 			nil,
 		)
 		require.NoError(t, err)
-		require.Equal(t, "SELECT 1 FROM custom_schema.river_job", updatedSQL)
+		require.Equal(t, `SELECT 1 FROM "custom_schema".river_job`, updatedSQL)
 	})
 }

--- a/rivermigrate/river_migrate.go
+++ b/rivermigrate/river_migrate.go
@@ -547,7 +547,7 @@ func (m *Migrator[TTx]) applyMigrations(ctx context.Context, exec riverdriver.Ex
 
 	var schema string
 	if m.schema != "" {
-		schema = m.schema + "."
+		schema = dbutil.SafeIdentifier(m.schema) + "."
 	}
 	schemaReplacement := map[string]sqlctemplate.Replacement{
 		"schema": {Value: schema},

--- a/rivershared/util/dbutil/db_util.go
+++ b/rivershared/util/dbutil/db_util.go
@@ -3,10 +3,18 @@ package dbutil
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/riverqueue/river/riverdriver"
 )
+
+// SafeIdentifier returns a safely quoted identifier (e.g. a table or schem
+// name) for use in SQL queries. It wraps the identifier in quotes and escapes
+// any internal quotes as appropriate.
+func SafeIdentifier(ident string) string {
+	return `"` + strings.ReplaceAll(ident, `"`, `""`) + `"`
+}
 
 // RollbackWithoutCancel initiates a rollback, but one in which context is
 // overridden with context.WithoutCancel so that the rollback can proceed even

--- a/rivershared/util/dbutil/db_util_test.go
+++ b/rivershared/util/dbutil/db_util_test.go
@@ -14,6 +14,18 @@ import (
 	"github.com/riverqueue/river/rivershared/util/dbutil"
 )
 
+func TestSafeIdentifier(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, `"simple"`, dbutil.SafeIdentifier("simple"))
+	require.Equal(t, `"has space"`, dbutil.SafeIdentifier("has space"))
+	require.Equal(t, `"has""quote"`, dbutil.SafeIdentifier(`has"quote`))
+	require.Equal(t, `"has""""many"`, dbutil.SafeIdentifier(`has""many`))
+	require.Equal(t, `""`, dbutil.SafeIdentifier(""))
+	require.Equal(t, `"my_schema"`, dbutil.SafeIdentifier("my_schema"))
+	require.Equal(t, `"MixedCase"`, dbutil.SafeIdentifier("MixedCase"))
+}
+
 func TestRollbackCancelOverride(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Came up in #1170: we don't quote schemas in SQL operations, and that can
lead to problems in use of spaces, special characters, and uppercase
characters. It's not the end of the world given use of the above can be
considered a sizable anti-pattern anyway, but use of quoting is good for
general correctness.

Fixes #1170.