### PR TITLE
Fix custom schema support of rivertest.Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `rivermigrate.ValidateOpts.TargetVersion` so validation can check migrations up to a specific target version, matching the target-version behavior available on `Migrate` and `MigrateTx`. Notably, this is a breaking API change as the validate functions previously didn't take any options. [PR #1259](https://github.com/riverqueue/river/pull/1259)
 
+### Fixed
+
+- Fixed `rivertest.Worker.Work` and `WorkJob` to honor a configured custom `Config.Schema` when transitioning a job to its running state. Previously, the running-state update ran unqualified and could fail on a connection whose `search_path` didn't include the configured schema. [PR #1262](https://github.com/riverqueue/river/pull/1262)
+
 ## [0.38.0] - 2026-05-22
 
 ### Added

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -166,6 +166,7 @@ func (w *Worker[T, TTx]) workJob(ctx context.Context, tb testing.TB, tx TTx, job
 		AttemptedAtDoUpdate: true,
 		AttemptedBy:         append(job.AttemptedBy, w.config.ID),
 		AttemptedByDoUpdate: true,
+		Schema:              w.config.Schema,
 		StateDoUpdate:       true,
 		State:               rivertype.JobStateRunning,
 	})

--- a/rivertest/worker_test.go
+++ b/rivertest/worker_test.go
@@ -450,6 +450,34 @@ func TestWorker_Work(t *testing.T) {
 		require.True(t, middlewareCalled)
 		require.True(t, middlewareWithBaseServiceCalled)
 	})
+
+	// Honors config.Schema: River lives in a named schema, worked through a
+	// transaction with an empty search_path so tables resolve only via schema
+	// qualification. Needs its own infrastructure, so it skips setup.
+	t.Run("CustomSchema", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dbPool = riversharedtest.DBPool(ctx, t)
+			driver = riverpgxv5.New(dbPool)
+			schema = riverdbtest.TestSchema(ctx, t, driver, nil)
+			config = &river.Config{ID: "rivertest-worker", Schema: schema}
+		)
+
+		tx, err := dbPool.Begin(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tx.Rollback(ctx) })
+
+		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
+			require.Equal(t, rivertype.JobStateRunning, job.State)
+			return nil
+		})
+
+		tw := NewWorker(t, driver, config, worker)
+		res, err := tw.Work(ctx, t, tx, testArgs{Value: "test"}, nil)
+		require.NoError(t, err)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
+	})
 }
 
 func TestWorker_WorkJob(t *testing.T) {
@@ -555,5 +583,39 @@ func TestWorker_WorkJob(t *testing.T) {
 		res, err := testWorker.WorkJob(ctx, t, bundle.tx, job)
 		require.ErrorContains(t, err, "failed to update job to running state")
 		require.Nil(t, res)
+	})
+
+	// Honors config.Schema: River lives in a named schema, worked through a
+	// transaction with an empty search_path so tables resolve only via schema
+	// qualification. Needs its own infrastructure, so it skips setup.
+	t.Run("CustomSchema", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			dbPool = riversharedtest.DBPool(ctx, t)
+			driver = riverpgxv5.New(dbPool)
+			schema = riverdbtest.TestSchema(ctx, t, driver, nil)
+			config = &river.Config{ID: "rivertest-workjob", Schema: schema}
+		)
+
+		tx, err := dbPool.Begin(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = tx.Rollback(ctx) })
+
+		client, err := river.NewClient(driver, config)
+		require.NoError(t, err)
+
+		insertRes, err := client.InsertTx(ctx, tx, testArgs{Value: "test"}, nil)
+		require.NoError(t, err)
+
+		worker := river.WorkFunc(func(ctx context.Context, job *river.Job[testArgs]) error {
+			require.Equal(t, rivertype.JobStateRunning, job.State)
+			return nil
+		})
+
+		tw := NewWorker(t, driver, config, worker)
+		res, err := tw.WorkJob(ctx, t, tx, insertRes.Job)
+		require.NoError(t, err)
+		require.Equal(t, river.EventKindJobCompleted, res.EventKind)
 	})
 }


### PR DESCRIPTION
Currently, `rivertest.Worker` ignores custom schema in river config.

The fix is one line. Also added a test case for it.

Simple testcontainers-based repro:

```go
package repro

import (
	"context"
	"testing"
	"time"

	"github.com/jackc/pgx/v5/pgxpool"
	"github.com/riverqueue/river"
	"github.com/riverqueue/river/riverdriver/riverpgxv5"
	"github.com/riverqueue/river/rivermigrate"
	"github.com/riverqueue/river/rivertest"
	"github.com/stretchr/testify/require"
	"github.com/testcontainers/testcontainers-go"
	"github.com/testcontainers/testcontainers-go/modules/postgres"
	"github.com/testcontainers/testcontainers-go/wait"
)

type Args struct{}

func (Args) Kind() string { return "repro" }

// TestRivertestWorkerCustomSchema reproduces the rivertest.Worker custom-schema bug.
//
//	PRE-FIX  (released river through v0.38.0): FAILS with
//	  "failed to update job to running state: ... relation \"river_job\" does not exist"
//	POST-FIX (replace -> patched fork): PASSES.
//
// River is migrated into a NON-default schema, and the job is worked through a
// transaction whose search_path doesn't include that schema. The insert (via
// the client) qualifies river_job with the schema, but the pre-fix running-state
// update runs unqualified and can't find the table.
func TestRivertestWorkerCustomSchema(t *testing.T) {
	ctx := context.Background()

	pgc, err := postgres.Run(ctx, "postgres:18-alpine",
		postgres.WithDatabase("river"),
		postgres.WithUsername("postgres"),
		postgres.WithPassword("postgres"),
		testcontainers.WithWaitStrategy(
			wait.ForLog("database system is ready to accept connections").
				WithOccurrence(2).WithStartupTimeout(60*time.Second),
		),
	)
	require.NoError(t, err)
	t.Cleanup(func() { _ = pgc.Terminate(ctx) })

	dsn, err := pgc.ConnectionString(ctx, "sslmode=disable")
	require.NoError(t, err)

	pool, err := pgxpool.New(ctx, dsn)
	require.NoError(t, err)
	t.Cleanup(pool.Close)

	const schema = "custom_schema"

	_, err = pool.Exec(ctx, "CREATE SCHEMA "+schema)
	require.NoError(t, err)
	migrator, err := rivermigrate.New(riverpgxv5.New(pool), &rivermigrate.Config{Schema: schema})
	require.NoError(t, err)
	_, err = migrator.Migrate(ctx, rivermigrate.DirectionUp, nil)
	require.NoError(t, err)

	config := &river.Config{ID: "repro", Schema: schema}
	tx, err := pool.Begin(ctx)
	require.NoError(t, err)
	t.Cleanup(func() { _ = tx.Rollback(ctx) })

	worker := river.WorkFunc(func(ctx context.Context, job *river.Job[Args]) error { return nil })
	tw := rivertest.NewWorker(t, riverpgxv5.New(pool), config, worker)

	res, err := tw.Work(ctx, t, tx, Args{}, nil)
	require.NoError(t, err) // <-- fails pre-fix
	require.Equal(t, river.EventKindJobCompleted, res.EventKind)
}
```

Disclosure: Claude Opus assisted in authoring the fix. Everything's carefully human reviewed, and PR is entirely human authored.
