### PR TITLE
fix race condition in batch completer stats

### DIFF
--- a/internal/jobcompleter/job_completer.go
+++ b/internal/jobcompleter/job_completer.go
@@ -513,7 +513,9 @@ func (c *BatchCompleter) JobSetStateIfRunning(ctx context.Context, stats *jobsta
 	c.setStateParamsMu.Lock()
 	defer c.setStateParamsMu.Unlock()
 
-	c.setStateParams[params.ID] = &batchCompleterSetState{params, stats}
+	statsSnapshot := *stats
+
+	c.setStateParams[params.ID] = &batchCompleterSetState{params, &statsSnapshot}
 	c.setStateStartTimes[params.ID] = now
 
 	return nil

--- a/internal/jobcompleter/job_completer_test.go
+++ b/internal/jobcompleter/job_completer_test.go
@@ -487,6 +487,65 @@ func TestBatchCompleter(t *testing.T) {
 	})
 }
 
+func TestBatchCompleter_JobStatsSnapshotsPerUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		completer   *BatchCompleter
+		sharedStats *jobstats.JobStatistics
+		subscribeCh chan []CompleterJobUpdated
+	}
+
+	setup := func(t *testing.T) *testBundle {
+		t.Helper()
+
+		execMock := &partialExecutorMock{}
+		execMock.JobSetStateIfRunningManyFunc = func(ctx context.Context, params *riverdriver.JobSetStateIfRunningManyParams) ([]*rivertype.JobRow, error) {
+			rows := make([]*rivertype.JobRow, len(params.ID))
+			for i := range params.ID {
+				rows[i] = &rivertype.JobRow{
+					ID:    params.ID[i],
+					State: params.State[i],
+				}
+			}
+			return rows, nil
+		}
+
+		subscribeCh := make(chan []CompleterJobUpdated, 2)
+		completer := NewBatchCompleter(riversharedtest.BaseServiceArchetype(t), "", execMock, &riverpilot.StandardPilot{}, subscribeCh)
+		completer.disableSleep = true
+
+		return &testBundle{
+			completer: completer,
+			sharedStats: &jobstats.JobStatistics{
+				QueueWaitDuration: 11 * time.Millisecond,
+				RunDuration:       13 * time.Millisecond,
+			},
+			subscribeCh: subscribeCh,
+		}
+	}
+
+	bundle := setup(t)
+
+	require.NoError(t, bundle.completer.JobSetStateIfRunning(ctx, bundle.sharedStats, riverdriver.JobSetStateCompleted(1, time.Now(), nil)))
+	require.NoError(t, bundle.completer.handleBatch(ctx))
+
+	firstUpdates := riversharedtest.WaitOrTimeout(t, bundle.subscribeCh)
+	require.Len(t, firstUpdates, 1)
+
+	require.NoError(t, bundle.completer.JobSetStateIfRunning(ctx, bundle.sharedStats, riverdriver.JobSetStateCompleted(2, time.Now(), nil)))
+	require.NoError(t, bundle.completer.handleBatch(ctx))
+
+	secondUpdates := riversharedtest.WaitOrTimeout(t, bundle.subscribeCh)
+	require.Len(t, secondUpdates, 1)
+
+	require.NotSame(t, bundle.sharedStats, firstUpdates[0].JobStats)
+	require.NotSame(t, bundle.sharedStats, secondUpdates[0].JobStats)
+	require.NotSame(t, firstUpdates[0].JobStats, secondUpdates[0].JobStats)
+}
+
 func TestInlineCompleter(t *testing.T) {
 	t.Parallel()
 

--- a/rivershared/cmd/update-mod-go/main.go
+++ b/rivershared/cmd/update-mod-go/main.go
@@ -42,7 +42,7 @@ func run() error {
 		return err
 	}
 
-	workFileData, err := os.ReadFile(workFilename) //nolint:gosec // validated by localPath
+	workFileData, err := os.ReadFile(workFilename)
 	if err != nil {
 		return fmt.Errorf("error reading file %q: %w", workFilename, err)
 	}
@@ -98,7 +98,7 @@ func localPath(baseDir, filename string) (string, error) {
 }
 
 func parseAndUpdateGoModFile(checkOnly bool, modFilename, workFilename, workGoVersion, workToolchainName string) (bool, error) {
-	modFileData, err := os.ReadFile(modFilename) //nolint:gosec // validated by localPath
+	modFileData, err := os.ReadFile(modFilename)
 	if err != nil {
 		return false, fmt.Errorf("error reading file %q: %w", modFilename, err)
 	}

--- a/rivershared/cmd/update-mod-go/main_test.go
+++ b/rivershared/cmd/update-mod-go/main_test.go
@@ -31,7 +31,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 
 		file, err := os.CreateTemp(t.TempDir(), "go.mod")
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = os.Remove(file.Name()) }) //nolint:gosec // temp file path comes from os.CreateTemp
+		t.Cleanup(func() { _ = os.Remove(file.Name()) })
 
 		_, err = file.WriteString(sampleGoMod)
 		require.NoError(t, err)

--- a/rivershared/cmd/update-mod-version/main.go
+++ b/rivershared/cmd/update-mod-version/main.go
@@ -51,7 +51,7 @@ func run() error {
 		return err
 	}
 
-	workFileData, err := os.ReadFile(workFilename) //nolint:gosec // validated by localPath
+	workFileData, err := os.ReadFile(workFilename)
 	if err != nil {
 		return fmt.Errorf("error reading file %q: %w", workFilename, err)
 	}
@@ -97,7 +97,7 @@ func localPath(baseDir, filename string) (string, error) {
 }
 
 func parseAndUpdateGoModFile(filename, packagePrefix, version string) (bool, error) {
-	fileData, err := os.ReadFile(filename) //nolint:gosec // validated by localPath
+	fileData, err := os.ReadFile(filename)
 	if err != nil {
 		return false, fmt.Errorf("error reading file %q: %w", filename, err)
 	}

--- a/rivershared/cmd/update-mod-version/main_test.go
+++ b/rivershared/cmd/update-mod-version/main_test.go
@@ -36,7 +36,7 @@ func TestParseAndUpdateGoModFile(t *testing.T) {
 
 		file, err := os.CreateTemp(t.TempDir(), "go.mod")
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = os.Remove(file.Name()) }) //nolint:gosec // temp file path comes from os.CreateTemp
+		t.Cleanup(func() { _ = os.Remove(file.Name()) })
 
 		_, err = file.WriteString(sampleGoMod)
 		require.NoError(t, err)


### PR DESCRIPTION
Batch completion could race when multiple job completions reused the
same `JobStatistics` pointer. Short excerpt from the race detector
failure in a recent CI run:

    WARNING: DATA RACE
    Write at ... BatchCompleter.handleBatch.func4()
    .../internal/jobcompleter/job_completer.go:482
    Previous read ... jobStatisticsFromInternal()
    .../event.go:75

`BatchCompleter` queued the caller's stats pointer directly and later
mutated `CompleteDuration` before publishing updates. Batch job error
paths can reuse one stats object across multiple completions, so a later
batch could mutate stats that were already visible to subscribers.

Take a snapshot of `JobStatistics` when queuing the completion so each
published update owns an immutable copy. Add regression coverage that
queues two completions with a shared stats pointer and verifies that
each published update has a distinct snapshot.