### PR TITLE
drop JSON cast cache in text-mode adapter

### DIFF
--- a/riverdriver/riverpgxv5/json_text_mode_adaptation.go
+++ b/riverdriver/riverpgxv5/json_text_mode_adaptation.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -39,13 +38,7 @@ type jsonPlaceholderCast struct {
 	isArray  bool
 }
 
-var jsonCastPlaceholderCache sync.Map //nolint:gochecknoglobals // Cache cast parsing for hot query paths.
-
 func jsonPlaceholderCasts(sql string) []jsonPlaceholderCast {
-	if cached, ok := jsonCastPlaceholderCache.Load(sql); ok {
-		return cached.([]jsonPlaceholderCast) //nolint:forcetypeassert
-	}
-
 	matches := jsonCastPlaceholderRegexp.FindAllStringSubmatch(sql, -1)
 	casts := make([]jsonPlaceholderCast, 0, len(matches))
 	seen := make(map[int]int, len(matches))
@@ -76,7 +69,6 @@ func jsonPlaceholderCasts(sql string) []jsonPlaceholderCast {
 		casts = append(casts, cast)
 	}
 
-	jsonCastPlaceholderCache.Store(sql, casts)
 	return casts
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the JSON text-mode parameter adaptation work from #1155.

`jsonPlaceholderCasts` currently caches parsed cast placeholders in a
process-wide map keyed by the full rendered SQL string. Because adaptation runs
after template schema replacement, varying schemas produce distinct cache keys
for otherwise-identical queries. In long-lived processes with many schema
values, this can grow monotonically over time.

This change drops the cast-placeholder cache and parses casts per call instead,
which keeps behavior unchanged while removing schema-driven unbounded cache
growth risk.

## Why this is safe

- The functional adaptation logic is unchanged.
- The additional parsing work only happens on text-mode adaptation paths.
- Existing adapter tests continue to validate behavior.

## Testing

- `go test ./riverdriver/riverpgxv5 ./riverdriver/riverdrivertest`
