### PR TITLE
Buffered `requestResignChan`

### DIFF
--- a/internal/leadership/elector.go
+++ b/internal/leadership/elector.go
@@ -139,7 +139,9 @@ func (e *Elector) Start(ctx context.Context) error {
 	// We'll send to this channel anytime a leader resigns on the key with `name`
 	e.leaderResignedChan = make(chan struct{})
 
-	e.requestResignChan = make(chan struct{})
+	// Buffered to 1 so a send from handleLeadershipNotification doesn't block
+	// if keepLeadershipLoop hasn't entered its select yet.
+	e.requestResignChan = make(chan struct{}, 1)
 
 	var sub *notifier.Subscription
 	if e.notifier == nil {

--- a/internal/leadership/elector_test.go
+++ b/internal/leadership/elector_test.go
@@ -344,6 +344,31 @@ func testElector[TElectorBundle any](
 		startstoptest.Stress(ctx, t, elector)
 	})
 
+	t.Run("RequestResignImmediatelyAfterElection", func(t *testing.T) {
+		t.Parallel()
+
+		elector, _ := setup(t, nil)
+
+		startElector(ctx, t, elector)
+
+		elector.testSignals.GainedLeadership.WaitOrTimeout()
+
+		// Send a resign request immediately after gaining leadership.
+		// GainedLeadership is signaled _before_ keepLeadershipLoop is
+		// entered, so the resign request arrives before the loop's
+		// select. This only works if requestResignChan is buffered;
+		// with an unbuffered channel the send would be dropped by the
+		// default case since nobody is receiving yet.
+		payload, err := json.Marshal(DBNotification{
+			Action: DBNotificationKindRequestResign,
+		})
+		require.NoError(t, err)
+		elector.handleLeadershipNotification(ctx, notifier.NotificationTopicLeadership, string(payload))
+
+		elector.testSignals.ResignedLeadership.WaitOrTimeout()
+		elector.testSignals.GainedLeadership.WaitOrTimeout()
+	})
+
 	t.Run("RequestResignStress", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Aims to fix another intermittent test failure:

https://github.com/riverqueue/river/actions/runs/24312716933/job/70985012980?pr=1205

    --- FAIL: TestElector_WithNotifier (0.00s)
        --- FAIL: TestElector_WithNotifier/RequestResignStress (20.41s)
            elector_test.go:350: Generated postgres schema "leadership_2026_04_12t17_52_43_schema_04" with migrations [1 2 3 4 5 6] on line "main" in 229.626141ms [4 generated] [0 reused]
            elector_test.go:352: Starting test_client_id
            elector_test.go:375: Requesting leadership resign
            elector_test.go:375: Requesting leadership resign
            elector_test.go:375: Requesting leadership resign
            elector_test.go:375: Requesting leadership resign
            elector_test.go:375: Requesting leadership resign
            test_signal.go:95: timed out waiting on test signal after 10s
            test_signal.go:95: timed out waiting on test signal after 10s
            riverdbtest.go:293: Checked in postgres schema "leadership_2026_04_12t17_52_43_schema_04"; 1 idle schema(s) [5 generated] [3 reused]
    FAIL
    FAIL	github.com/riverqueue/river/internal/leadership	20.948s

The problem is that when `requestResignChan` is unbuffered, if
`keepLeadershipLoop` hasn't yet entered its `select`, then the `default`
statement on the `select` below will cause all senders (we have 5
competing senders in the `RequestResignStress` test case) to fall
through without sending anything:

    select {
    case <-ctx.Done():
    case e.requestResignChan <- struct{}{}:
    default:
            // if context is not done and requestResignChan has an item in it
            // already, do nothing
    }

By making the channel buffered, we guarantee at least one sender gets a
message through, and we don't end up hanging the test.