### PR TITLE
Add `initTestConfig` helper for more succinct example tests

### DIFF
--- a/example_batch_insert_test.go
+++ b/example_batch_insert_test.go
@@ -3,16 +3,12 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -45,15 +41,12 @@ func Example_batchInsert() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &BatchInsertWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_client_from_context_test.go
+++ b/example_client_from_context_test.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -52,16 +48,13 @@ func ExampleClientFromContext_pgx() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &ContextClientWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		ID:     "ClientFromContextClient",
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
+		ID: "ClientFromContextClient",
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_complete_job_within_tx_test.go
+++ b/example_complete_job_within_tx_test.go
@@ -3,16 +3,12 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -71,15 +67,12 @@ func Example_completeJobWithinTx() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &TransactionalWorker{dbPool: dbPool})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_cron_job_test.go
+++ b/example_cron_job_test.go
@@ -3,17 +3,13 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/robfig/cron/v3"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -52,8 +48,7 @@ func Example_cronJob() {
 		panic(err)
 	}
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		PeriodicJobs: []*river.PeriodicJob{
 			river.NewPeriodicJob(
 				schedule,
@@ -66,10 +61,8 @@ func Example_cronJob() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_custom_insert_opts_test.go
+++ b/example_custom_insert_opts_test.go
@@ -3,16 +3,12 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -69,16 +65,13 @@ func Example_customInsertOpts() {
 	river.AddWorker(workers, &AlwaysHighPriorityWorker{})
 	river.AddWorker(workers, &SometimesHighPriorityWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 			"high_priority":    {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_error_handler_test.go
+++ b/example_error_handler_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/util/slogutil"
@@ -73,16 +72,14 @@ func Example_errorHandler() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &ErroringWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		ErrorHandler: &CustomErrorHandler{},
 		Logger:       slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(9), ReplaceAttr: slogutil.NoLevelTime})), // Suppress logging so example output is cleaner (9 > slog.LevelError).
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_global_hooks_test.go
+++ b/example_global_hooks_test.go
@@ -3,16 +3,12 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -55,7 +51,7 @@ var (
 
 // Example_globalHooks demonstrates the use of hooks to modify River behavior
 // which are global to a River client.
-func Example_globalHooks() {
+func Example_globalHooks() { //nolint:dupl
 	ctx := context.Background()
 
 	dbPool, err := pgxpool.New(ctx, riversharedtest.TestDatabaseURL())
@@ -67,21 +63,18 @@ func Example_globalHooks() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &NoOpWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		// Order is significant. See output below.
 		Hooks: []rivertype.Hook{
 			&BothInsertAndWorkBeginHook{},
 			&InsertBeginHook{},
 			&WorkBeginHook{},
 		},
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_global_middleware_test.go
+++ b/example_global_middleware_test.go
@@ -3,16 +3,12 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -55,7 +51,7 @@ var (
 
 // Example_globalMiddleware demonstrates the use of middleware to modify River
 // behavior which are global to a River client.
-func Example_globalMiddleware() {
+func Example_globalMiddleware() { //nolint:dupl
 	ctx := context.Background()
 
 	dbPool, err := pgxpool.New(ctx, riversharedtest.TestDatabaseURL())
@@ -67,9 +63,8 @@ func Example_globalMiddleware() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &NoOpWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		// Order is significant. See output below.
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
 		Middleware: []rivertype.Middleware{
 			&JobBothInsertAndWorkMiddleware{},
 			&JobInsertMiddleware{},
@@ -78,10 +73,8 @@ func Example_globalMiddleware() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_graceful_shutdown_test.go
+++ b/example_graceful_shutdown_test.go
@@ -13,11 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/util/slogutil"
-	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
 type WaitsForCancelOnlyArgs struct{}
@@ -65,15 +63,13 @@ func Example_gracefulShutdown() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &WaitsForCancelOnlyWorker{jobStarted: jobStarted})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTimeJobID})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_insert_and_work_test.go
+++ b/example_insert_and_work_test.go
@@ -3,17 +3,13 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"sort"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -48,15 +44,12 @@ func Example_insertAndWork() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &SortWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_job_args_hooks_test.go
+++ b/example_job_args_hooks_test.go
@@ -3,16 +3,12 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -91,15 +87,12 @@ func Example_jobArgsHooks() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &JobWithHooksWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_job_cancel_from_client_test.go
+++ b/example_job_cancel_from_client_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/util/slogutil"
@@ -53,15 +52,13 @@ func Example_jobCancelFromClient() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &SleepingWorker{jobChan: jobChan})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTimeJobID})),
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_job_cancel_test.go
+++ b/example_job_cancel_test.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -49,15 +45,12 @@ func Example_jobCancel() { //nolint:dupl
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &CancellingWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_job_snooze_test.go
+++ b/example_job_snooze_test.go
@@ -3,17 +3,13 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -51,15 +47,12 @@ func Example_jobSnooze() { //nolint:dupl
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &SnoozingWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 10},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_periodic_job_test.go
+++ b/example_periodic_job_test.go
@@ -3,17 +3,13 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -45,8 +41,7 @@ func Example_periodicJob() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &PeriodicJobWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		PeriodicJobs: []*river.PeriodicJob{
 			river.NewPeriodicJob(
 				river.PeriodicInterval(15*time.Minute),
@@ -59,10 +54,8 @@ func Example_periodicJob() {
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_queue_pause_test.go
+++ b/example_queue_pause_test.go
@@ -3,18 +3,13 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
-	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
 type ReportingArgs struct{}
@@ -56,16 +51,13 @@ func Example_queuePause() {
 	jobWorkedCh := make(chan string)
 	river.AddWorker(workers, &ReportingWorker{jobWorkedCh: jobWorkedCh})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			unreliableQueue: {MaxWorkers: 10},
 			reliableQueue:   {MaxWorkers: 10},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_scheduled_job_test.go
+++ b/example_scheduled_job_test.go
@@ -3,18 +3,13 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
-	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
 type ScheduledArgs struct {
@@ -46,15 +41,12 @@ func Example_scheduledJob() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &ScheduledWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_subscription_test.go
+++ b/example_subscription_test.go
@@ -11,11 +11,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/util/slogutil"
-	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
 type SubscriptionArgs struct {
@@ -53,15 +51,13 @@ func Example_subscription() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &SubscriptionWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.Level(9), ReplaceAttr: slogutil.NoLevelTime})), // Suppress logging so example output is cleaner (9 > slog.LevelError).
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_unique_job_test.go
+++ b/example_unique_job_test.go
@@ -3,17 +3,13 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -76,15 +72,12 @@ func Example_uniqueJob() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &ReconcileAccountWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/example_work_func_test.go
+++ b/example_work_func_test.go
@@ -3,16 +3,12 @@ package river_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -40,15 +36,12 @@ func Example_workFunc() {
 		return nil
 	}))
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/riverdriver/riverdrivertest/common_test.go
+++ b/riverdriver/riverdrivertest/common_test.go
@@ -1,8 +1,7 @@
-package river_test
+package riverdrivertest_test
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -14,24 +13,6 @@ import (
 	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
-
-//
-// This file used as a holding place for test helpers for examples so that the
-// helpers aren't included in Godoc and keep each example more succinct.
-//
-
-type NoOpArgs struct{}
-
-func (NoOpArgs) Kind() string { return "no_op" }
-
-type NoOpWorker struct {
-	river.WorkerDefaults[NoOpArgs]
-}
-
-func (w *NoOpWorker) Work(ctx context.Context, job *river.Job[NoOpArgs]) error {
-	fmt.Printf("NoOpWorker.Work ran\n")
-	return nil
-}
 
 // initTestConfig initializes properties on a given River config with defaults
 // suitable for example tests, including an isolated test schema and

--- a/riverdriver/riverdrivertest/example_libsql_test.go
+++ b/riverdriver/riverdrivertest/example_libsql_test.go
@@ -3,15 +3,12 @@ package riverdrivertest_test
 import (
 	"context"
 	"database/sql"
-	"log/slog"
-	"os"
 
 	_ "github.com/tursodatabase/libsql-client-go/libsql"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riversqlite"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
 
@@ -36,14 +33,12 @@ func Example_libSQL() { //nolint:dupl
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &SortWorker{})
 
-	riverClient, err := river.NewClient(driver, &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(driver, initTestConfig(ctx, nil, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		TestOnly: true, // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/riverdriver/riverdrivertest/example_sqlite_test.go
+++ b/riverdriver/riverdrivertest/example_sqlite_test.go
@@ -56,14 +56,12 @@ func Example_sqlite() { //nolint:dupl
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &SortWorker{})
 
-	riverClient, err := river.NewClient(driver, &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(driver, initTestConfig(ctx, nil, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
-		TestOnly: true, // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/riverlog/common_test.go
+++ b/riverlog/common_test.go
@@ -1,8 +1,7 @@
-package river_test
+package riverlog_test
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -14,24 +13,6 @@ import (
 	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
-
-//
-// This file used as a holding place for test helpers for examples so that the
-// helpers aren't included in Godoc and keep each example more succinct.
-//
-
-type NoOpArgs struct{}
-
-func (NoOpArgs) Kind() string { return "no_op" }
-
-type NoOpWorker struct {
-	river.WorkerDefaults[NoOpArgs]
-}
-
-func (w *NoOpWorker) Work(ctx context.Context, job *river.Job[NoOpArgs]) error {
-	fmt.Printf("NoOpWorker.Work ran\n")
-	return nil
-}
 
 // initTestConfig initializes properties on a given River config with defaults
 // suitable for example tests, including an isolated test schema and
@@ -46,7 +27,6 @@ func (w *NoOpWorker) Work(ctx context.Context, job *river.Job[NoOpArgs]) error {
 // `pgxpool.New` and `river.NewClient` wiring visible in each example.
 func initTestConfig(ctx context.Context, dbPool *pgxpool.Pool, config *river.Config) *river.Config {
 	if config.Logger == nil {
-		// Keep internal client logs off stdout so doctest output stays stable.
 		config.Logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 			Level:       slog.LevelWarn,
 			ReplaceAttr: slogutil.NoLevelTime,

--- a/riverlog/example_new_middleware_custom_context_test.go
+++ b/riverlog/example_new_middleware_custom_context_test.go
@@ -6,17 +6,13 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/riverlog"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -54,8 +50,7 @@ func ExampleNewMiddlewareCustomContext() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &CustomContextLoggingWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
@@ -68,10 +63,8 @@ func ExampleNewMiddlewareCustomContext() {
 				return context.WithValue(ctx, customContextKey{}, logger)
 			}, nil),
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/riverlog/example_new_middleware_test.go
+++ b/riverlog/example_new_middleware_test.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/riverlog"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
@@ -48,8 +46,7 @@ func ExampleNewMiddleware() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &LoggingWorker{})
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), initTestConfig(ctx, dbPool, &river.Config{
 		Queues: map[string]river.QueueConfig{
 			river.QueueDefault: {MaxWorkers: 100},
 		},
@@ -63,10 +60,8 @@ func ExampleNewMiddleware() {
 				return slog.NewTextHandler(w, &slog.HandlerOptions{ReplaceAttr: slogutil.NoLevelTime})
 			}, nil),
 		},
-		Schema:   riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil), // only necessary for the example test
-		TestOnly: true,                                                                         // suitable only for use in tests; remove for live environments
-		Workers:  workers,
-	})
+		Workers: workers,
+	}))
 	if err != nil {
 		panic(err)
 	}

--- a/rivertest/common_test.go
+++ b/rivertest/common_test.go
@@ -1,8 +1,7 @@
-package river_test
+package rivertest_test
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -14,24 +13,6 @@ import (
 	"github.com/riverqueue/river/rivershared/util/slogutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 )
-
-//
-// This file used as a holding place for test helpers for examples so that the
-// helpers aren't included in Godoc and keep each example more succinct.
-//
-
-type NoOpArgs struct{}
-
-func (NoOpArgs) Kind() string { return "no_op" }
-
-type NoOpWorker struct {
-	river.WorkerDefaults[NoOpArgs]
-}
-
-func (w *NoOpWorker) Work(ctx context.Context, job *river.Job[NoOpArgs]) error {
-	fmt.Printf("NoOpWorker.Work ran\n")
-	return nil
-}
 
 // initTestConfig initializes properties on a given River config with defaults
 // suitable for example tests, including an isolated test schema and
@@ -46,7 +27,6 @@ func (w *NoOpWorker) Work(ctx context.Context, job *river.Job[NoOpArgs]) error {
 // `pgxpool.New` and `river.NewClient` wiring visible in each example.
 func initTestConfig(ctx context.Context, dbPool *pgxpool.Pool, config *river.Config) *river.Config {
 	if config.Logger == nil {
-		// Keep internal client logs off stdout so doctest output stays stable.
 		config.Logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 			Level:       slog.LevelWarn,
 			ReplaceAttr: slogutil.NoLevelTime,

--- a/rivertest/example_require_inserted_test.go
+++ b/rivertest/example_require_inserted_test.go
@@ -3,18 +3,13 @@ package rivertest_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
-	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertest"
 )
 
@@ -44,17 +39,12 @@ func Example_requireInserted() {
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &RequiredWorker{})
 
-	var (
-		schema     = riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil)
-		schemaOpts = &rivertest.RequireInsertedOpts{Schema: schema}
-	)
-
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger:   slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
-		Schema:   schema, // only necessary for the example test
-		TestOnly: true,   // suitable only for use in tests; remove for live environments
-		Workers:  workers,
+	config := initTestConfig(ctx, dbPool, &river.Config{
+		Workers: workers,
 	})
+	schemaOpts := &rivertest.RequireInsertedOpts{Schema: config.Schema}
+
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), config)
 	if err != nil {
 		panic(err)
 	}
@@ -84,7 +74,7 @@ func Example_requireInserted() {
 	_ = rivertest.RequireInsertedTx[*riverpgxv5.Driver](ctx, t, tx, &RequiredArgs{}, &rivertest.RequireInsertedOpts{
 		Priority: 1,
 		Queue:    river.QueueDefault,
-		Schema:   schema,
+		Schema:   config.Schema,
 	})
 
 	// Insert and verify one on a pool instead of transaction.

--- a/rivertest/example_require_many_inserted_test.go
+++ b/rivertest/example_require_many_inserted_test.go
@@ -3,18 +3,13 @@ package rivertest_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/slogutil"
-	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertest"
 )
 
@@ -62,16 +57,15 @@ func Example_requireManyInserted() {
 	river.AddWorker(workers, &FirstRequiredWorker{})
 	river.AddWorker(workers, &SecondRequiredWorker{})
 
+	config := initTestConfig(ctx, dbPool, &river.Config{
+		Workers: workers,
+	})
 	var (
-		schema     = riverdbtest.TestSchema(ctx, testutil.PanicTB(), riverpgxv5.New(dbPool), nil)
+		schema     = config.Schema
 		schemaOpts = &rivertest.RequireInsertedOpts{Schema: schema}
 	)
 
-	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), &river.Config{
-		Logger:  slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn, ReplaceAttr: slogutil.NoLevelTime})),
-		Schema:  schema, // only necessary for the example test
-		Workers: workers,
-	})
+	riverClient, err := river.NewClient(riverpgxv5.New(dbPool), config)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Here, add an `initTestConfig` helper for example tests that wraps up a
lot of the common testing logic in each. This leaves the example tests
more succinct, takes a lot of test-only code out of the equation to keep
the signal higher for readers, and makes broadly refactoring example
tests easier as changes may need to only be made in one place. This is
very similar to the change we already made in River Pro.