### PR TITLE
Add `.envrc` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.envrc
 /go.work.sum
 /internal/cmd/riverbench/riverbench
 /river


### PR DESCRIPTION
Just a small one to add `.envrc` to `.gitignore`. Though not strictly
required for anything, I use it to set a few env vars for things I'm
doing in development.