### PR TITLE
Add queue-state count regression benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new `HookQueueStateCount` hook which is run by a River leader to generate queue count statistics. [PR #1203](https://github.com/riverqueue/river/pull/1203).
+- Middleware that implements `rivertype.Hook` can be looked up as hooks even if passed into `Config.Middleware`. Similarly, hooks that implement `rivertype.Middleware` can be looked up as middleware even if passed into `Config.Hooks`. [PR #1203](https://github.com/riverqueue/river/pull/1203).
+
 ## [0.34.0] - 2026-04-08
 
 ### Added

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -657,6 +658,7 @@ type clientTestSignals struct {
 	periodicJobEnqueuer   *maintenance.PeriodicJobEnqueuerTestSignals
 	queueCleaner          *maintenance.QueueCleanerTestSignals
 	queueMaintainerLeader *maintenance.QueueMaintainerLeaderTestSignals
+	queueStateCounter     *maintenance.QueueStateCounterTestSignals
 	reindexer             *maintenance.ReindexerTestSignals
 }
 
@@ -678,6 +680,9 @@ func (ts *clientTestSignals) Init(tb testutil.TestingTB) {
 	}
 	if ts.queueMaintainerLeader != nil {
 		ts.queueMaintainerLeader.Init(tb)
+	}
+	if ts.queueStateCounter != nil {
+		ts.queueStateCounter.Init(tb)
 	}
 	if ts.reindexer != nil {
 		ts.reindexer.Init(tb)
@@ -759,7 +764,7 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 		config:               config,
 		driver:               driver,
 		hookLookupByJob:      hooklookup.NewJobHookLookup(),
-		hookLookupGlobal:     hooklookup.NewHookLookup(config.Hooks),
+		hookLookupGlobal:     nil, // initialized below after cross-referencing with middleware
 		producersByQueueName: make(map[string]*producer),
 		testSignals:          clientTestSignals{},
 		workCancel:           func(cause error) {}, // replaced on start, but here in case StopAndCancel is called before start up
@@ -780,9 +785,9 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 	// the more abstract config.Middleware for middleware are set, but not both,
 	// so in practice we never append all three of these to each other.
 	{
-		middleware := config.Middleware
+		middlewares := config.Middleware
 		for _, jobInsertMiddleware := range config.JobInsertMiddleware {
-			middleware = append(middleware, jobInsertMiddleware)
+			middlewares = append(middlewares, jobInsertMiddleware)
 		}
 	outerLoop:
 		for _, workerMiddleware := range config.WorkerMiddleware {
@@ -798,16 +803,44 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 				}
 			}
 
-			middleware = append(middleware, workerMiddleware)
+			middlewares = append(middlewares, workerMiddleware)
 		}
 
-		for _, middleware := range middleware {
+		for _, middleware := range middlewares {
 			if withBaseService, ok := middleware.(baseservice.WithBaseService); ok {
 				baseservice.Init(archetype, withBaseService)
 			}
 		}
 
-		client.middlewareLookupGlobal = middlewarelookup.NewMiddlewareLookup(middleware)
+		// Cross-reference hooks and middleware: any middleware that also
+		// implements Hook is added to hooks, and any hook that also implements
+		// Middleware is added to middleware. Deduplication prevents double
+		// registration when the same struct is passed to both Config.Hooks and
+		// Config.Middleware.
+		hooks := config.Hooks
+
+		for _, middleware := range middlewares {
+			if hook, ok := middleware.(rivertype.Hook); ok {
+				// Only add if this middleware isn't already in hooks (it may
+				// have been passed to both config properties).
+				alreadyInHooks := slices.Contains(hooks, hook)
+				if !alreadyInHooks {
+					hooks = append(hooks, hook)
+				}
+			}
+		}
+
+		for _, hook := range config.Hooks {
+			if middleware, ok := hook.(rivertype.Middleware); ok {
+				alreadyInMiddleware := slices.Contains(middlewares, middleware)
+				if !alreadyInMiddleware {
+					middlewares = append(middlewares, middleware)
+				}
+			}
+		}
+
+		client.hookLookupGlobal = hooklookup.NewHookLookup(hooks)
+		client.middlewareLookupGlobal = middlewarelookup.NewMiddlewareLookup(middlewares)
 	}
 
 	pluginDriver, _ := driver.(driverPlugin[TTx])
@@ -959,6 +992,16 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 			}, driver.GetExecutor())
 			maintenanceServices = append(maintenanceServices, queueCleaner)
 			client.testSignals.queueCleaner = &queueCleaner.TestSignals
+		}
+
+		{
+			queueStateCounter := maintenance.NewQueueStateCounter(archetype, &maintenance.QueueStateCounterConfig{
+				HookLookupGlobal: client.hookLookupGlobal,
+				QueueNames:       maputil.Keys(config.Queues),
+				Schema:           config.Schema,
+			}, driver.GetExecutor())
+			maintenanceServices = append(maintenanceServices, queueStateCounter)
+			client.testSignals.queueStateCounter = &queueStateCounter.TestSignals
 		}
 
 		{

--- a/client_test.go
+++ b/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tidwall/sjson"
 
 	"github.com/riverqueue/river/internal/dbunique"
+	"github.com/riverqueue/river/internal/hooklookup"
 	"github.com/riverqueue/river/internal/jobexecutor"
 	"github.com/riverqueue/river/internal/maintenance"
 	"github.com/riverqueue/river/internal/middlewarelookup"
@@ -7627,6 +7628,46 @@ func Test_NewClient_Validations(t *testing.T) {
 			},
 		},
 		{
+			name: "Middleware implementing Hook is available in hook lookup",
+			configFunc: func(config *Config) {
+				config.Middleware = []rivertype.Middleware{&middlewareWithHook{}}
+			},
+			validateResult: func(t *testing.T, client *Client[pgx.Tx]) { //nolint:thelper
+				require.Len(t, client.hookLookupGlobal.ByHookKind(hooklookup.HookKindWorkBegin), 1)
+			},
+		},
+		{
+			name: "Hook implementing Middleware is available in middleware lookup",
+			configFunc: func(config *Config) {
+				config.Hooks = []rivertype.Hook{&hookWithMiddleware{}}
+			},
+			validateResult: func(t *testing.T, client *Client[pgx.Tx]) { //nolint:thelper
+				require.Len(t, client.middlewareLookupGlobal.ByMiddlewareKind(middlewarelookup.MiddlewareKindWorker), 1)
+			},
+		},
+		{
+			name: "Hook implementing Middleware in both configs is deduplicated in middleware lookup",
+			configFunc: func(config *Config) {
+				hm := &hookWithMiddleware{}
+				config.Hooks = []rivertype.Hook{hm}
+				config.Middleware = []rivertype.Middleware{hm}
+			},
+			validateResult: func(t *testing.T, client *Client[pgx.Tx]) { //nolint:thelper
+				require.Len(t, client.middlewareLookupGlobal.ByMiddlewareKind(middlewarelookup.MiddlewareKindWorker), 1)
+			},
+		},
+		{
+			name: "Middleware implementing Hook in both configs is deduplicated in hook lookup",
+			configFunc: func(config *Config) {
+				mh := &middlewareWithHook{}
+				config.Hooks = []rivertype.Hook{mh}
+				config.Middleware = []rivertype.Middleware{mh}
+			},
+			validateResult: func(t *testing.T, client *Client[pgx.Tx]) { //nolint:thelper
+				require.Len(t, client.hookLookupGlobal.ByHookKind(hooklookup.HookKindWorkBegin), 1)
+			},
+		},
+		{
 			name: "Middleware not allowed with JobInsertMiddleware",
 			configFunc: func(config *Config) {
 				config.JobInsertMiddleware = []rivertype.JobInsertMiddleware{&overridableJobMiddleware{}}
@@ -8625,3 +8666,31 @@ func (f JobArgsWithHooksFunc) Hooks() []rivertype.Hook {
 func (JobArgsWithHooksFunc) MarshalJSON() ([]byte, error) { return []byte("{}"), nil }
 
 func (JobArgsWithHooksFunc) UnmarshalJSON([]byte) error { return nil }
+
+// middlewareWithHook is a middleware that also implements HookWorkBegin,
+// used to test cross-pollination from middleware to hooks.
+type middlewareWithHook struct {
+	MiddlewareDefaults
+}
+
+func (m *middlewareWithHook) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+	return doInner(ctx)
+}
+
+func (m *middlewareWithHook) IsHook() bool { return true }
+
+func (m *middlewareWithHook) WorkBegin(ctx context.Context, job *rivertype.JobRow) error {
+	return nil
+}
+
+// hookWithMiddleware is a hook that also implements WorkerMiddleware,
+// used to test cross-pollination from hooks to middleware.
+type hookWithMiddleware struct {
+	HookDefaults
+}
+
+func (h *hookWithMiddleware) IsMiddleware() bool { return true }
+
+func (h *hookWithMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(ctx context.Context) error) error {
+	return doInner(ctx)
+}

--- a/hook_defaults_funcs.go
+++ b/hook_defaults_funcs.go
@@ -33,6 +33,16 @@ func (f HookPeriodicJobsStartFunc) Start(ctx context.Context, params *rivertype.
 	return f(ctx, params)
 }
 
+// HookQueueStateCountFunc is a convenience helper for implementing
+// rivertype.HookQueueStateCount using a simple function instead of a struct.
+type HookQueueStateCountFunc func(ctx context.Context, params *rivertype.HookQueueStateCountParams)
+
+func (f HookQueueStateCountFunc) IsHook() bool { return true }
+
+func (f HookQueueStateCountFunc) QueueStateCount(ctx context.Context, params *rivertype.HookQueueStateCountParams) {
+	f(ctx, params)
+}
+
 // HookWorkBeginFunc is a convenience helper for implementing
 // rivertype.HookWorkBegin using a simple function instead of a struct.
 type HookWorkBeginFunc func(ctx context.Context, job *rivertype.JobRow) error

--- a/internal/hooklookup/hook_lookup.go
+++ b/internal/hooklookup/hook_lookup.go
@@ -15,6 +15,7 @@ type HookKind string
 const (
 	HookKindInsertBegin       HookKind = "insert_begin"
 	HookKindPeriodicJobsStart HookKind = "periodic_job_start"
+	HookKindQueueStateCount   HookKind = "queue_state_count"
 	HookKindWorkBegin         HookKind = "work_begin"
 	HookKindWorkEnd           HookKind = "work_end"
 )
@@ -87,6 +88,12 @@ func (c *hookLookup) ByHookKind(kind HookKind) []rivertype.Hook {
 	case HookKindPeriodicJobsStart:
 		for _, hook := range c.hooks {
 			if typedHook, ok := hook.(rivertype.HookPeriodicJobsStart); ok {
+				c.hooksByKind[kind] = append(c.hooksByKind[kind], typedHook)
+			}
+		}
+	case HookKindQueueStateCount:
+		for _, hook := range c.hooks {
+			if typedHook, ok := hook.(rivertype.HookQueueStateCount); ok {
 				c.hooksByKind[kind] = append(c.hooksByKind[kind], typedHook)
 			}
 		}

--- a/internal/maintenance/queue_state_counter.go
+++ b/internal/maintenance/queue_state_counter.go
@@ -1,0 +1,188 @@
+package maintenance
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/riverqueue/river/internal/hooklookup"
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivershared/riversharedmaintenance"
+	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/testutil"
+	"github.com/riverqueue/river/rivershared/util/timeutil"
+	"github.com/riverqueue/river/rivertype"
+)
+
+const QueueStateCounterIntervalDefault = 10 * time.Second
+
+var jobStateAll = rivertype.JobStates() //nolint:gochecknoglobals
+
+// QueueStateCounterTestSignals are internal signals used exclusively in tests.
+type QueueStateCounterTestSignals struct {
+	CountedOnce testsignal.TestSignal[struct{}] // notifies when a count pass finishes
+}
+
+func (ts *QueueStateCounterTestSignals) Init(tb testutil.TestingTB) {
+	ts.CountedOnce.Init(tb)
+}
+
+type QueueStateCounterConfig struct {
+	// HookLookupGlobal provides access to globally registered hooks.
+	HookLookupGlobal hooklookup.HookLookupInterface
+
+	// Interval is the amount of time between count runs.
+	Interval time.Duration
+
+	// QueueNames is the list of configured queue names. Counts are emitted for
+	// all of these queues even if they have no jobs, with zero counts for all
+	// states.
+	QueueNames []string
+
+	// Schema where River tables are located. Empty string omits schema, causing
+	// Postgres to default to `search_path`.
+	Schema string
+}
+
+func (c *QueueStateCounterConfig) mustValidate() *QueueStateCounterConfig {
+	if c.Interval <= 0 {
+		panic("QueueStateCounterConfig.Interval must be above zero")
+	}
+
+	return c
+}
+
+// QueueStateCounter periodically counts jobs by queue and state, logging the
+// results. This provides visibility into queue health without requiring
+// external monitoring queries. The maintenance service only runs if there is a
+// HookQueueStateCount hook registered that consumes the counts.
+type QueueStateCounter struct {
+	riversharedmaintenance.QueueMaintainerServiceBase
+	startstop.BaseStartStop
+
+	// exported for test purposes
+	Config      *QueueStateCounterConfig
+	TestSignals QueueStateCounterTestSignals
+
+	exec riverdriver.Executor
+}
+
+func NewQueueStateCounter(archetype *baseservice.Archetype, config *QueueStateCounterConfig, exec riverdriver.Executor) *QueueStateCounter {
+	return baseservice.Init(archetype, &QueueStateCounter{
+		Config: (&QueueStateCounterConfig{
+			HookLookupGlobal: config.HookLookupGlobal,
+			Interval:         cmp.Or(config.Interval, QueueStateCounterIntervalDefault),
+			QueueNames:       config.QueueNames,
+			Schema:           config.Schema,
+		}).mustValidate(),
+		exec: exec,
+	})
+}
+
+func (s *QueueStateCounter) Start(ctx context.Context) error {
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
+	if !shouldStart {
+		return nil
+	}
+
+	s.StaggerStart(ctx)
+
+	go func() {
+		started()
+		defer stopped() // this defer should come first so it's last out
+
+		s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStopped)
+
+		// If no hooks are registered, there's no one to send counts to, so
+		// start, but don't do anything.
+		if len(s.Config.HookLookupGlobal.ByHookKind(hooklookup.HookKindQueueStateCount)) < 1 {
+			<-ctx.Done()
+			return
+		}
+
+		ticker := timeutil.NewTickerWithInitialTick(ctx, s.Config.Interval)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			if err := s.runOnce(ctx); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					s.Logger.ErrorContext(ctx, s.Name+": Error counting queue states", slog.String("error", err.Error()))
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (s *QueueStateCounter) runOnce(ctx context.Context) error {
+	ctx, cancelFunc := context.WithTimeout(ctx, riversharedmaintenance.TimeoutDefault)
+	defer cancelFunc()
+
+	rawCounts, err := s.exec.JobCountByQueueAndState(ctx, &riverdriver.JobCountByQueueAndStateParams{
+		QueueNames: s.Config.QueueNames,
+		Schema:     s.Config.Schema,
+	})
+	if err != nil {
+		return err
+	}
+
+	byQueue := s.buildResults(ctx, rawCounts)
+
+	for _, hook := range s.Config.HookLookupGlobal.ByHookKind(hooklookup.HookKindQueueStateCount) {
+		hook.(rivertype.HookQueueStateCount).QueueStateCount(ctx, &rivertype.HookQueueStateCountParams{ //nolint:forcetypeassert
+			ByQueue: byQueue,
+		})
+	}
+
+	s.TestSignals.CountedOnce.Signal(struct{}{})
+
+	return nil
+}
+
+// buildResults converts raw driver counts into results with all configured
+// queues and all job states filled in (zeroed where needed), logging one line
+// per queue.
+func (s *QueueStateCounter) buildResults(ctx context.Context, rawCounts map[string]map[rivertype.JobState]int) map[string]rivertype.HookQueueStateCountResult {
+	// Ensure all configured queues are present, even if they have no jobs.
+	for _, queue := range s.Config.QueueNames {
+		if rawCounts[queue] == nil {
+			rawCounts[queue] = make(map[rivertype.JobState]int)
+		}
+	}
+
+	countsByQueue := make(map[string]rivertype.HookQueueStateCountResult, len(rawCounts))
+
+	for queue, stateCounts := range rawCounts {
+		attrs := make([]slog.Attr, 0, 2+len(jobStateAll))
+		attrs = append(attrs, slog.String("queue", queue))
+		total := 0
+
+		for _, state := range jobStateAll {
+			if _, ok := stateCounts[state]; !ok {
+				stateCounts[state] = 0
+			}
+			total += stateCounts[state]
+			attrs = append(attrs, slog.Int(string(state), stateCounts[state]))
+		}
+
+		attrs = append(attrs, slog.Int("total", total))
+		s.Logger.LogAttrs(ctx, slog.LevelInfo, s.Name+": Queue state counts", attrs...)
+
+		countsByQueue[queue] = rivertype.HookQueueStateCountResult{
+			ByState: stateCounts,
+			Total:   total,
+		}
+	}
+
+	return countsByQueue
+}

--- a/internal/maintenance/queue_state_counter_test.go
+++ b/internal/maintenance/queue_state_counter_test.go
@@ -1,0 +1,161 @@
+package maintenance
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/internal/hooklookup"
+	"github.com/riverqueue/river/riverdbtest"
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivershared/riversharedtest"
+	"github.com/riverqueue/river/rivershared/startstoptest"
+	"github.com/riverqueue/river/rivershared/testfactory"
+	"github.com/riverqueue/river/rivershared/util/ptrutil"
+	"github.com/riverqueue/river/rivertype"
+)
+
+func TestQueueStateCounter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		exec riverdriver.Executor
+	}
+
+	setup := func(t *testing.T, hooks []rivertype.Hook, queueNames []string) (*QueueStateCounter, *testBundle) {
+		t.Helper()
+
+		var (
+			tx   = riverdbtest.TestTxPgx(ctx, t)
+			exec = riverpgxv5.New(nil).UnwrapExecutor(tx)
+		)
+
+		svc := NewQueueStateCounter(
+			riversharedtest.BaseServiceArchetype(t),
+			&QueueStateCounterConfig{
+				HookLookupGlobal: hooklookup.NewHookLookup(hooks),
+				QueueNames:       queueNames,
+			},
+			exec,
+		)
+		svc.StaggerStartupDisable(true)
+		svc.TestSignals.Init(t)
+		t.Cleanup(svc.Stop)
+
+		return svc, &testBundle{exec: exec}
+	}
+
+	t.Run("CountsJobsByQueueAndState", func(t *testing.T) {
+		t.Parallel()
+
+		hook := &capturingQueueStateCountHook{}
+		svc, bundle := setup(t, []rivertype.Hook{hook}, []string{"queue1", "queue2", "queue_empty"})
+
+		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateCompleted)})
+		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateCompleted)})
+		_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
+
+		require.NoError(t, svc.Start(ctx))
+		svc.TestSignals.CountedOnce.WaitOrTimeout()
+
+		counts := hook.LastParams().ByQueue
+
+		// All three configured queues are present, including queue_empty
+		// which has no jobs.
+		require.Len(t, counts, 3)
+
+		// All job states are present for each queue, even those with zero jobs.
+		for _, queue := range []string{"queue1", "queue2", "queue_empty"} {
+			require.Len(t, counts[queue].ByState, len(rivertype.JobStates()), "queue %q should have all states", queue)
+		}
+
+		require.Equal(t, 2, counts["queue1"].ByState[rivertype.JobStateAvailable])
+		require.Equal(t, 1, counts["queue1"].ByState[rivertype.JobStateRunning])
+		require.Equal(t, 0, counts["queue1"].ByState[rivertype.JobStateCompleted])
+		require.Equal(t, 3, counts["queue1"].Total)
+
+		require.Equal(t, 1, counts["queue2"].ByState[rivertype.JobStateAvailable])
+		require.Equal(t, 2, counts["queue2"].ByState[rivertype.JobStateCompleted])
+		require.Equal(t, 1, counts["queue2"].ByState[rivertype.JobStateDiscarded])
+		require.Equal(t, 0, counts["queue2"].ByState[rivertype.JobStateRunning])
+		require.Equal(t, 4, counts["queue2"].Total)
+
+		// queue_empty has all states present, all zero.
+		for _, state := range rivertype.JobStates() {
+			require.Equal(t, 0, counts["queue_empty"].ByState[state], "queue_empty[%s] should be 0", state)
+		}
+		require.Equal(t, 0, counts["queue_empty"].Total)
+	})
+
+	t.Run("NoopsWithoutHooks", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t, nil, nil)
+
+		// With no hooks, Start returns immediately without starting the service.
+		require.NoError(t, svc.Start(ctx))
+
+		// Service should not have started, so calling Start again should also
+		// succeed (StartInit would return false if it were already running).
+		require.NoError(t, svc.Start(ctx))
+	})
+
+	t.Run("StartStop", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t, []rivertype.Hook{&capturingQueueStateCountHook{}}, nil)
+
+		require.NoError(t, svc.Start(ctx))
+		svc.TestSignals.CountedOnce.WaitOrTimeout()
+	})
+
+	t.Run("StartStopStress", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t, []rivertype.Hook{&capturingQueueStateCountHook{}}, nil)
+		svc.Logger = riversharedtest.LoggerWarn(t)       // loop started/stop log is very noisy; suppress
+		svc.TestSignals = QueueStateCounterTestSignals{} // deinit so channels don't fill
+
+		startstoptest.Stress(ctx, t, svc)
+	})
+
+	t.Run("StartStopStressNoHooks", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t, nil, nil)
+		svc.Logger = riversharedtest.LoggerWarn(t)       // loop started/stop log is very noisy; suppress
+		svc.TestSignals = QueueStateCounterTestSignals{} // deinit so channels don't fill
+
+		startstoptest.Stress(ctx, t, svc)
+	})
+}
+
+// capturingQueueStateCountHook captures the last params received from the hook
+// invocation.
+type capturingQueueStateCountHook struct {
+	mu         sync.Mutex
+	lastParams *rivertype.HookQueueStateCountParams
+}
+
+func (h *capturingQueueStateCountHook) IsHook() bool { return true }
+
+func (h *capturingQueueStateCountHook) QueueStateCount(_ context.Context, params *rivertype.HookQueueStateCountParams) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.lastParams = params
+}
+
+func (h *capturingQueueStateCountHook) LastParams() *rivertype.HookQueueStateCountParams {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.lastParams
+}

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -202,7 +202,7 @@ type Executor interface {
 
 	JobCancel(ctx context.Context, params *JobCancelParams) (*rivertype.JobRow, error)
 	JobCountByAllStates(ctx context.Context, params *JobCountByAllStatesParams) (map[rivertype.JobState]int, error)
-	JobCountByQueueAndState(ctx context.Context, params *JobCountByQueueAndStateParams) ([]*JobCountByQueueAndStateResult, error)
+	JobCountByQueueAndState(ctx context.Context, params *JobCountByQueueAndStateParams) (map[string]map[rivertype.JobState]int, error)
 	JobCountByState(ctx context.Context, params *JobCountByStateParams) (int, error)
 	JobDelete(ctx context.Context, params *JobDeleteParams) (*rivertype.JobRow, error)
 	JobDeleteBefore(ctx context.Context, params *JobDeleteBeforeParams) (int, error)
@@ -357,12 +357,6 @@ type JobCountByAllStatesParams struct {
 type JobCountByQueueAndStateParams struct {
 	QueueNames []string
 	Schema     string
-}
-
-type JobCountByQueueAndStateResult struct {
-	CountAvailable int64
-	CountRunning   int64
-	Queue          string
 }
 
 type JobCountByStateParams struct {

--- a/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverdatabasesql/internal/dbsqlc/river_job.sql.go
@@ -132,48 +132,20 @@ func (q *Queries) JobCountByAllStates(ctx context.Context, db DBTX) ([]*JobCount
 }
 
 const jobCountByQueueAndState = `-- name: JobCountByQueueAndState :many
-WITH all_queues AS (
-    SELECT DISTINCT unnest($1::text[])::text AS queue
-),
-
-running_job_counts AS (
-    SELECT
-        queue,
-        COUNT(*) AS count
-    FROM /* TEMPLATE: schema */river_job
-    WHERE queue = ANY($1::text[])
-        AND state = 'running'
-    GROUP BY queue
-),
-
-available_job_counts AS (
-    SELECT
-        queue,
-        COUNT(*) AS count
-    FROM
-      /* TEMPLATE: schema */river_job
-    WHERE queue = ANY($1::text[])
-        AND state = 'available'
-    GROUP BY queue
-)
-
 SELECT
-    all_queues.queue,
-    COALESCE(available_job_counts.count, 0) AS count_available,
-    COALESCE(running_job_counts.count, 0) AS count_running
-FROM
-    all_queues
-LEFT JOIN
-    running_job_counts ON all_queues.queue = running_job_counts.queue
-LEFT JOIN
-    available_job_counts ON all_queues.queue = available_job_counts.queue
-ORDER BY all_queues.queue ASC
+    queue,
+    state,
+    COUNT(*) AS count
+FROM /* TEMPLATE: schema */river_job
+WHERE queue = ANY($1::text[])
+GROUP BY queue, state
+ORDER BY queue, state
 `
 
 type JobCountByQueueAndStateRow struct {
-	Queue          string
-	CountAvailable int64
-	CountRunning   int64
+	Queue string
+	State RiverJobState
+	Count int64
 }
 
 func (q *Queries) JobCountByQueueAndState(ctx context.Context, db DBTX, queueNames []string) ([]*JobCountByQueueAndStateRow, error) {
@@ -185,7 +157,7 @@ func (q *Queries) JobCountByQueueAndState(ctx context.Context, db DBTX, queueNam
 	var items []*JobCountByQueueAndStateRow
 	for rows.Next() {
 		var i JobCountByQueueAndStateRow
-		if err := rows.Scan(&i.Queue, &i.CountAvailable, &i.CountRunning); err != nil {
+		if err := rows.Scan(&i.Queue, &i.State, &i.Count); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -222,18 +222,17 @@ func (e *Executor) JobCountByAllStates(ctx context.Context, params *riverdriver.
 	return countsMap, nil
 }
 
-func (e *Executor) JobCountByQueueAndState(ctx context.Context, params *riverdriver.JobCountByQueueAndStateParams) ([]*riverdriver.JobCountByQueueAndStateResult, error) {
+func (e *Executor) JobCountByQueueAndState(ctx context.Context, params *riverdriver.JobCountByQueueAndStateParams) (map[string]map[rivertype.JobState]int, error) {
 	rows, err := dbsqlc.New().JobCountByQueueAndState(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.QueueNames)
 	if err != nil {
 		return nil, interpretError(err)
 	}
-	results := make([]*riverdriver.JobCountByQueueAndStateResult, len(rows))
-	for i, row := range rows {
-		results[i] = &riverdriver.JobCountByQueueAndStateResult{
-			CountAvailable: row.CountAvailable,
-			CountRunning:   row.CountRunning,
-			Queue:          row.Queue,
+	results := make(map[string]map[rivertype.JobState]int)
+	for _, row := range rows {
+		if results[row.Queue] == nil {
+			results[row.Queue] = make(map[rivertype.JobState]int)
 		}
+		results[row.Queue][rivertype.JobState(row.State)] = int(row.Count)
 	}
 	return results, nil
 }

--- a/riverdriver/riverdrivertest/job_read.go
+++ b/riverdriver/riverdrivertest/job_read.go
@@ -86,7 +86,7 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 	t.Run("JobCountByQueueAndState", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("CountsJobsInAvailableAndRunningForEachOfTheSpecifiedQueues", func(t *testing.T) {
+		t.Run("CountsAllStatesForSpecifiedQueues", func(t *testing.T) {
 			t.Parallel()
 
 			exec, _ := setup(ctx, t)
@@ -96,10 +96,10 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateCompleted)})
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue3"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue3"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
 
 			countsByQueue, err := exec.JobCountByQueueAndState(ctx, &riverdriver.JobCountByQueueAndStateParams{
 				QueueNames: []string{"queue1", "queue2"},
@@ -109,62 +109,32 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			require.Len(t, countsByQueue, 2)
 
-			require.Equal(t, "queue1", countsByQueue[0].Queue)
-			require.Equal(t, int64(2), countsByQueue[0].CountAvailable)
-			require.Equal(t, int64(3), countsByQueue[0].CountRunning)
-			require.Equal(t, "queue2", countsByQueue[1].Queue)
-			require.Equal(t, int64(1), countsByQueue[1].CountAvailable)
-			require.Equal(t, int64(1), countsByQueue[1].CountRunning)
+			require.Equal(t, 2, countsByQueue["queue1"][rivertype.JobStateAvailable])
+			require.Equal(t, 3, countsByQueue["queue1"][rivertype.JobStateRunning])
+			require.Equal(t, 1, countsByQueue["queue1"][rivertype.JobStateCompleted])
+			require.Equal(t, 0, countsByQueue["queue1"][rivertype.JobStateCancelled])
+
+			require.Equal(t, 1, countsByQueue["queue2"][rivertype.JobStateAvailable])
+			require.Equal(t, 1, countsByQueue["queue2"][rivertype.JobStateRunning])
 		})
 
-		t.Run("IncludesRequestedQueuesThatHaveNoJobs", func(t *testing.T) {
+		t.Run("ExcludesQueuesNotRequested", func(t *testing.T) {
 			t.Parallel()
 
 			exec, _ := setup(ctx, t)
 
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
 
 			countsByQueue, err := exec.JobCountByQueueAndState(ctx, &riverdriver.JobCountByQueueAndStateParams{
-				QueueNames: []string{"queue1", "queue2"},
+				QueueNames: []string{"queue1"},
 				Schema:     "",
 			})
 			require.NoError(t, err)
 
-			require.Len(t, countsByQueue, 2)
-
-			require.Equal(t, "queue1", countsByQueue[0].Queue)
-			require.Equal(t, int64(0), countsByQueue[0].CountAvailable)
-			require.Equal(t, int64(0), countsByQueue[0].CountRunning)
-
-			require.Equal(t, "queue2", countsByQueue[1].Queue)
-			require.Equal(t, int64(1), countsByQueue[1].CountAvailable)
-			require.Equal(t, int64(1), countsByQueue[1].CountRunning)
-		})
-
-		t.Run("InputQueueNamesAreDeduplicated", func(t *testing.T) {
-			t.Parallel()
-
-			exec, _ := setup(ctx, t)
-
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
-
-			countsByQueue, err := exec.JobCountByQueueAndState(ctx, &riverdriver.JobCountByQueueAndStateParams{
-				QueueNames: []string{"queue2", "queue1", "queue1"},
-				Schema:     "",
-			})
-			require.NoError(t, err)
-
-			require.Len(t, countsByQueue, 2)
-
-			require.Equal(t, "queue1", countsByQueue[0].Queue)
-			require.Equal(t, int64(0), countsByQueue[0].CountAvailable)
-			require.Equal(t, int64(0), countsByQueue[0].CountRunning)
-
-			require.Equal(t, "queue2", countsByQueue[1].Queue)
-			require.Equal(t, int64(1), countsByQueue[1].CountAvailable)
-			require.Equal(t, int64(1), countsByQueue[1].CountRunning)
+			require.Len(t, countsByQueue, 1)
+			require.Equal(t, 1, countsByQueue["queue1"][rivertype.JobStateAvailable])
+			require.Nil(t, countsByQueue["queue2"])
 		})
 	})
 

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql
@@ -86,42 +86,14 @@ FROM /* TEMPLATE: schema */ river_job
 GROUP BY state;
 
 -- name: JobCountByQueueAndState :many
-WITH all_queues AS (
-    SELECT DISTINCT unnest(@queue_names::text[])::text AS queue
-),
-
-running_job_counts AS (
-    SELECT
-        queue,
-        COUNT(*) AS count
-    FROM /* TEMPLATE: schema */river_job
-    WHERE queue = ANY(@queue_names::text[])
-        AND state = 'running'
-    GROUP BY queue
-),
-
-available_job_counts AS (
-    SELECT
-        queue,
-        COUNT(*) AS count
-    FROM
-      /* TEMPLATE: schema */river_job
-    WHERE queue = ANY(@queue_names::text[])
-        AND state = 'available'
-    GROUP BY queue
-)
-
 SELECT
-    all_queues.queue,
-    COALESCE(available_job_counts.count, 0) AS count_available,
-    COALESCE(running_job_counts.count, 0) AS count_running
-FROM
-    all_queues
-LEFT JOIN
-    running_job_counts ON all_queues.queue = running_job_counts.queue
-LEFT JOIN
-    available_job_counts ON all_queues.queue = available_job_counts.queue
-ORDER BY all_queues.queue ASC;
+    queue,
+    state,
+    COUNT(*) AS count
+FROM /* TEMPLATE: schema */river_job
+WHERE queue = ANY(@queue_names::text[])
+GROUP BY queue, state
+ORDER BY queue, state;
 
 -- name: JobCountByState :one
 SELECT count(*)

--- a/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riverpgxv5/internal/dbsqlc/river_job.sql.go
@@ -129,48 +129,20 @@ func (q *Queries) JobCountByAllStates(ctx context.Context, db DBTX) ([]*JobCount
 }
 
 const jobCountByQueueAndState = `-- name: JobCountByQueueAndState :many
-WITH all_queues AS (
-    SELECT DISTINCT unnest($1::text[])::text AS queue
-),
-
-running_job_counts AS (
-    SELECT
-        queue,
-        COUNT(*) AS count
-    FROM /* TEMPLATE: schema */river_job
-    WHERE queue = ANY($1::text[])
-        AND state = 'running'
-    GROUP BY queue
-),
-
-available_job_counts AS (
-    SELECT
-        queue,
-        COUNT(*) AS count
-    FROM
-      /* TEMPLATE: schema */river_job
-    WHERE queue = ANY($1::text[])
-        AND state = 'available'
-    GROUP BY queue
-)
-
 SELECT
-    all_queues.queue,
-    COALESCE(available_job_counts.count, 0) AS count_available,
-    COALESCE(running_job_counts.count, 0) AS count_running
-FROM
-    all_queues
-LEFT JOIN
-    running_job_counts ON all_queues.queue = running_job_counts.queue
-LEFT JOIN
-    available_job_counts ON all_queues.queue = available_job_counts.queue
-ORDER BY all_queues.queue ASC
+    queue,
+    state,
+    COUNT(*) AS count
+FROM /* TEMPLATE: schema */river_job
+WHERE queue = ANY($1::text[])
+GROUP BY queue, state
+ORDER BY queue, state
 `
 
 type JobCountByQueueAndStateRow struct {
-	Queue          string
-	CountAvailable int64
-	CountRunning   int64
+	Queue string
+	State RiverJobState
+	Count int64
 }
 
 func (q *Queries) JobCountByQueueAndState(ctx context.Context, db DBTX, queueNames []string) ([]*JobCountByQueueAndStateRow, error) {
@@ -182,7 +154,7 @@ func (q *Queries) JobCountByQueueAndState(ctx context.Context, db DBTX, queueNam
 	var items []*JobCountByQueueAndStateRow
 	for rows.Next() {
 		var i JobCountByQueueAndStateRow
-		if err := rows.Scan(&i.Queue, &i.CountAvailable, &i.CountRunning); err != nil {
+		if err := rows.Scan(&i.Queue, &i.State, &i.Count); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/riverdriver/riverpgxv5/queue_state_count_benchmark_test.go
+++ b/riverdriver/riverpgxv5/queue_state_count_benchmark_test.go
@@ -1,0 +1,163 @@
+package riverpgxv5_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/riverdbtest"
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivershared/riversharedtest"
+	"github.com/riverqueue/river/rivertype"
+)
+
+func BenchmarkJobCountByQueueAndState(b *testing.B) {
+	ctx := context.Background()
+
+	dbPool := riversharedtest.DBPool(ctx, b)
+	driver := riverpgxv5.New(dbPool)
+	exec := driver.GetExecutor()
+	schema := riverdbtest.TestSchema(ctx, b, driver, nil)
+	numJobs := queueStateCountBenchmarkNumJobs(b)
+
+	seedQueueStateCountBenchmarkData(ctx, b, exec, schema, numJobs)
+
+	queueNamesTwo := queueStateCountBenchmarkQueueNames(2)
+	queueNamesTen := queueStateCountBenchmarkQueueNames(10)
+
+	for _, benchmarkCase := range []struct {
+		name       string
+		queueNames []string
+	}{
+		{name: "TwoQueues", queueNames: queueNamesTwo},
+		{name: "TenQueues", queueNames: queueNamesTen},
+	} {
+		b.Run(benchmarkCase.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			params := &riverdriver.JobCountByQueueAndStateParams{
+				QueueNames: benchmarkCase.queueNames,
+				Schema:     schema,
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				results, err := driver.GetExecutor().JobCountByQueueAndState(ctx, params)
+				require.NoError(b, err)
+				require.NotEmpty(b, results)
+			}
+		})
+	}
+}
+
+func queueStateCountBenchmarkNumJobs(b *testing.B) int {
+	b.Helper()
+
+	numJobs := 20_000
+	if numJobsEnv := os.Getenv("RIVER_BENCH_QUEUE_STATE_COUNT_NUM_JOBS"); numJobsEnv != "" {
+		parsedNumJobs, err := strconv.Atoi(numJobsEnv)
+		require.NoError(b, err)
+		require.Greater(b, parsedNumJobs, 0)
+
+		numJobs = parsedNumJobs
+	}
+
+	return numJobs
+}
+
+func queueStateCountBenchmarkQueueNames(numQueues int) []string {
+	queueNames := make([]string, numQueues)
+	for i := range numQueues {
+		queueNames[i] = fmt.Sprintf("queue_%03d", i+1)
+	}
+
+	return queueNames
+}
+
+func queueStateCountBenchmarkQueue(jobNum int) string {
+	// Rotate queue more slowly than state so every queue gets every state.
+	return fmt.Sprintf("queue_%03d", ((jobNum/8)%100)+1)
+}
+
+func queueStateCountBenchmarkState(jobNum int) rivertype.JobState {
+	switch jobNum % 8 {
+	case 0:
+		return rivertype.JobStateRunning
+	case 1:
+		return rivertype.JobStateAvailable
+	case 2:
+		return rivertype.JobStateCompleted
+	case 3:
+		return rivertype.JobStateCancelled
+	case 4:
+		return rivertype.JobStateDiscarded
+	case 5:
+		return rivertype.JobStateRetryable
+	case 6:
+		return rivertype.JobStateScheduled
+	default:
+		return rivertype.JobStatePending
+	}
+}
+
+func seedQueueStateCountBenchmarkData(ctx context.Context, b *testing.B, exec riverdriver.Executor, schema string, numJobs int) {
+	b.Helper()
+
+	const insertBatchSize = 5000
+
+	now := time.Now().UTC()
+
+	for start := 0; start < numJobs; start += insertBatchSize {
+		end := min(start+insertBatchSize, numJobs)
+		insertParams := make([]*riverdriver.JobInsertFullParams, 0, end-start)
+
+		for jobNum := start; jobNum < end; jobNum++ {
+			finalizedAt, scheduledAt, state := queueStateCountBenchmarkTimestamps(now, jobNum)
+
+			insertParams = append(insertParams, &riverdriver.JobInsertFullParams{
+				EncodedArgs: []byte(`{}`),
+				FinalizedAt: finalizedAt,
+				Kind:        "benchmark",
+				MaxAttempts: 25,
+				Metadata:    []byte(`{}`),
+				Priority:    (jobNum % 4) + 1,
+				Queue:       queueStateCountBenchmarkQueue(jobNum),
+				ScheduledAt: &scheduledAt,
+				State:       state,
+			})
+		}
+
+		_, err := exec.JobInsertFullMany(ctx, &riverdriver.JobInsertFullManyParams{
+			Jobs:   insertParams,
+			Schema: schema,
+		})
+		require.NoError(b, err)
+	}
+
+	countsByState, err := exec.JobCountByAllStates(ctx, &riverdriver.JobCountByAllStatesParams{Schema: schema})
+	require.NoError(b, err)
+
+	var numRows int
+	for _, numJobsForState := range countsByState {
+		numRows += numJobsForState
+	}
+	require.Equal(b, numJobs, numRows)
+}
+
+func queueStateCountBenchmarkTimestamps(now time.Time, jobNum int) (*time.Time, time.Time, rivertype.JobState) {
+	scheduledAt := now.Add(-time.Duration(jobNum%100000) * time.Second)
+	state := queueStateCountBenchmarkState(jobNum)
+
+	if state != rivertype.JobStateCancelled && state != rivertype.JobStateCompleted && state != rivertype.JobStateDiscarded {
+		return nil, scheduledAt, state
+	}
+
+	finalizedAt := scheduledAt.Add(time.Second)
+	return &finalizedAt, scheduledAt, state
+}

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -230,18 +230,17 @@ func (e *Executor) JobCountByAllStates(ctx context.Context, params *riverdriver.
 	return countsMap, nil
 }
 
-func (e *Executor) JobCountByQueueAndState(ctx context.Context, params *riverdriver.JobCountByQueueAndStateParams) ([]*riverdriver.JobCountByQueueAndStateResult, error) {
+func (e *Executor) JobCountByQueueAndState(ctx context.Context, params *riverdriver.JobCountByQueueAndStateParams) (map[string]map[rivertype.JobState]int, error) {
 	rows, err := dbsqlc.New().JobCountByQueueAndState(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.QueueNames)
 	if err != nil {
 		return nil, interpretError(err)
 	}
-	results := make([]*riverdriver.JobCountByQueueAndStateResult, len(rows))
-	for i, row := range rows {
-		results[i] = &riverdriver.JobCountByQueueAndStateResult{
-			CountAvailable: row.CountAvailable,
-			CountRunning:   row.CountRunning,
-			Queue:          row.Queue,
+	results := make(map[string]map[rivertype.JobState]int)
+	for _, row := range rows {
+		if results[row.Queue] == nil {
+			results[row.Queue] = make(map[rivertype.JobState]int)
 		}
+		results[row.Queue][rivertype.JobState(row.State)] = int(row.Count)
 	}
 	return results, nil
 }

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
@@ -56,22 +56,14 @@ FROM /* TEMPLATE: schema */river_job
 GROUP BY state;
 
 -- name: JobCountByQueueAndState :many
-WITH queue_stats AS (
-    SELECT
-        river_job.queue,
-        COUNT(CASE WHEN river_job.state = 'available' THEN 1 END) AS count_available,
-        COUNT(CASE WHEN river_job.state = 'running' THEN 1 END) AS count_running
-    FROM /* TEMPLATE: schema */river_job
-    WHERE river_job.queue IN (sqlc.slice('queue_names'))
-    GROUP BY river_job.queue
-)
-
 SELECT
-    cast(queue AS text) AS queue,
-    count_available,
-    count_running
-FROM queue_stats
-ORDER BY queue ASC;
+    cast(river_job.queue AS text) AS queue,
+    cast(river_job.state AS text) AS state,
+    COUNT(*) AS count
+FROM /* TEMPLATE: schema */river_job
+WHERE river_job.queue IN (sqlc.slice('queue_names'))
+GROUP BY river_job.queue, river_job.state
+ORDER BY river_job.queue ASC, river_job.state ASC;
 
 -- name: JobCountByState :one
 SELECT count(*)

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
@@ -103,28 +103,20 @@ func (q *Queries) JobCountByAllStates(ctx context.Context, db DBTX) ([]*JobCount
 }
 
 const jobCountByQueueAndState = `-- name: JobCountByQueueAndState :many
-WITH queue_stats AS (
-    SELECT
-        river_job.queue,
-        COUNT(CASE WHEN river_job.state = 'available' THEN 1 END) AS count_available,
-        COUNT(CASE WHEN river_job.state = 'running' THEN 1 END) AS count_running
-    FROM /* TEMPLATE: schema */river_job
-    WHERE river_job.queue IN (/*SLICE:queue_names*/?)
-    GROUP BY river_job.queue
-)
-
 SELECT
-    cast(queue AS text) AS queue,
-    count_available,
-    count_running
-FROM queue_stats
-ORDER BY queue ASC
+    cast(river_job.queue AS text) AS queue,
+    cast(river_job.state AS text) AS state,
+    COUNT(*) AS count
+FROM /* TEMPLATE: schema */river_job
+WHERE river_job.queue IN (/*SLICE:queue_names*/?)
+GROUP BY river_job.queue, river_job.state
+ORDER BY river_job.queue ASC, river_job.state ASC
 `
 
 type JobCountByQueueAndStateRow struct {
-	Queue          string
-	CountAvailable int64
-	CountRunning   int64
+	Queue string
+	State string
+	Count int64
 }
 
 func (q *Queries) JobCountByQueueAndState(ctx context.Context, db DBTX, queueNames []string) ([]*JobCountByQueueAndStateRow, error) {
@@ -146,7 +138,7 @@ func (q *Queries) JobCountByQueueAndState(ctx context.Context, db DBTX, queueNam
 	var items []*JobCountByQueueAndStateRow
 	for rows.Next() {
 		var i JobCountByQueueAndStateRow
-		if err := rows.Scan(&i.Queue, &i.CountAvailable, &i.CountRunning); err != nil {
+		if err := rows.Scan(&i.Queue, &i.State, &i.Count); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -290,51 +290,18 @@ func (e *Executor) JobCountByAllStates(ctx context.Context, params *riverdriver.
 	return countsMap, nil
 }
 
-func (e *Executor) JobCountByQueueAndState(ctx context.Context, params *riverdriver.JobCountByQueueAndStateParams) ([]*riverdriver.JobCountByQueueAndStateResult, error) {
+func (e *Executor) JobCountByQueueAndState(ctx context.Context, params *riverdriver.JobCountByQueueAndStateParams) (map[string]map[rivertype.JobState]int, error) {
 	rows, err := dbsqlc.New().JobCountByQueueAndState(schemaTemplateParam(ctx, params.Schema), e.dbtx, params.QueueNames)
 	if err != nil {
 		return nil, interpretError(err)
 	}
-
-	// The PostgreSQL drivers implement this query with an `all_queues` CTE and
-	// LEFT JOINs, so they return one row per requested queue, including queues
-	// that currently have no jobs. The input queue list is deduplicated in SQL.
-	// The SQLite sqlc driver only reliably supports `sqlc.slice` in `IN (...)`,
-	// and we haven't found a workable way to bind a parameterized list through
-	// `json_each(...)` to produce equivalent SQL. The SQLite SQL query therefore
-	// returns only queues with matching rows, and this wrapper fills in missing
-	// queues to match PostgreSQL behavior.
-	countsByQueue := make(map[string]struct {
-		CountAvailable int64
-		CountRunning   int64
-	}, len(rows))
+	results := make(map[string]map[rivertype.JobState]int)
 	for _, row := range rows {
-		countsByQueue[row.Queue] = struct {
-			CountAvailable int64
-			CountRunning   int64
-		}{
-			CountAvailable: row.CountAvailable,
-			CountRunning:   row.CountRunning,
+		if results[row.Queue] == nil {
+			results[row.Queue] = make(map[rivertype.JobState]int)
 		}
+		results[row.Queue][rivertype.JobState(row.State)] = int(row.Count)
 	}
-
-	queueNames := slices.Clone(params.QueueNames)
-	slices.Sort(queueNames)
-	queueNames = slices.Compact(queueNames)
-
-	results := make([]*riverdriver.JobCountByQueueAndStateResult, 0, len(queueNames))
-	for _, queueName := range queueNames {
-		result := &riverdriver.JobCountByQueueAndStateResult{
-			Queue: queueName,
-		}
-		if counts, ok := countsByQueue[queueName]; ok {
-			result.CountAvailable = counts.CountAvailable
-			result.CountRunning = counts.CountRunning
-		}
-
-		results = append(results, result)
-	}
-
 	return results, nil
 }
 

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -351,6 +351,35 @@ type HookPeriodicJobsStartParams struct {
 	DurableJobs []*DurablePeriodicJob
 }
 
+// HookQueueStateCount is an interface to a hook that runs each time the queue
+// state counter maintenance service performs a count.
+type HookQueueStateCount interface {
+	Hook
+
+	// QueueStateCount is invoked after the queue state counter has completed a
+	// count of jobs by queue and state.
+	QueueStateCount(ctx context.Context, params *HookQueueStateCountParams)
+}
+
+// HookQueueStateCountParams are parameters for HookQueueStateCount.
+type HookQueueStateCountParams struct {
+	// ByQueue is a map of queue name to its count results. All queues
+	// configured with this client are included, even if they don't currently
+	// contain jobs.
+	ByQueue map[string]HookQueueStateCountResult
+}
+
+// HookQueueStateCountResult contains coutns for a single queue.
+type HookQueueStateCountResult struct {
+	// ByState is a map of job state to the number of jobs in that state for the
+	// queue. All job states are included, even if they have no jobs in that
+	// state.
+	ByState map[JobState]int
+
+	// Total is the total number of jobs across all states for the queue.
+	Total int
+}
+
 // HookWorkBegin is an interface to a hook that runs after a job has been locked
 // for work and before it's worked.
 type HookWorkBegin interface {


### PR DESCRIPTION
Stacked on #1203.

This adds a small pgx benchmark around `JobCountByQueueAndState` so we have a cheap default signal in normal runs, but can still scale it up locally with `RIVER_BENCH_QUEUE_STATE_COUNT_NUM_JOBS` when we want enough rows to make the planner choice obvious. The benchmark seeds a migrated `river_job` table in Go using batched `JobInsertFullMany` calls, and keeps the states evenly distributed across queues so every queue exercises every state.

On my machine (PostgreSQL 16.13, 200k rows, 100 queues, all 8 states distributed across every queue), the current query in #1203 regressed sharply against the previous query shape when I temporarily restored the old implementation locally and reran the same benchmark harness.

| Case | Current query | Old query | Regression |
| --- | ---: | ---: | ---: |
| Benchmark, 2 queues | ~17.6 ms/op | ~0.37 ms/op | ~47x slower |
| Benchmark, 10 queues | ~16.7 ms/op | ~1.19 ms/op | ~14x slower |
| `EXPLAIN ANALYZE`, 2 queues | ~27.6 ms | ~1.7 ms | ~16x slower |
| `EXPLAIN ANALYZE`, 10 queues | ~15.4 ms | ~8.4 ms | ~1.8x slower |

`EXPLAIN (ANALYZE, BUFFERS)` shows the reason. The new query filters on `queue` and groups by `(queue, state)`, so PostgreSQL no longer has a left-edge match on the existing `(state, queue, priority, scheduled_at, id)` index and falls back to a parallel sequential scan. The old query shape keeps separate `state = 'available'` and `state = 'running'` branches, so PostgreSQL can still use `river_job_prioritized_fetching_index` via index-only scans.

The committed benchmark only measures the current query. The old-query numbers above came from temporarily restoring the previous implementation locally, collecting the benchmark and plan data, and then restoring the branch state. This PR is only here to make the regression easy to reproduce and discuss before changing the SQL or adding another index.

<details>
<summary>Full <code>EXPLAIN (ANALYZE, BUFFERS)</code> output for 2 queues</summary>

Current query:

```text
Finalize GroupAggregate  (cost=5225.31..5430.70 rows=795 width=22) (actual time=25.476..27.461 rows=16 loops=1)
  Group Key: queue, state
  Buffers: shared hit=3157
  ->  Gather Merge  (cost=5225.31..5410.83 rows=1590 width=22) (actual time=25.468..27.437 rows=48 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        Buffers: shared hit=3157
        ->  Sort  (cost=4225.29..4227.28 rows=795 width=22) (actual time=19.113..19.115 rows=16 loops=3)
              Sort Key: queue, state
              Sort Method: quicksort  Memory: 25kB
              Buffers: shared hit=3157
              Worker 0:  Sort Method: quicksort  Memory: 25kB
              Worker 1:  Sort Method: quicksort  Memory: 25kB
              ->  Partial HashAggregate  (cost=4179.04..4186.99 rows=795 width=22) (actual time=19.053..19.061 rows=16 loops=3)
                    Group Key: queue, state
                    Batches: 1  Memory Usage: 49kB
                    Buffers: shared hit=3125
                    Worker 0:  Batches: 1  Memory Usage: 49kB
                    Worker 1:  Batches: 1  Memory Usage: 49kB
                    ->  Parallel Seq Scan on river_job  (cost=0.00..4166.67 rows=1650 width=14) (actual time=0.042..18.665 rows=1333 loops=3)
                          Filter: (queue = ANY ('{queue_001,queue_002}'::text[]))
                          Rows Removed by Filter: 65333
                          Buffers: shared hit=3125
Planning:
  Buffers: shared hit=181 read=3
Planning Time: 1.690 ms
Execution Time: 27.628 ms
```

Old query:

```text
Sort  (cost=71.16..71.16 rows=2 width=48) (actual time=1.675..1.676 rows=2 loops=1)
  Sort Key: (unnest('{queue_001,queue_002}'::text[]))
  Sort Method: quicksort  Memory: 25kB
  Buffers: shared hit=10 read=13
  ->  Hash Right Join  (cost=68.78..71.15 rows=2 width=48) (actual time=1.666..1.672 rows=2 loops=1)
        Hash Cond: (river_job.queue = (unnest('{queue_001,queue_002}'::text[])))
        Buffers: shared hit=10 read=13
        ->  HashAggregate  (cost=37.26..38.25 rows=99 width=18) (actual time=0.570..0.570 rows=2 loops=1)
              Group Key: river_job.queue
              Batches: 1  Memory Usage: 24kB
              Buffers: shared hit=4 read=5
              ->  Index Only Scan using river_job_prioritized_fetching_index on river_job  (cost=0.42..34.77 rows=497 width=10) (actual time=0.182..0.506 rows=500 loops=1)
                    Index Cond: ((state = 'available'::queue_state_count_explain.river_job_state) AND (queue = ANY ('{queue_001,queue_002}'::text[])))
                    Heap Fetches: 0
                    Buffers: shared hit=4 read=5
        ->  Hash  (cost=31.50..31.50 rows=2 width=40) (actual time=1.088..1.089 rows=2 loops=1)
              Buckets: 1024  Batches: 1  Memory Usage: 9kB
              Buffers: shared hit=6 read=8
              ->  Hash Right Join  (cost=29.25..31.50 rows=2 width=40) (actual time=1.064..1.073 rows=2 loops=1)
                    Hash Cond: (river_job_1.queue = (unnest('{queue_001,queue_002}'::text[])))
                    Buffers: shared hit=6 read=8
                    ->  HashAggregate  (cost=29.18..30.17 rows=99 width=18) (actual time=1.050..1.051 rows=2 loops=1)
                          Group Key: river_job_1.queue
                          Batches: 1  Memory Usage: 24kB
                          Buffers: shared hit=6 read=8
                          ->  Index Only Scan using river_job_prioritized_fetching_index on river_job river_job_1  (cost=0.42..26.71 rows=493 width=10) (actual time=0.327..0.995 rows=500 loops=1)
                                Index Cond: ((state = 'running'::queue_state_count_explain.river_job_state) AND (queue = ANY ('{queue_001,queue_002}'::text[])))
                                Heap Fetches: 0
                                Buffers: shared hit=6 read=8
                    ->  Hash  (cost=0.05..0.05 rows=2 width=32) (actual time=0.009..0.010 rows=2 loops=1)
                          Buckets: 1024  Batches: 1  Memory Usage: 9kB
                          ->  Unique  (cost=0.04..0.05 rows=2 width=32) (actual time=0.006..0.007 rows=2 loops=1)
                                ->  Sort  (cost=0.04..0.04 rows=2 width=32) (actual time=0.005..0.006 rows=2 loops=1)
                                      Sort Key: (unnest('{queue_001,queue_002}'::text[]))
                                      Sort Method: quicksort  Memory: 25kB
                                      ->  ProjectSet  (cost=0.00..0.03 rows=2 width=32) (actual time=0.001..0.002 rows=2 loops=1)
                                            ->  Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.000..0.000 rows=1 loops=1)
Planning:
  Buffers: shared hit=3
Planning Time: 0.195 ms
Execution Time: 1.717 ms
```

</details>

<details>
<summary>Full <code>EXPLAIN (ANALYZE, BUFFERS)</code> output for 10 queues</summary>

Current query:

```text
Finalize GroupAggregate  (cost=5484.38..5691.06 rows=800 width=22) (actual time=13.719..15.387 rows=80 loops=1)
  Group Key: queue, state
  Buffers: shared hit=3157
  ->  Gather Merge  (cost=5484.38..5671.06 rows=1600 width=22) (actual time=13.710..15.346 rows=240 loops=1)
        Workers Planned: 2
        Workers Launched: 2
        Buffers: shared hit=3157
        ->  Sort  (cost=4484.35..4486.35 rows=800 width=22) (actual time=10.958..10.961 rows=80 loops=3)
              Sort Key: queue, state
              Sort Method: quicksort  Memory: 28kB
              Buffers: shared hit=3157
              Worker 0:  Sort Method: quicksort  Memory: 28kB
              Worker 1:  Sort Method: quicksort  Memory: 28kB
              ->  Partial HashAggregate  (cost=4437.78..4445.78 rows=800 width=22) (actual time=10.891..10.903 rows=80 loops=3)
                    Group Key: queue, state
                    Batches: 1  Memory Usage: 49kB
                    Buffers: shared hit=3125
                    Worker 0:  Batches: 1  Memory Usage: 49kB
                    Worker 1:  Batches: 1  Memory Usage: 49kB
                    ->  Parallel Seq Scan on river_job  (cost=0.03..4375.02 rows=8367 width=14) (actual time=0.026..9.899 rows=6667 loops=3)
                          Filter: (queue = ANY ('{queue_001,queue_002,queue_003,queue_004,queue_005,queue_006,queue_007,queue_008,queue_009,queue_010}'::text[]))
                          Rows Removed by Filter: 60000
                          Buffers: shared hit=3125
Planning:
  Buffers: shared hit=5 read=1
Planning Time: 0.271 ms
Execution Time: 15.429 ms
```

Old query:

```text
Sort  (cost=379.27..379.29 rows=10 width=48) (actual time=8.039..8.045 rows=10 loops=1)
  Sort Key: (unnest('{queue_001,queue_002,queue_003,queue_004,queue_005,queue_006,queue_007,queue_008,queue_009,queue_010}'::text[]))
  Sort Method: quicksort  Memory: 25kB
  Buffers: shared hit=70 read=29
  ->  Hash Right Join  (cost=376.63..379.10 rows=10 width=48) (actual time=7.967..7.985 rows=10 loops=1)
        Hash Cond: (river_job.queue = (unnest('{queue_001,queue_002,queue_003,queue_004,queue_005,queue_006,queue_007,queue_008,queue_009,queue_010}'::text[])))
        Buffers: shared hit=67 read=29
        ->  HashAggregate  (cost=187.17..188.17 rows=100 width=18) (actual time=3.198..3.202 rows=10 loops=1)
              Group Key: river_job.queue
              Batches: 1  Memory Usage: 24kB
              Buffers: shared hit=29 read=15
              ->  Index Only Scan using river_job_prioritized_fetching_index on river_job  (cost=0.42..174.58 rows=2518 width=10) (actual time=0.042..2.066 rows=2500 loops=1)
                    Index Cond: ((state = 'available'::queue_state_count_explain.river_job_state) AND (queue = ANY ('{queue_001,queue_002,queue_003,queue_004,queue_005,queue_006,queue_007,queue_008,queue_009,queue_010}'::text[])))
                    Heap Fetches: 0
                    Buffers: shared hit=29 read=15
        ->  Hash  (cost=189.33..189.33 rows=10 width=40) (actual time=4.641..4.644 rows=10 loops=1)
              Buckets: 1024  Batches: 1  Memory Usage: 9kB
              Buffers: shared hit=38 read=14
              ->  Hash Right Join  (cost=187.06..189.33 rows=10 width=40) (actual time=4.614..4.629 rows=10 loops=1)
                    Hash Cond: (river_job_1.queue = (unnest('{queue_001,queue_002,queue_003,queue_004,queue_005,queue_006,queue_007,queue_008,queue_009,queue_010}'::text[])))
                    Buffers: shared hit=38 read=14
                    ->  HashAggregate  (cost=186.71..187.71 rows=100 width=18) (actual time=4.565..4.568 rows=10 loops=1)
                          Group Key: river_job_1.queue
                          Batches: 1  Memory Usage: 24kB
                          Buffers: shared hit=38 read=14
                          ->  Index Only Scan using river_job_prioritized_fetching_index on river_job river_job_1  (cost=0.42..174.21 rows=2501 width=10) (actual time=0.420..3.977 rows=2500 loops=1)
                                Index Cond: ((state = 'running'::queue_state_count_explain.river_job_state) AND (queue = ANY ('{queue_001,queue_002,queue_003,queue_004,queue_005,queue_006,queue_007,queue_008,queue_009,queue_010}'::text[])))
                                Heap Fetches: 0
                                Buffers: shared hit=38 read=14
                    ->  Hash  (cost=0.22..0.22 rows=10 width=32) (actual time=0.020..0.021 rows=10 loops=1)
                          Buckets: 1024  Batches: 1  Memory Usage: 9kB
                          ->  HashAggregate  (cost=0.09..0.22 rows=10 width=32) (actual time=0.010..0.012 rows=10 loops=1)
                                Group Key: unnest('{queue_001,queue_002,queue_003,queue_004,queue_005,queue_006,queue_007,queue_008,queue_009,queue_010}'::text[])
                                Batches: 1  Memory Usage: 24kB
                                ->  ProjectSet  (cost=0.00..0.07 rows=10 width=32) (actual time=0.004..0.006 rows=10 loops=1)
                                      ->  Result  (cost=0.00..0.01 rows=1 width=0) (actual time=0.001..0.001 rows=1 loops=1)
Planning:
  Buffers: shared hit=154 read=8
Planning Time: 4.956 ms
Execution Time: 8.376 ms
```

</details>
