### PR TITLE
Add "table repacker" maintenance services that runs `REPACK (CONCURRENTLY)`

### DIFF
--- a/client.go
+++ b/client.go
@@ -280,6 +280,27 @@ type Config struct {
 	// than working them. If it's specified, then Workers must also be given.
 	Queues map[string]QueueConfig
 
+	// RepackerEnabled enables the table repacker maintenance service, which
+	// periodically runs REPACK (CONCURRENTLY) on the river_job table to reclaim
+	// space from dead tuples. This is not enabled by default.
+	//
+	// REPACK (CONCURRENTLY) requires Postgres >= 19. On older versions, the
+	// repacker falls back to VACUUM FULL, which takes an ACCESS EXCLUSIVE lock
+	// on the table and blocks all reads and writes for the duration of the
+	// operation. This is not safe for production use on Postgres < 19 and
+	// should only be used during planned maintenance windows.
+	RepackerEnabled bool
+
+	// RepackerSchedule is the schedule for running the table repacker. If nil,
+	// the table repacker will run at 01:00 UTC every day.
+	RepackerSchedule PeriodicSchedule
+
+	// RepackerTimeout is the amount of time to wait for the table repacker to
+	// run before cancelling it via context. Set to -1 to disable the timeout.
+	//
+	// Defaults to 5 minutes.
+	RepackerTimeout time.Duration
+
 	// ReindexerSchedule is the schedule for running the reindexer. If nil, the
 	// reindexer will run at midnight UTC every day.
 	ReindexerSchedule PeriodicSchedule
@@ -451,6 +472,9 @@ func (c *Config) WithDefaults() *Config {
 		PeriodicJobs:                c.PeriodicJobs,
 		PollOnly:                    c.PollOnly,
 		Queues:                      c.Queues,
+		RepackerEnabled:             c.RepackerEnabled,
+		RepackerSchedule:            c.RepackerSchedule,
+		RepackerTimeout:             cmp.Or(c.RepackerTimeout, maintenance.TableRepackerTimeoutDefault),
 		ReindexerIndexNames:         reindexerIndexNames,
 		ReindexerSchedule:           c.ReindexerSchedule,
 		ReindexerTimeout:            cmp.Or(c.ReindexerTimeout, maintenance.ReindexerTimeoutDefault),
@@ -498,6 +522,9 @@ func (c *Config) validate() error {
 	}
 	if len(c.Middleware) > 0 && (len(c.JobInsertMiddleware) > 0 || len(c.WorkerMiddleware) > 0) {
 		return errors.New("only one of the pair JobInsertMiddleware/WorkerMiddleware or Middleware may be provided (Middleware is recommended, and may contain both job insert and worker middleware)")
+	}
+	if c.RepackerTimeout < -1 {
+		return errors.New("RepackerTimeout cannot be negative, except for -1 (infinite)")
 	}
 	if c.ReindexerTimeout < -1 {
 		return errors.New("ReindexerTimeout cannot be negative, except for -1 (infinite)")
@@ -658,6 +685,7 @@ type clientTestSignals struct {
 	queueCleaner          *maintenance.QueueCleanerTestSignals
 	queueMaintainerLeader *maintenance.QueueMaintainerLeaderTestSignals
 	reindexer             *maintenance.ReindexerTestSignals
+	tableRepacker         *maintenance.TableRepackerTestSignals
 }
 
 func (ts *clientTestSignals) Init(tb testutil.TestingTB) {
@@ -681,6 +709,9 @@ func (ts *clientTestSignals) Init(tb testutil.TestingTB) {
 	}
 	if ts.reindexer != nil {
 		ts.reindexer.Init(tb)
+	}
+	if ts.tableRepacker != nil {
+		ts.tableRepacker.Init(tb)
 	}
 }
 
@@ -975,6 +1006,21 @@ func NewClient[TTx any](driver riverdriver.Driver[TTx], config *Config) (*Client
 			}, driver.GetExecutor())
 			maintenanceServices = append(maintenanceServices, reindexer)
 			client.testSignals.reindexer = &reindexer.TestSignals
+		}
+
+		if config.RepackerEnabled {
+			var scheduleFunc func(time.Time) time.Time
+			if config.RepackerSchedule != nil {
+				scheduleFunc = config.RepackerSchedule.Next
+			}
+
+			tableRepacker := maintenance.NewTableRepacker(archetype, &maintenance.TableRepackerConfig{
+				ScheduleFunc: scheduleFunc,
+				Schema:       config.Schema,
+				Timeout:      config.RepackerTimeout,
+			}, driver.GetExecutor())
+			maintenanceServices = append(maintenanceServices, tableRepacker)
+			client.testSignals.tableRepacker = &tableRepacker.TestSignals
 		}
 
 		if pluginPilot != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -5572,6 +5572,21 @@ func Test_Client_Maintenance(t *testing.T) {
 		svc := maintenance.GetService[*maintenance.Reindexer](client.queueMaintainer)
 		svc.TestSignals.Reindexed.WaitOrTimeout()
 	})
+
+	t.Run("TableRepacker", func(t *testing.T) {
+		t.Parallel()
+
+		config := newTestConfig(t, "")
+		config.RepackerEnabled = true
+		config.RepackerSchedule = &runOnceSchedule{}
+
+		client, _ := setup(t, config)
+
+		startAndWaitForQueueMaintainer(ctx, t, client)
+
+		svc := maintenance.GetService[*maintenance.TableRepacker](client.queueMaintainer)
+		svc.TestSignals.Repacked.WaitOrTimeout()
+	})
 }
 
 type runOnceSchedule struct {

--- a/internal/maintenance/table_repacker.go
+++ b/internal/maintenance/table_repacker.go
@@ -1,0 +1,236 @@
+package maintenance
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/rivershared/baseservice"
+	"github.com/riverqueue/river/rivershared/riversharedmaintenance"
+	"github.com/riverqueue/river/rivershared/startstop"
+	"github.com/riverqueue/river/rivershared/testsignal"
+	"github.com/riverqueue/river/rivershared/util/testutil"
+)
+
+const (
+	// TableRepackerTimeoutDefault is the default timeout of the table repacker.
+	// Repacking a large table may take a while, so the default timeout is quite
+	// generous.
+	TableRepackerTimeoutDefault = 5 * time.Minute
+
+	// PostgresVersionRepackMinimum is the minimum version of Postgres that
+	// supports REPACK (CONCURRENTLY). Postgres 19 is the first version to
+	// include this feature.
+	PostgresVersionRepackMinimum = 190000
+)
+
+// TableRepackerTestSignals are internal signals used exclusively in tests.
+type TableRepackerTestSignals struct {
+	Repacked testsignal.TestSignal[struct{}] // notifies when a run finishes
+}
+
+func (ts *TableRepackerTestSignals) Init(tb testutil.TestingTB) {
+	ts.Repacked.Init(tb)
+}
+
+type TableRepackerConfig struct {
+	// ScheduleFunc returns the next scheduled run time for the repacker given
+	// the current time.
+	ScheduleFunc func(time.Time) time.Time
+
+	// Schema where River tables are located. Empty string omits schema, causing
+	// Postgres to default to `search_path`.
+	Schema string
+
+	// Timeout is the amount of time to wait for a repack query to run before
+	// cancelling it via context.
+	Timeout time.Duration
+}
+
+func (c *TableRepackerConfig) mustValidate() *TableRepackerConfig {
+	if c.ScheduleFunc == nil {
+		panic("TableRepackerConfig.ScheduleFunc must be set")
+	}
+	if c.Timeout < -1 {
+		panic("TableRepackerConfig.Timeout must be above zero")
+	}
+
+	return c
+}
+
+// TableRepacker periodically executes a REPACK (CONCURRENTLY) command on the
+// river_job table to reclaim space from dead tuples. This is a more efficient
+// alternative to VACUUM FULL because it doesn't take an exclusive lock on the
+// table.
+//
+// REPACK (CONCURRENTLY) requires Postgres >= 19. On older versions, the
+// repacker falls back to VACUUM FULL, which takes an exclusive lock and blocks
+// all access to the table for the duration of the operation. This fallback is
+// not safe for production use and will only be used if explicitly configured.
+type TableRepacker struct {
+	riversharedmaintenance.QueueMaintainerServiceBase
+	startstop.BaseStartStop
+
+	// exported for test purposes
+	Config      *TableRepackerConfig
+	TestSignals TableRepackerTestSignals
+
+	exec          riverdriver.Executor
+	useVacuumFull bool // falls back to VACUUM FULL for Postgres < 19
+}
+
+func NewTableRepacker(archetype *baseservice.Archetype, config *TableRepackerConfig, exec riverdriver.Executor) *TableRepacker {
+	scheduleFunc := config.ScheduleFunc
+	if scheduleFunc == nil {
+		scheduleFunc = (&DefaultTableRepackerSchedule{}).Next
+	}
+
+	return baseservice.Init(archetype, &TableRepacker{
+		Config: (&TableRepackerConfig{
+			ScheduleFunc: scheduleFunc,
+			Schema:       config.Schema,
+			Timeout:      cmp.Or(config.Timeout, TableRepackerTimeoutDefault),
+		}).mustValidate(),
+
+		exec: exec,
+	})
+}
+
+func (s *TableRepacker) Start(ctx context.Context) error {
+	ctx, shouldStart, started, stopped := s.StartInit(ctx)
+	if !shouldStart {
+		return nil
+	}
+
+	s.StaggerStart(ctx)
+
+	go func() {
+		started()
+		defer stopped() // this defer should come first so it's last out
+
+		s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStarted)
+		defer s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRunLoopStopped)
+
+		// Detect the Postgres version to determine whether we can use REPACK
+		// (CONCURRENTLY) or need to fall back to VACUUM FULL. This only needs
+		// to be done once at start. If the version query fails (e.g. on
+		// non-Postgres databases like SQLite), the service disables itself.
+		if !s.useVacuumFull {
+			useVacuumFull, err := s.detectVacuumFallback(ctx)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
+				s.Logger.WarnContext(ctx, s.Name+": Couldn't detect Postgres version; disabling table repacker (this is expected on non-Postgres databases)",
+					slog.String("error", err.Error()))
+				return
+			}
+			s.useVacuumFull = useVacuumFull
+		}
+
+		nextRunAt := s.Config.ScheduleFunc(time.Now().UTC())
+
+		s.Logger.DebugContext(ctx, s.Name+": Scheduling first run", slog.Time("next_run_at", nextRunAt))
+
+		timerUntilNextRun := time.NewTimer(time.Until(nextRunAt))
+		scheduleNextRun := func() {
+			// Advance from the previous scheduled time, not "now", so retries
+			// stay aligned with the configured cadence and don't immediately
+			// refire after a timer that has already elapsed.
+			nextRunAt = s.Config.ScheduleFunc(nextRunAt)
+			timerUntilNextRun.Reset(time.Until(nextRunAt))
+		}
+
+		for {
+			select {
+			case <-timerUntilNextRun.C:
+				if err := s.repackTable(ctx); err != nil {
+					if !errors.Is(err, context.Canceled) {
+						s.Logger.ErrorContext(ctx, s.Name+": Error repacking table", slog.String("error", err.Error()))
+					}
+				}
+
+				s.TestSignals.Repacked.Signal(struct{}{})
+
+				scheduleNextRun()
+
+				s.Logger.DebugContext(ctx, s.Name+riversharedmaintenance.LogPrefixRanSuccessfully,
+					slog.Time("next_run_at", nextRunAt))
+
+			case <-ctx.Done():
+				// Clean up timer resources. We know it has _not_ received from
+				// the timer since its last reset because that would have led us
+				// to the case above instead of here.
+				if !timerUntilNextRun.Stop() {
+					<-timerUntilNextRun.C
+				}
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// detectVacuumFallback checks the Postgres version and returns true if we need
+// to fall back to VACUUM FULL (i.e., Postgres < 19).
+func (s *TableRepacker) detectVacuumFallback(ctx context.Context) (bool, error) {
+	var versionNumStr string
+	if err := s.exec.QueryRow(ctx, "SHOW server_version_num").Scan(&versionNumStr); err != nil {
+		return false, err
+	}
+
+	versionNum, err := strconv.Atoi(versionNumStr)
+	if err != nil {
+		return false, err
+	}
+
+	if versionNum < PostgresVersionRepackMinimum {
+		s.Logger.WarnContext(ctx, s.Name+": Postgres version does not support REPACK (CONCURRENTLY); falling back to VACUUM FULL which takes an exclusive lock",
+			slog.Int("postgres_version_num", versionNum), slog.Int("minimum_version_for_repack", PostgresVersionRepackMinimum))
+		return true, nil
+	}
+
+	s.Logger.InfoContext(ctx, s.Name+": Using REPACK (CONCURRENTLY)",
+		slog.Int("postgres_version_num", versionNum))
+
+	return false, nil
+}
+
+func (s *TableRepacker) repackTable(ctx context.Context) error {
+	var cancel func()
+	if s.Config.Timeout > -1 {
+		ctx, cancel = context.WithTimeout(ctx, s.Config.Timeout)
+		defer cancel()
+	}
+
+	if err := s.exec.TableRepack(ctx, &riverdriver.TableRepackParams{
+		Schema:        s.Config.Schema,
+		Table:         "river_job",
+		UseVacuumFull: s.useVacuumFull,
+	}); err != nil {
+		return err
+	}
+
+	action := "REPACK (CONCURRENTLY)"
+	if s.useVacuumFull {
+		action = "VACUUM FULL"
+	}
+
+	s.Logger.InfoContext(ctx, s.Name+": Repacked table", slog.String("table", "river_job"), slog.String("action", action))
+	return nil
+}
+
+// DefaultTableRepackerSchedule is a default schedule for the table repacker
+// which runs at 01:00 UTC daily, offset from the reindexer's midnight schedule
+// so they don't overlap.
+type DefaultTableRepackerSchedule struct{}
+
+// Next returns the next scheduled time for the table repacker.
+func (s *DefaultTableRepackerSchedule) Next(t time.Time) time.Time {
+	return t.Add(24 * time.Hour).Truncate(24 * time.Hour).Add(1 * time.Hour)
+}

--- a/internal/maintenance/table_repacker_test.go
+++ b/internal/maintenance/table_repacker_test.go
@@ -1,0 +1,224 @@
+package maintenance
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/riverdbtest"
+	"github.com/riverqueue/river/riverdriver"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivershared/riversharedtest"
+	"github.com/riverqueue/river/rivershared/startstoptest"
+)
+
+type tableRepackerExecutorMock struct {
+	riverdriver.Executor
+
+	tableRepackCalls atomic.Int32
+	tableRepackFunc  func(ctx context.Context, params *riverdriver.TableRepackParams) error
+}
+
+func newTableRepackerExecutorMock(exec riverdriver.Executor) *tableRepackerExecutorMock {
+	return &tableRepackerExecutorMock{
+		Executor:        exec,
+		tableRepackFunc: exec.TableRepack,
+	}
+}
+
+func (m *tableRepackerExecutorMock) TableRepack(ctx context.Context, params *riverdriver.TableRepackParams) error {
+	m.tableRepackCalls.Add(1)
+	return m.tableRepackFunc(ctx, params)
+}
+
+func TestTableRepacker(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	type testBundle struct {
+		exec   riverdriver.Executor
+		schema string
+	}
+
+	setup := func(t *testing.T) (*TableRepacker, *testBundle) {
+		t.Helper()
+
+		var (
+			dbPool = riversharedtest.DBPool(ctx, t)
+			driver = riverpgxv5.New(dbPool)
+			schema = riverdbtest.TestSchema(ctx, t, driver, nil)
+		)
+
+		bundle := &testBundle{
+			exec:   riverpgxv5.New(dbPool).GetExecutor(),
+			schema: schema,
+		}
+
+		archetype := riversharedtest.BaseServiceArchetype(t)
+
+		fromNow := func(d time.Duration) func(time.Time) time.Time {
+			return func(t time.Time) time.Time {
+				return t.Add(d)
+			}
+		}
+
+		svc := NewTableRepacker(archetype, &TableRepackerConfig{
+			ScheduleFunc: fromNow(500 * time.Millisecond),
+			Schema:       schema,
+		}, bundle.exec)
+		svc.StaggerStartupDisable(true)
+		svc.TestSignals.Init(t)
+		t.Cleanup(svc.Stop)
+
+		return svc, bundle
+	}
+
+	runImmediatelyThenOnceAnHour := func() func(time.Time) time.Time {
+		alreadyRan := false
+		return func(t time.Time) time.Time {
+			if alreadyRan {
+				return t.Add(time.Hour)
+			}
+			alreadyRan = true
+			return t.Add(time.Millisecond)
+		}
+	}
+
+	t.Run("StartStopStress", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t)
+		svc.Logger = riversharedtest.LoggerWarn(t)   // loop started/stop log is very noisy; suppress
+		svc.TestSignals = TableRepackerTestSignals{} // deinit so channels don't fill
+
+		startstoptest.Stress(ctx, t, svc)
+	})
+
+	t.Run("RepackSuccess", func(t *testing.T) {
+		t.Parallel()
+
+		svc, bundle := setup(t)
+
+		mockExec := newTableRepackerExecutorMock(bundle.exec)
+		mockExec.tableRepackFunc = func(ctx context.Context, params *riverdriver.TableRepackParams) error {
+			return nil
+		}
+		svc.exec = mockExec
+
+		svc.Config.ScheduleFunc = runImmediatelyThenOnceAnHour()
+
+		require.NoError(t, svc.Start(ctx))
+		svc.TestSignals.Repacked.WaitOrTimeout()
+
+		require.GreaterOrEqual(t, int(mockExec.tableRepackCalls.Load()), 1)
+	})
+
+	t.Run("RepackUsesVacuumFullWhenDetected", func(t *testing.T) {
+		t.Parallel()
+
+		svc, bundle := setup(t)
+
+		var repackedWithVacuumFull atomic.Bool
+		mockExec := newTableRepackerExecutorMock(bundle.exec)
+		mockExec.tableRepackFunc = func(ctx context.Context, params *riverdriver.TableRepackParams) error {
+			if params.UseVacuumFull {
+				repackedWithVacuumFull.Store(true)
+			}
+			return nil
+		}
+		svc.exec = mockExec
+		svc.useVacuumFull = true // simulate Postgres < 19
+
+		svc.Config.ScheduleFunc = runImmediatelyThenOnceAnHour()
+
+		require.NoError(t, svc.Start(ctx))
+		svc.TestSignals.Repacked.WaitOrTimeout()
+
+		require.True(t, repackedWithVacuumFull.Load())
+	})
+
+	t.Run("RepackPassesSchemaAndTable", func(t *testing.T) {
+		t.Parallel()
+
+		svc, bundle := setup(t)
+
+		var capturedParams atomic.Pointer[riverdriver.TableRepackParams]
+		mockExec := newTableRepackerExecutorMock(bundle.exec)
+		mockExec.tableRepackFunc = func(ctx context.Context, params *riverdriver.TableRepackParams) error {
+			capturedParams.Store(params)
+			return nil
+		}
+		svc.exec = mockExec
+
+		svc.Config.ScheduleFunc = runImmediatelyThenOnceAnHour()
+
+		require.NoError(t, svc.Start(ctx))
+		svc.TestSignals.Repacked.WaitOrTimeout()
+
+		params := capturedParams.Load()
+		require.NotNil(t, params)
+		require.Equal(t, "river_job", params.Table)
+		require.Equal(t, bundle.schema, params.Schema)
+	})
+
+	t.Run("StopsImmediately", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t)
+
+		require.NoError(t, svc.Start(ctx))
+		svc.Stop()
+	})
+
+	t.Run("RespectsContextCancellation", func(t *testing.T) {
+		t.Parallel()
+
+		svc, _ := setup(t)
+
+		ctx, cancelFunc := context.WithCancel(ctx)
+		require.NoError(t, svc.Start(ctx))
+
+		// To avoid a potential race, make sure to get a reference to the
+		// service's stopped channel _before_ cancellation as it's technically
+		// possible for the cancel to "win" and remove the stopped channel
+		// before we can start waiting on it.
+		stopped := svc.Stopped()
+		cancelFunc()
+		riversharedtest.WaitOrTimeout(t, stopped)
+	})
+
+	t.Run("AppliesDefaultScheduleAndTimeout", func(t *testing.T) {
+		t.Parallel()
+
+		svc, bundle := setup(t)
+		now := time.Now().UTC()
+		svc = NewTableRepacker(&svc.Archetype, &TableRepackerConfig{}, bundle.exec)
+
+		require.Equal(t, TableRepackerTimeoutDefault, svc.Config.Timeout)
+		require.Equal(t, svc.Config.ScheduleFunc(now), (&DefaultTableRepackerSchedule{}).Next(now))
+	})
+}
+
+func TestDefaultTableRepackerSchedule(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithMidnightInputReturns1AM24HoursLater", func(t *testing.T) {
+		t.Parallel()
+
+		schedule := &DefaultTableRepackerSchedule{}
+		result := schedule.Next(time.Date(2023, 8, 31, 0, 0, 0, 0, time.UTC))
+		require.Equal(t, time.Date(2023, 9, 1, 1, 0, 0, 0, time.UTC), result)
+	})
+
+	t.Run("With1NanosecondBeforeMidnightItReturnsUpcoming1AM", func(t *testing.T) {
+		t.Parallel()
+
+		schedule := &DefaultTableRepackerSchedule{}
+		result := schedule.Next(time.Date(2023, 8, 31, 23, 59, 59, 999999999, time.UTC))
+		require.Equal(t, time.Date(2023, 9, 1, 1, 0, 0, 0, time.UTC), result)
+	})
+}

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -276,6 +276,15 @@ type Executor interface {
 	// TableExists checks whether a table exists for the schema in the current
 	// search schema.
 	TableExists(ctx context.Context, params *TableExistsParams) (bool, error)
+
+	// TableRepack repacks a table to reclaim space from dead tuples. On
+	// Postgres >= 19, this uses `REPACK (CONCURRENTLY)` which doesn't take an
+	// exclusive lock. On older versions, it falls back to `VACUUM FULL` which
+	// does take an exclusive lock and blocks all access to the table.
+	//
+	// API is not stable. DO NOT USE.
+	TableRepack(ctx context.Context, params *TableRepackParams) error
+
 	TableTruncate(ctx context.Context, params *TableTruncateParams) error
 }
 
@@ -863,6 +872,20 @@ type SchemaGetExpiredParams struct {
 type TableExistsParams struct {
 	Schema string
 	Table  string
+}
+
+type TableRepackParams struct {
+	// Schema where the table is located. Empty string omits schema, causing
+	// Postgres to default to `search_path`.
+	Schema string
+
+	// Table is the name of the table to repack.
+	Table string
+
+	// UseVacuumFull forces the use of VACUUM FULL instead of REPACK
+	// (CONCURRENTLY). VACUUM FULL takes an exclusive lock and should only be
+	// used when REPACK is unavailable (Postgres < 19).
+	UseVacuumFull bool
 }
 
 type TableTruncateParams struct {

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -995,6 +995,25 @@ func (e *Executor) SchemaGetExpired(ctx context.Context, params *riverdriver.Sch
 	return schemas, nil
 }
 
+func (e *Executor) TableRepack(ctx context.Context, params *riverdriver.TableRepackParams) error {
+	var maybeSchema string
+	if params.Schema != "" {
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
+	}
+
+	table := maybeSchema + dbutil.SafeIdentifier(params.Table)
+
+	var sql string
+	if params.UseVacuumFull {
+		sql = "VACUUM FULL " + table
+	} else {
+		sql = "REPACK (CONCURRENTLY) " + table
+	}
+
+	_, err := e.dbtx.ExecContext(ctx, sql)
+	return interpretError(err)
+}
+
 func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExistsParams) (bool, error) {
 	// Different from other operations because the schemaAndTable name is a parameter.
 	schemaAndTable := params.Table

--- a/riverdriver/riverdrivertest/schema_introspection.go
+++ b/riverdriver/riverdrivertest/schema_introspection.go
@@ -216,6 +216,34 @@ func exerciseSchemaIntrospection[TTx any](ctx context.Context, t *testing.T,
 		})
 	})
 
+	t.Run("TableRepack", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("RepacksTable", func(t *testing.T) {
+			t.Parallel()
+
+			// REPACK/VACUUM FULL can't run inside a transaction block, so this
+			// must use a full schema.
+			driver, schema := driverWithSchema(ctx, t, nil)
+
+			if driver.DatabaseName() == databaseNameSQLite {
+				err := driver.GetExecutor().TableRepack(ctx, &riverdriver.TableRepackParams{
+					Schema: schema,
+					Table:  "river_job",
+				})
+				require.ErrorIs(t, err, riverdriver.ErrNotImplemented)
+				return
+			}
+
+			err := driver.GetExecutor().TableRepack(ctx, &riverdriver.TableRepackParams{
+				Schema:        schema,
+				Table:         "river_job",
+				UseVacuumFull: true, // use VACUUM FULL so the test works on any Postgres version
+			})
+			require.NoError(t, err)
+		})
+	})
+
 	t.Run("SchemaGetExpired", func(t *testing.T) {
 		t.Parallel()
 

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -991,6 +991,23 @@ func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExi
 	return exists, interpretError(err)
 }
 
+func (e *Executor) TableRepack(ctx context.Context, params *riverdriver.TableRepackParams) error {
+	var maybeSchema string
+	if params.Schema != "" {
+		maybeSchema = dbutil.SafeIdentifier(params.Schema) + "."
+	}
+
+	var sql string
+	if params.UseVacuumFull {
+		sql = "VACUUM FULL " + maybeSchema + dbutil.SafeIdentifier(params.Table)
+	} else {
+		sql = "REPACK (CONCURRENTLY) " + maybeSchema + dbutil.SafeIdentifier(params.Table)
+	}
+
+	_, err := e.dbtx.Exec(ctx, sql)
+	return interpretError(err)
+}
+
 func (e *Executor) TableTruncate(ctx context.Context, params *riverdriver.TableTruncateParams) error {
 	var maybeSchema string
 	if params.Schema != "" {

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -1453,6 +1453,10 @@ func (e *Executor) TableExists(ctx context.Context, params *riverdriver.TableExi
 	return exists, interpretError(err)
 }
 
+func (e *Executor) TableRepack(_ context.Context, _ *riverdriver.TableRepackParams) error {
+	return riverdriver.ErrNotImplemented
+}
+
 func (e *Executor) TableTruncate(ctx context.Context, params *riverdriver.TableTruncateParams) error {
 	var maybeSchema string
 	if params.Schema != "" {


### PR DESCRIPTION
Here, add a maintenance service modeled on the reindexer that runs
`REPACK (CONCURRENTLY)`, a new feature slated for Postgres 19 [1]. This
is an exciting new feature that can fully reset a table without needing
to take an exclusive lock the way that `VACUUM FULL` does.

This feature may be on the riskier side at first, so I've disabled it by
default, requiring an explicit `RepackerEnabled: true` to activate.

Similar to the reindexer it runs once a day. I've staggered its start
time to 1 AM UTC so it's offset from the reindexer's start time of
midnight.

This relies on Postgres 19 to work, so it's not really suitable for
release yet, but I've put in fallback code that causes it to run `VACUUM
FULL` for Postgres prior to 19. (This is obviously not suitable for use,
but it gets the test matrix running.)

[1] https://github.com/postgres/postgres/commit/28d534e2ae0ac888b5460f977a10cd9bb017ef98