### PR TITLE
Upgrade golangci-lint to 2.11.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -299,7 +299,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v2.10.1
+      GOLANGCI_LINT_VERSION: v2.11.4
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -624,7 +624,7 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 	for i := range len(params.ID) {
 		if params.Attempt[i] != nil {
 			setStateParams.AttemptDoUpdate[i] = true
-			setStateParams.Attempt[i] = int32(*params.Attempt[i])
+			setStateParams.Attempt[i] = int32(*params.Attempt[i]) //nolint:gosec
 		}
 		if params.ErrData[i] != nil {
 			setStateParams.ErrorsDoUpdate[i] = true


### PR DESCRIPTION
Upgrades golangci-lint to 2.11.4 to keep it on the same version as other
repositories. The version in there is already pretty recent, so no
changes are needed.