### PR TITLE
Fix accidentally inverted logic in listener log check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix accidentally inverted conditional on notifier error log check. [PR #1231](https://github.com/riverqueue/river/pull/1231).
+
 ## [0.35.0] - 2026-04-18
 
 ### Changed

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -263,7 +263,7 @@ func (n *Notifier) listenerClose(ctx context.Context, skipLock bool) {
 
 	n.Logger.DebugContext(ctx, n.Name+": Listener closing")
 	if err := n.listener.Close(ctx); err != nil {
-		if shouldIgnoreListenerError(err) {
+		if !shouldIgnoreListenerError(err) {
 			n.Logger.ErrorContext(ctx, n.Name+": Error closing listener", "err", err)
 		}
 	}


### PR DESCRIPTION
Follows up #1216 with a fix whereby the conditional on the check on
whether to log an error was accidentally inverted.