### PR TITLE
Guarantee output order in batch insertion example

### DIFF
--- a/example_batch_insert_test.go
+++ b/example_batch_insert_test.go
@@ -62,10 +62,6 @@ func Example_batchInsert() {
 	subscribeChan, subscribeCancel := riverClient.Subscribe(river.EventKindJobCompleted)
 	defer subscribeCancel()
 
-	if err := riverClient.Start(ctx); err != nil {
-		panic(err)
-	}
-
 	results, err := riverClient.InsertMany(ctx, []river.InsertManyParams{
 		{Args: BatchInsertArgs{}},
 		{Args: BatchInsertArgs{}},
@@ -77,6 +73,12 @@ func Example_batchInsert() {
 		panic(err)
 	}
 	fmt.Printf("Inserted %d jobs\n", len(results))
+
+	// Start the client after inserting and printing so that the "Inserted"
+	// message is guaranteed to appear before any "Worked" messages.
+	if err := riverClient.Start(ctx); err != nil {
+		panic(err)
+	}
 
 	// Wait for jobs to complete. Only needed for purposes of the example test.
 	riversharedtest.WaitOrTimeoutN(testutil.PanicTB(), subscribeChan, 5)


### PR DESCRIPTION
Aims to fix an intermittently failing example wherein we can print an
"Inserted ..." message after the work messages coming from each inserted
job.

https://github.com/riverqueue/river/actions/runs/24310710305/job/70979718727

    --- FAIL: Example_batchInsert (0.09s)
    got:
    Worked a job
    Worked a job
    Worked a job
    Worked a job
    Worked a job
    Inserted 5 jobs
    want:
    Inserted 5 jobs
    Worked a job
    Worked a job
    Worked a job
    Worked a job
    Worked a job
    FAIL
    FAIL	github.com/riverqueue/river	26.753s

The fix is pretty straightforward in making sure we do the inserts
(and therefore print the right message) before starting the client and
introducing the possibility that jobs can be worked.