### PR TITLE
Remove unused reindexer constant

### DIFF
--- a/internal/maintenance/reindexer.go
+++ b/internal/maintenance/reindexer.go
@@ -16,8 +16,6 @@ import (
 )
 
 const (
-	ReindexerIntervalDefault = 24 * time.Hour
-
 	// ReindexerTimeoutDefault is the default timeout of the reindexer.
 	//
 	// We've had user reports of builds taking 45 seconds on large tables, so


### PR DESCRIPTION
I just noticed while putting together #1228 that we have an unused
constant in the reindexer, `ReindexerIntervalDefault`, as some time back
the interval was replaced by a schedule func. Here, drop it.