### PR TITLE
Add 30s timeout to PeriodicJobEnqueuer insertBatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrap `PeriodicJobEnqueuer.insertBatch` database calls in a 30-second timeout. Previously, a stalled pgx `Begin`/`Insert`/`Commit` could hang the periodic enqueuer indefinitely, halting all periodic job insertion until the process was restarted or leader re-elected.
+
 ## [0.37.0] - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Wrap `PeriodicJobEnqueuer.insertBatch` database calls in a 30-second timeout. Previously, a stalled pgx `Begin`/`Insert`/`Commit` could hang the periodic enqueuer indefinitely, halting all periodic job insertion until the process was restarted or leader re-elected.
+- Wrap `PeriodicJobEnqueuer.insertBatch` database calls in a 30-second timeout. Previously, a stalled pgx `Begin`/`Insert`/`Commit` could hang the periodic enqueuer indefinitely, halting all periodic job insertion until the process was restarted or leader re-elected. [PR #1251](https://github.com/riverqueue/river/pull/1251)
 
 ## [0.37.0] - 2026-05-11
 

--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -523,6 +523,9 @@ func (s *PeriodicJobEnqueuer) insertBatch(ctx context.Context, insertParamsMany 
 		return
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, riversharedmaintenance.TimeoutDefault)
+	defer cancel()
+
 	tx, err := s.exec.Begin(ctx)
 	if err != nil {
 		s.Logger.ErrorContext(ctx, s.Name+": Error starting transaction", "error", err.Error())


### PR DESCRIPTION
Previously, `PeriodicJobEnqueuer.insertBatch` passed the raw service context directly to `Begin`/`Insert`/`Commit`, with no per-batch deadline (unlike all other calls to the db). If the underlying connection stalled, the enqueuer would hang indefinitely, halting all periodic job insertion until the process was restarted. **We have observed this issue multiple times during RW-RO failovers or temporary network unavailability, stalls in our case could last from minutes to hours**

Wrapped the DB calls in `context.WithTimeout(ctx,
riversharedmaintenance.TimeoutDefault)` (30s), matching the pattern already used by `JobScheduler` and `JobRescuer`.