### PR TITLE
Fix intermittently failing test `Test_Client_JobCompletion/JobThatReturnsErrIsRetryable`

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7291,8 +7291,6 @@ func Test_Client_JobCompletion(t *testing.T) {
 
 		client, bundle := setup(t, config)
 
-		now := client.baseService.Time.StubNow(time.Now().UTC())
-
 		insertRes, err := client.Insert(ctx, JobArgs{}, nil)
 		require.NoError(t, err)
 
@@ -7304,7 +7302,7 @@ func Test_Client_JobCompletion(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, rivertype.JobStateRetryable, reloadedJob.State)
-		require.WithinDuration(t, now.Add(retryPolicy.Interval()), reloadedJob.ScheduledAt, time.Microsecond)
+		require.WithinDuration(t, reloadedJob.AttemptedAt.Add(retryPolicy.Interval()), reloadedJob.ScheduledAt, time.Microsecond)
 		require.Nil(t, reloadedJob.FinalizedAt)
 	})
 


### PR DESCRIPTION
Here, try to address an intermittently failing test seen in CI [1].

The problem seems to be that although the test case stubs the current
time with `StubNow`, it's possible for the producer's fetch loop to be
running concurrently and call `NowOrNil()` before the stub takes effect,
causing a divergence from the stubbed time by a few milliseconds.

The fix here drops the use of stubbed now, and instead asserts that the
new `ScheduledAt` is `AttemptedAt` plus the expected retry interval,
using a value from a reloaded job row to guarantee we don't have a race.
We drop the use of time stubbing completely as this approach no longer
requires it.

[1] https://github.com/riverqueue/river/actions/runs/25657083352/job/75308035231