### PR TITLE
Recover from panicking notifier subscribers

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -180,8 +180,18 @@ func (n *Notifier) deliverNotifications(ctx context.Context) {
 			}()
 
 			for _, notifyFunc := range notifyFuncs {
-				// TODO: panic recovery on delivery attempts
-				notifyFunc(NotificationTopic(notification.Topic), notification.Payload)
+				func() {
+					defer func() {
+						if panicVal := recover(); panicVal != nil {
+							n.Logger.ErrorContext(ctx, n.Name+": Notification delivery panicked",
+								slog.String("panic_val", fmt.Sprintf("%v", panicVal)),
+								slog.String("topic", string(notification.Topic)),
+							)
+						}
+					}()
+
+					notifyFunc(NotificationTopic(notification.Topic), notification.Payload)
+				}()
 			}
 		}
 	}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -185,7 +185,7 @@ func (n *Notifier) deliverNotifications(ctx context.Context) {
 						if panicVal := recover(); panicVal != nil {
 							n.Logger.ErrorContext(ctx, n.Name+": Notification delivery panicked",
 								slog.String("panic_val", fmt.Sprintf("%v", panicVal)),
-								slog.String("topic", string(notification.Topic)),
+								slog.String("topic", notification.Topic),
 							)
 						}
 					}()

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -401,6 +401,53 @@ func TestNotifier(t *testing.T) {
 		requireNoNotification(t, notifyChan2)
 	})
 
+	t.Run("PanicInSubscriberDoesNotBreakDelivery", func(t *testing.T) {
+		t.Parallel()
+
+		notifier := New(riversharedtest.BaseServiceArchetype(t), nil)
+
+		panicChan := make(chan TopicAndPayload, 10)
+		notifyChan := make(chan TopicAndPayload, 10)
+
+		notifier.subscriptions[testTopic1] = []*Subscription{
+			{
+				notifyFunc: func(topic NotificationTopic, payload string) {
+					panicChan <- TopicAndPayload{topic, payload}
+					panic("panic from notify func")
+				},
+				notifier: notifier,
+				topic:    testTopic1,
+			},
+			{
+				notifyFunc: topicAndPayloadNotifyFunc(notifyChan),
+				notifier:   notifier,
+				topic:      testTopic1,
+			},
+		}
+
+		runCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			notifier.deliverNotifications(runCtx)
+		}()
+
+		notifier.notificationBuf <- &riverdriver.Notification{Topic: string(testTopic1), Payload: "msg1"}
+
+		require.Equal(t, TopicAndPayload{testTopic1, "msg1"}, riversharedtest.WaitOrTimeout(t, panicChan))
+		require.Equal(t, TopicAndPayload{testTopic1, "msg1"}, riversharedtest.WaitOrTimeout(t, notifyChan))
+
+		notifier.notificationBuf <- &riverdriver.Notification{Topic: string(testTopic1), Payload: "msg2"}
+
+		require.Equal(t, TopicAndPayload{testTopic1, "msg2"}, riversharedtest.WaitOrTimeout(t, panicChan))
+		require.Equal(t, TopicAndPayload{testTopic1, "msg2"}, riversharedtest.WaitOrTimeout(t, notifyChan))
+
+		cancel()
+		riversharedtest.WaitOrTimeout(t, done)
+	})
+
 	// Stress test meant to suss out any races that there might be in the
 	// subscribe or interrupt loop code.
 	t.Run("MultipleSubscribersStress", func(t *testing.T) {


### PR DESCRIPTION
1. Failure mechanism

Notifier delivers subscriber callbacks from a shared delivery goroutine in `deliverNotifications`. Right now, one panicking callback can take down that goroutine and stop delivery for unrelated subscribers.

2. Semantic change

Wrap each subscriber callback invocation in local panic recovery.

If one subscriber panics, River now logs the panic value and notification topic, then continues delivering to later subscribers and stays alive for future notifications.

3. Why this design

This keeps the fix at the narrowest boundary that owns the risk: the callback fan-out loop.

It does not change the subscription API or the notifier control flow. It only prevents one bad subscriber from killing delivery for everyone else.

4. Testing

Added `PanicInSubscriberDoesNotBreakDelivery` in `internal/notifier/notifier_test.go`.

The test drives `notificationBuf` directly so it stays unit-scoped. It proves that:
- a panicking subscriber still sees the notification up to the panic point,
- another subscriber still receives the same notification,
- later notifications are still delivered after the panic.