### PR TITLE
Use `json_each` to make SQLite single inserts batch inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change SQLite driver operations over to use bulk inserts where possible now that sqlc has better support for `json_each`. [PR #1276](https://github.com/riverqueue/river/pull/1276)
+
 ### Fixed
 
 - Fix `JobCancel` having no effect on running jobs when using a poll-only driver (e.g. `riverdatabasesql`). The `controlActionCancel` event was silently dropped in `fetchAndRunLoop`'s `queueControlCh` handler instead of being forwarded to `maybeCancelJob`. Note: this fix only works within a single process; cross-process cancels in poll-only setups must wait for the next poll cycle. [PR #1245](https://github.com/riverqueue/river/pull/1245).

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql
@@ -189,15 +189,6 @@ WHERE state = 'running'
 ORDER BY id
 LIMIT @max;
 
--- Insert a job.
---
--- This is supposed to be a batch insert, but various limitations of the
--- combined SQLite + sqlc has left me unable to find a way of injecting many
--- arguments en masse (like how we slightly abuse arrays to pull it off for the
--- Postgres drivers), so we loop over many insert operations instead, with the
--- expectation that this may be fixable in the future. Because SQLite targets
--- will often be local and therefore with a very minimal round trip compared to
--- a network, looping over operations is probably okay performance-wise.
 -- name: JobInsertFast :one
 INSERT INTO /* TEMPLATE: schema */river_job(
     id,
@@ -228,6 +219,56 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     CASE WHEN length(cast(@unique_key AS blob)) = 0 THEN NULL ELSE @unique_key END,
     @unique_states
 )
+ON CONFLICT (unique_key)
+    WHERE unique_key IS NOT NULL
+        AND unique_states IS NOT NULL
+        AND CASE state
+                WHEN 'available' THEN unique_states & (1 << 0)
+                WHEN 'cancelled' THEN unique_states & (1 << 1)
+                WHEN 'completed' THEN unique_states & (1 << 2)
+                WHEN 'discarded' THEN unique_states & (1 << 3)
+                WHEN 'pending'   THEN unique_states & (1 << 4)
+                WHEN 'retryable' THEN unique_states & (1 << 5)
+                WHEN 'running'   THEN unique_states & (1 << 6)
+                WHEN 'scheduled' THEN unique_states & (1 << 7)
+                ELSE 0
+            END >= 1
+    -- Something needs to be updated for a row to be returned on a conflict.
+    DO UPDATE SET kind = EXCLUDED.kind
+RETURNING *;
+
+-- name: JobInsertFastMany :many
+INSERT INTO /* TEMPLATE: schema */river_job(
+    id,
+    args,
+    created_at,
+    kind,
+    max_attempts,
+    metadata,
+    priority,
+    queue,
+    scheduled_at,
+    state,
+    tags,
+    unique_key,
+    unique_states
+)
+SELECT
+    cast(json_extract(value, '$.id') AS integer),
+    json(cast(json_extract(value, '$.args') AS blob)),
+    coalesce(cast(json_extract(value, '$.created_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.kind') AS text),
+    cast(json_extract(value, '$.max_attempts') AS integer),
+    json(cast(json_extract(value, '$.metadata') AS blob)),
+    cast(json_extract(value, '$.priority') AS integer),
+    cast(json_extract(value, '$.queue') AS text),
+    coalesce(cast(json_extract(value, '$.scheduled_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.state') AS text),
+    json(cast(json_extract(value, '$.tags') AS blob)),
+    CASE WHEN length(cast(json_extract(value, '$.unique_key') AS text)) = 0 THEN NULL ELSE unhex(cast(json_extract(value, '$.unique_key') AS text)) END,
+    nullif(cast(json_extract(value, '$.unique_states') AS integer), 0)
+FROM json_each(cast(@jobs AS blob))
+WHERE true
 ON CONFLICT (unique_key)
     WHERE unique_key IS NOT NULL
         AND unique_states IS NOT NULL
@@ -290,6 +331,52 @@ ON CONFLICT (unique_key)
             END >= 1
 DO NOTHING;
 
+-- name: JobInsertFastManyNoReturning :execrows
+INSERT INTO /* TEMPLATE: schema */river_job(
+    args,
+    created_at,
+    kind,
+    max_attempts,
+    metadata,
+    priority,
+    queue,
+    scheduled_at,
+    state,
+    tags,
+    unique_key,
+    unique_states
+)
+SELECT
+    json(cast(json_extract(value, '$.args') AS blob)),
+    coalesce(cast(json_extract(value, '$.created_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.kind') AS text),
+    cast(json_extract(value, '$.max_attempts') AS integer),
+    json(cast(json_extract(value, '$.metadata') AS blob)),
+    cast(json_extract(value, '$.priority') AS integer),
+    cast(json_extract(value, '$.queue') AS text),
+    coalesce(cast(json_extract(value, '$.scheduled_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.state') AS text),
+    json(cast(json_extract(value, '$.tags') AS blob)),
+    CASE WHEN length(cast(json_extract(value, '$.unique_key') AS text)) = 0 THEN NULL ELSE unhex(cast(json_extract(value, '$.unique_key') AS text)) END,
+    nullif(cast(json_extract(value, '$.unique_states') AS integer), 0)
+FROM json_each(cast(@jobs AS blob))
+WHERE true
+ON CONFLICT (unique_key)
+    WHERE unique_key IS NOT NULL
+        AND unique_states IS NOT NULL
+        AND CASE state
+                WHEN 'available' THEN unique_states & (1 << 0)
+                WHEN 'cancelled' THEN unique_states & (1 << 1)
+                WHEN 'completed' THEN unique_states & (1 << 2)
+                WHEN 'discarded' THEN unique_states & (1 << 3)
+                WHEN 'pending'   THEN unique_states & (1 << 4)
+                WHEN 'retryable' THEN unique_states & (1 << 5)
+                WHEN 'running'   THEN unique_states & (1 << 6)
+                WHEN 'scheduled' THEN unique_states & (1 << 7)
+                ELSE 0
+            END >= 1
+DO NOTHING;
+
 -- name: JobInsertFull :one
 INSERT INTO /* TEMPLATE: schema */river_job(
     args,
@@ -328,6 +415,47 @@ INSERT INTO /* TEMPLATE: schema */river_job(
     CASE WHEN length(cast(@unique_key AS blob)) = 0 THEN NULL ELSE @unique_key END,
     @unique_states
 ) RETURNING *;
+
+-- name: JobInsertFullMany :many
+INSERT INTO /* TEMPLATE: schema */river_job(
+    args,
+    attempt,
+    attempted_at,
+    attempted_by,
+    created_at,
+    errors,
+    finalized_at,
+    kind,
+    max_attempts,
+    metadata,
+    priority,
+    queue,
+    scheduled_at,
+    state,
+    tags,
+    unique_key,
+    unique_states
+)
+SELECT
+    json(cast(json_extract(value, '$.args') AS blob)),
+    cast(json_extract(value, '$.attempt') AS integer),
+    cast(json_extract(value, '$.attempted_at') AS text),
+    CASE WHEN json_type(value, '$.attempted_by') IS NULL THEN NULL ELSE json(cast(json_extract(value, '$.attempted_by') AS blob)) END,
+    coalesce(cast(json_extract(value, '$.created_at') AS text), datetime('now', 'subsec')),
+    CASE WHEN json_type(value, '$.errors') IS NULL THEN NULL ELSE json(cast(json_extract(value, '$.errors') AS blob)) END,
+    cast(json_extract(value, '$.finalized_at') AS text),
+    cast(json_extract(value, '$.kind') AS text),
+    cast(json_extract(value, '$.max_attempts') AS integer),
+    json(cast(json_extract(value, '$.metadata') AS blob)),
+    cast(json_extract(value, '$.priority') AS integer),
+    cast(json_extract(value, '$.queue') AS text),
+    coalesce(cast(json_extract(value, '$.scheduled_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.state') AS text),
+    json(cast(json_extract(value, '$.tags') AS blob)),
+    CASE WHEN length(cast(json_extract(value, '$.unique_key') AS text)) = 0 THEN NULL ELSE unhex(cast(json_extract(value, '$.unique_key') AS text)) END,
+    nullif(cast(json_extract(value, '$.unique_states') AS integer), 0)
+FROM json_each(cast(@jobs AS blob))
+RETURNING *;
 
 -- name: JobKindList :many
 SELECT DISTINCT kind

--- a/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_job.sql.go
@@ -678,15 +678,6 @@ type JobInsertFastParams struct {
 	UniqueStates *int64
 }
 
-// Insert a job.
-//
-// This is supposed to be a batch insert, but various limitations of the
-// combined SQLite + sqlc has left me unable to find a way of injecting many
-// arguments en masse (like how we slightly abuse arrays to pull it off for the
-// Postgres drivers), so we loop over many insert operations instead, with the
-// expectation that this may be fixable in the future. Because SQLite targets
-// will often be local and therefore with a very minimal round trip compared to
-// a network, looping over operations is probably okay performance-wise.
 func (q *Queries) JobInsertFast(ctx context.Context, db DBTX, arg *JobInsertFastParams) (*RiverJob, error) {
 	row := db.QueryRowContext(ctx, jobInsertFast,
 		arg.ID,
@@ -725,6 +716,154 @@ func (q *Queries) JobInsertFast(ctx context.Context, db DBTX, arg *JobInsertFast
 		&i.UniqueStates,
 	)
 	return &i, err
+}
+
+const jobInsertFastMany = `-- name: JobInsertFastMany :many
+INSERT INTO /* TEMPLATE: schema */river_job(
+    id,
+    args,
+    created_at,
+    kind,
+    max_attempts,
+    metadata,
+    priority,
+    queue,
+    scheduled_at,
+    state,
+    tags,
+    unique_key,
+    unique_states
+)
+SELECT
+    cast(json_extract(value, '$.id') AS integer),
+    json(cast(json_extract(value, '$.args') AS blob)),
+    coalesce(cast(json_extract(value, '$.created_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.kind') AS text),
+    cast(json_extract(value, '$.max_attempts') AS integer),
+    json(cast(json_extract(value, '$.metadata') AS blob)),
+    cast(json_extract(value, '$.priority') AS integer),
+    cast(json_extract(value, '$.queue') AS text),
+    coalesce(cast(json_extract(value, '$.scheduled_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.state') AS text),
+    json(cast(json_extract(value, '$.tags') AS blob)),
+    CASE WHEN length(cast(json_extract(value, '$.unique_key') AS text)) = 0 THEN NULL ELSE unhex(cast(json_extract(value, '$.unique_key') AS text)) END,
+    nullif(cast(json_extract(value, '$.unique_states') AS integer), 0)
+FROM json_each(cast(?1 AS blob))
+WHERE true
+ON CONFLICT (unique_key)
+    WHERE unique_key IS NOT NULL
+        AND unique_states IS NOT NULL
+        AND CASE state
+                WHEN 'available' THEN unique_states & (1 << 0)
+                WHEN 'cancelled' THEN unique_states & (1 << 1)
+                WHEN 'completed' THEN unique_states & (1 << 2)
+                WHEN 'discarded' THEN unique_states & (1 << 3)
+                WHEN 'pending'   THEN unique_states & (1 << 4)
+                WHEN 'retryable' THEN unique_states & (1 << 5)
+                WHEN 'running'   THEN unique_states & (1 << 6)
+                WHEN 'scheduled' THEN unique_states & (1 << 7)
+                ELSE 0
+            END >= 1
+    -- Something needs to be updated for a row to be returned on a conflict.
+    DO UPDATE SET kind = EXCLUDED.kind
+RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+`
+
+func (q *Queries) JobInsertFastMany(ctx context.Context, db DBTX, jobs []byte) ([]*RiverJob, error) {
+	rows, err := db.QueryContext(ctx, jobInsertFastMany, jobs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			&i.AttemptedBy,
+			&i.CreatedAt,
+			&i.Errors,
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			&i.Tags,
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const jobInsertFastManyNoReturning = `-- name: JobInsertFastManyNoReturning :execrows
+INSERT INTO /* TEMPLATE: schema */river_job(
+    args,
+    created_at,
+    kind,
+    max_attempts,
+    metadata,
+    priority,
+    queue,
+    scheduled_at,
+    state,
+    tags,
+    unique_key,
+    unique_states
+)
+SELECT
+    json(cast(json_extract(value, '$.args') AS blob)),
+    coalesce(cast(json_extract(value, '$.created_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.kind') AS text),
+    cast(json_extract(value, '$.max_attempts') AS integer),
+    json(cast(json_extract(value, '$.metadata') AS blob)),
+    cast(json_extract(value, '$.priority') AS integer),
+    cast(json_extract(value, '$.queue') AS text),
+    coalesce(cast(json_extract(value, '$.scheduled_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.state') AS text),
+    json(cast(json_extract(value, '$.tags') AS blob)),
+    CASE WHEN length(cast(json_extract(value, '$.unique_key') AS text)) = 0 THEN NULL ELSE unhex(cast(json_extract(value, '$.unique_key') AS text)) END,
+    nullif(cast(json_extract(value, '$.unique_states') AS integer), 0)
+FROM json_each(cast(?1 AS blob))
+WHERE true
+ON CONFLICT (unique_key)
+    WHERE unique_key IS NOT NULL
+        AND unique_states IS NOT NULL
+        AND CASE state
+                WHEN 'available' THEN unique_states & (1 << 0)
+                WHEN 'cancelled' THEN unique_states & (1 << 1)
+                WHEN 'completed' THEN unique_states & (1 << 2)
+                WHEN 'discarded' THEN unique_states & (1 << 3)
+                WHEN 'pending'   THEN unique_states & (1 << 4)
+                WHEN 'retryable' THEN unique_states & (1 << 5)
+                WHEN 'running'   THEN unique_states & (1 << 6)
+                WHEN 'scheduled' THEN unique_states & (1 << 7)
+                ELSE 0
+            END >= 1
+DO NOTHING
+`
+
+func (q *Queries) JobInsertFastManyNoReturning(ctx context.Context, db DBTX, jobs []byte) (int64, error) {
+	result, err := db.ExecContext(ctx, jobInsertFastManyNoReturning, jobs)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const jobInsertFastNoReturning = `-- name: JobInsertFastNoReturning :execrows
@@ -910,6 +1049,90 @@ func (q *Queries) JobInsertFull(ctx context.Context, db DBTX, arg *JobInsertFull
 		&i.UniqueStates,
 	)
 	return &i, err
+}
+
+const jobInsertFullMany = `-- name: JobInsertFullMany :many
+INSERT INTO /* TEMPLATE: schema */river_job(
+    args,
+    attempt,
+    attempted_at,
+    attempted_by,
+    created_at,
+    errors,
+    finalized_at,
+    kind,
+    max_attempts,
+    metadata,
+    priority,
+    queue,
+    scheduled_at,
+    state,
+    tags,
+    unique_key,
+    unique_states
+)
+SELECT
+    json(cast(json_extract(value, '$.args') AS blob)),
+    cast(json_extract(value, '$.attempt') AS integer),
+    cast(json_extract(value, '$.attempted_at') AS text),
+    CASE WHEN json_type(value, '$.attempted_by') IS NULL THEN NULL ELSE json(cast(json_extract(value, '$.attempted_by') AS blob)) END,
+    coalesce(cast(json_extract(value, '$.created_at') AS text), datetime('now', 'subsec')),
+    CASE WHEN json_type(value, '$.errors') IS NULL THEN NULL ELSE json(cast(json_extract(value, '$.errors') AS blob)) END,
+    cast(json_extract(value, '$.finalized_at') AS text),
+    cast(json_extract(value, '$.kind') AS text),
+    cast(json_extract(value, '$.max_attempts') AS integer),
+    json(cast(json_extract(value, '$.metadata') AS blob)),
+    cast(json_extract(value, '$.priority') AS integer),
+    cast(json_extract(value, '$.queue') AS text),
+    coalesce(cast(json_extract(value, '$.scheduled_at') AS text), datetime('now', 'subsec')),
+    cast(json_extract(value, '$.state') AS text),
+    json(cast(json_extract(value, '$.tags') AS blob)),
+    CASE WHEN length(cast(json_extract(value, '$.unique_key') AS text)) = 0 THEN NULL ELSE unhex(cast(json_extract(value, '$.unique_key') AS text)) END,
+    nullif(cast(json_extract(value, '$.unique_states') AS integer), 0)
+FROM json_each(cast(?1 AS blob))
+RETURNING id, args, attempt, attempted_at, attempted_by, created_at, errors, finalized_at, kind, max_attempts, metadata, priority, queue, state, scheduled_at, tags, unique_key, unique_states
+`
+
+func (q *Queries) JobInsertFullMany(ctx context.Context, db DBTX, jobs []byte) ([]*RiverJob, error) {
+	rows, err := db.QueryContext(ctx, jobInsertFullMany, jobs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverJob
+	for rows.Next() {
+		var i RiverJob
+		if err := rows.Scan(
+			&i.ID,
+			&i.Args,
+			&i.Attempt,
+			&i.AttemptedAt,
+			&i.AttemptedBy,
+			&i.CreatedAt,
+			&i.Errors,
+			&i.FinalizedAt,
+			&i.Kind,
+			&i.MaxAttempts,
+			&i.Metadata,
+			&i.Priority,
+			&i.Queue,
+			&i.State,
+			&i.ScheduledAt,
+			&i.Tags,
+			&i.UniqueKey,
+			&i.UniqueStates,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const jobKindList = `-- name: JobKindList :many

--- a/riverdriver/riversqlite/internal/dbsqlc/river_migration.sql
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_migration.sql
@@ -39,30 +39,24 @@ FROM /* TEMPLATE: schema */river_migration
 WHERE line = @line
 ORDER BY version;
 
--- Insert a migration.
---
--- This is supposed to be a batch insert, but various limitations of the
--- combined SQLite + sqlc has left me unable to find a way of injecting many
--- arguments en masse (like how we slightly abuse arrays to pull it off for the
--- Postgres drivers), so we loop over many insert operations instead, with the
--- expectation that this may be fixable in the future. Because SQLite targets
--- will often be local and therefore with a very minimal round trip compared to
--- a network, looping over operations is probably okay performance-wise.
--- name: RiverMigrationInsert :one
+-- name: RiverMigrationInsertMany :many
 INSERT INTO /* TEMPLATE: schema */river_migration (
     line,
     version
-) VALUES (
+)
+SELECT
     @line,
-    @version
-) RETURNING *;
+    value
+FROM json_each(cast(@versions AS blob))
+RETURNING *;
 
--- name: RiverMigrationInsertAssumingMain :one
+-- name: RiverMigrationInsertManyAssumingMain :many
 INSERT INTO /* TEMPLATE: schema */river_migration (
     version
-) VALUES (
-    @version
 )
+SELECT
+    value
+FROM json_each(cast(@versions AS blob))
 RETURNING
     created_at,
     version;

--- a/riverdriver/riversqlite/internal/dbsqlc/river_migration.sql.go
+++ b/riverdriver/riversqlite/internal/dbsqlc/river_migration.sql.go
@@ -174,56 +174,82 @@ func (q *Queries) RiverMigrationGetByLine(ctx context.Context, db DBTX, line str
 	return items, nil
 }
 
-const riverMigrationInsert = `-- name: RiverMigrationInsert :one
+const riverMigrationInsertMany = `-- name: RiverMigrationInsertMany :many
 INSERT INTO /* TEMPLATE: schema */river_migration (
     line,
     version
-) VALUES (
+)
+SELECT
     ?1,
-    ?2
-) RETURNING line, version, created_at
+    value
+FROM json_each(cast(?2 AS blob))
+RETURNING line, version, created_at
 `
 
-type RiverMigrationInsertParams struct {
-	Line    string
-	Version int64
+type RiverMigrationInsertManyParams struct {
+	Line     string
+	Versions []byte
 }
 
-// Insert a migration.
-//
-// This is supposed to be a batch insert, but various limitations of the
-// combined SQLite + sqlc has left me unable to find a way of injecting many
-// arguments en masse (like how we slightly abuse arrays to pull it off for the
-// Postgres drivers), so we loop over many insert operations instead, with the
-// expectation that this may be fixable in the future. Because SQLite targets
-// will often be local and therefore with a very minimal round trip compared to
-// a network, looping over operations is probably okay performance-wise.
-func (q *Queries) RiverMigrationInsert(ctx context.Context, db DBTX, arg *RiverMigrationInsertParams) (*RiverMigration, error) {
-	row := db.QueryRowContext(ctx, riverMigrationInsert, arg.Line, arg.Version)
-	var i RiverMigration
-	err := row.Scan(&i.Line, &i.Version, &i.CreatedAt)
-	return &i, err
+func (q *Queries) RiverMigrationInsertMany(ctx context.Context, db DBTX, arg *RiverMigrationInsertManyParams) ([]*RiverMigration, error) {
+	rows, err := db.QueryContext(ctx, riverMigrationInsertMany, arg.Line, arg.Versions)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverMigration
+	for rows.Next() {
+		var i RiverMigration
+		if err := rows.Scan(&i.Line, &i.Version, &i.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
-const riverMigrationInsertAssumingMain = `-- name: RiverMigrationInsertAssumingMain :one
+const riverMigrationInsertManyAssumingMain = `-- name: RiverMigrationInsertManyAssumingMain :many
 INSERT INTO /* TEMPLATE: schema */river_migration (
     version
-) VALUES (
-    ?1
 )
+SELECT
+    value
+FROM json_each(cast(?1 AS blob))
 RETURNING
     created_at,
     version
 `
 
-type RiverMigrationInsertAssumingMainRow struct {
+type RiverMigrationInsertManyAssumingMainRow struct {
 	CreatedAt time.Time
 	Version   int64
 }
 
-func (q *Queries) RiverMigrationInsertAssumingMain(ctx context.Context, db DBTX, version int64) (*RiverMigrationInsertAssumingMainRow, error) {
-	row := db.QueryRowContext(ctx, riverMigrationInsertAssumingMain, version)
-	var i RiverMigrationInsertAssumingMainRow
-	err := row.Scan(&i.CreatedAt, &i.Version)
-	return &i, err
+func (q *Queries) RiverMigrationInsertManyAssumingMain(ctx context.Context, db DBTX, versions []byte) ([]*RiverMigrationInsertManyAssumingMainRow, error) {
+	rows, err := db.QueryContext(ctx, riverMigrationInsertManyAssumingMain, versions)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*RiverMigrationInsertManyAssumingMainRow
+	for rows.Next() {
+		var i RiverMigrationInsertManyAssumingMainRow
+		if err := rows.Scan(&i.CreatedAt, &i.Version); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -516,123 +517,47 @@ func (e *Executor) JobGetStuck(ctx context.Context, params *riverdriver.JobGetSt
 }
 
 func (e *Executor) JobInsertFastMany(ctx context.Context, params *riverdriver.JobInsertFastManyParams) ([]*riverdriver.JobInsertFastResult, error) {
-	var (
-		insertRes = make([]*riverdriver.JobInsertFastResult, len(params.Jobs))
+	// We use a special `(xmax != 0)` trick in Postgres to determine whether an
+	// upserted row was inserted or skipped, but as far as I can find, there's no
+	// such trick possible in SQLite. Instead, we roll a random nonce and insert
+	// it to metadata. If the same nonce comes back, we know we really inserted
+	// the row. If not, we're getting an existing row back.
+	uniqueNonce := randutil.Hex(8)
 
-		// We use a special `(xmax != 0)` trick in Postgres to determine whether
-		// an upserted row was inserted or skipped, but as far as I can find,
-		// there's no such trick possible in SQLite. Instead, we roll a random
-		// nonce and insert it to metadata. If the same nonce coes back, we know
-		// we really inserted the row. If not, we're getting an existing row back.
-		uniqueNonce = randutil.Hex(8)
-	)
-
-	if err := dbutil.WithTx(ctx, e, func(ctx context.Context, execTx riverdriver.ExecutorTx) error { // TODO
-		ctx = schemaTemplateParam(ctx, params.Schema)
-		dbtx := templateReplaceWrapper{dbtx: e.driver.UnwrapTx(execTx), replacer: &e.driver.replacer}
-
-		// Should be a batch insert, but that's currently impossible with SQLite/sqlc. https://github.com/sqlc-dev/sqlc/issues/3802
-		for i, params := range params.Jobs {
-			metadata, err := sjson.SetBytes(sliceutil.FirstNonEmpty(params.Metadata, []byte("{}")), rivercommon.MetadataKeyUniqueNonce, uniqueNonce)
-			if err != nil {
-				return err
-			}
-
-			tags, err := json.Marshal(params.Tags)
-			if err != nil {
-				return fmt.Errorf("error marshaling tags: %w", err)
-			}
-
-			var uniqueStates *int64
-			if params.UniqueStates != 0 {
-				uniqueStates = ptrutil.Ptr(int64(params.UniqueStates))
-			}
-
-			internal, err := dbsqlc.New().JobInsertFast(ctx, dbtx, &dbsqlc.JobInsertFastParams{
-				ID:           params.ID,
-				Args:         params.EncodedArgs,
-				CreatedAt:    timeStringNullable(params.CreatedAt),
-				Kind:         params.Kind,
-				MaxAttempts:  int64(params.MaxAttempts),
-				Metadata:     metadata,
-				Priority:     int64(params.Priority),
-				Queue:        params.Queue,
-				ScheduledAt:  timeStringNullable(params.ScheduledAt),
-				State:        string(params.State),
-				Tags:         tags,
-				UniqueKey:    params.UniqueKey,
-				UniqueStates: uniqueStates,
-			})
-			if err != nil {
-				return interpretError(err)
-			}
-
-			job, err := jobRowFromInternal(internal)
-			if err != nil {
-				return err
-			}
-
-			insertRes[i] = &riverdriver.JobInsertFastResult{
-				Job:                      job,
-				UniqueSkippedAsDuplicate: gjson.GetBytes(job.Metadata, rivercommon.MetadataKeyUniqueNonce).Str != uniqueNonce,
-			}
-		}
-
-		return nil
-	}); err != nil {
+	jobsParam, err := sqliteJobInsertFastManyJobsParam(params.Jobs, uniqueNonce)
+	if err != nil {
 		return nil, err
 	}
 
-	return insertRes, nil
+	jobs, err := dbsqlc.New().JobInsertFastMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, jobsParam)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+
+	return sliceutil.MapError(jobs, func(internal *dbsqlc.RiverJob) (*riverdriver.JobInsertFastResult, error) {
+		job, err := jobRowFromInternal(internal)
+		if err != nil {
+			return nil, err
+		}
+
+		return &riverdriver.JobInsertFastResult{
+			Job:                      job,
+			UniqueSkippedAsDuplicate: gjson.GetBytes(job.Metadata, rivercommon.MetadataKeyUniqueNonce).Str != uniqueNonce,
+		}, nil
+	})
 }
 
 func (e *Executor) JobInsertFastManyNoReturning(ctx context.Context, params *riverdriver.JobInsertFastManyParams) (int, error) {
-	var totalRowsAffected int
-
-	if err := dbutil.WithTx(ctx, e, func(ctx context.Context, execTx riverdriver.ExecutorTx) error {
-		ctx = schemaTemplateParam(ctx, params.Schema)
-		dbtx := templateReplaceWrapper{dbtx: e.driver.UnwrapTx(execTx), replacer: &e.driver.replacer}
-
-		// Should be a batch insert, but that's currently impossible with SQLite/sqlc. https://github.com/sqlc-dev/sqlc/issues/3802
-		for _, params := range params.Jobs {
-			tags, err := json.Marshal(params.Tags)
-			if err != nil {
-				// return nil, err
-				return fmt.Errorf("error marshaling tags: %w", err)
-			}
-
-			var uniqueStates *int64
-			if params.UniqueStates != 0 {
-				uniqueStates = ptrutil.Ptr(int64(params.UniqueStates))
-			}
-
-			rowsAffected, err := dbsqlc.New().JobInsertFastNoReturning(ctx, dbtx, &dbsqlc.JobInsertFastNoReturningParams{
-				Args:         params.EncodedArgs,
-				CreatedAt:    timeStringNullable(params.CreatedAt),
-				Kind:         params.Kind,
-				MaxAttempts:  int64(params.MaxAttempts),
-				Metadata:     sliceutil.FirstNonEmpty(params.Metadata, []byte("{}")),
-				Priority:     int64(params.Priority),
-				Queue:        params.Queue,
-				ScheduledAt:  timeStringNullable(params.ScheduledAt),
-				State:        string(params.State),
-				Tags:         tags,
-				UniqueKey:    params.UniqueKey,
-				UniqueStates: uniqueStates,
-			})
-			if err != nil {
-				return interpretError(err)
-			}
-
-			totalRowsAffected += int(rowsAffected)
-		}
-
-		return nil
-	}); err != nil {
+	jobsParam, err := sqliteJobInsertFastManyJobsParam(params.Jobs, "")
+	if err != nil {
 		return 0, err
 	}
 
-	return totalRowsAffected, nil
+	numInserted, err := dbsqlc.New().JobInsertFastManyNoReturning(schemaTemplateParam(ctx, params.Schema), e.dbtx, jobsParam)
+	if err != nil {
+		return 0, interpretError(err)
+	}
+	return int(numInserted), nil
 }
 
 func (e *Executor) JobInsertFull(ctx context.Context, params *riverdriver.JobInsertFullParams) (*rivertype.JobRow, error) {
@@ -690,77 +615,16 @@ func (e *Executor) JobInsertFull(ctx context.Context, params *riverdriver.JobIns
 }
 
 func (e *Executor) JobInsertFullMany(ctx context.Context, params *riverdriver.JobInsertFullManyParams) ([]*rivertype.JobRow, error) {
-	insertRes := make([]*rivertype.JobRow, len(params.Jobs))
-
-	if err := dbutil.WithTx(ctx, e, func(ctx context.Context, execTx riverdriver.ExecutorTx) error {
-		ctx = schemaTemplateParam(ctx, params.Schema)
-		dbtx := templateReplaceWrapper{dbtx: e.driver.UnwrapTx(execTx), replacer: &e.driver.replacer}
-
-		// Should be a batch insert, but that's currently impossible with SQLite/sqlc. https://github.com/sqlc-dev/sqlc/issues/3802
-		for i, jobParams := range params.Jobs {
-			var attemptedBy []byte
-			if jobParams.AttemptedBy != nil {
-				var err error
-				attemptedBy, err = json.Marshal(jobParams.AttemptedBy)
-				if err != nil {
-					return err
-				}
-			}
-
-			var errors []byte
-			if len(jobParams.Errors) > 0 {
-				var err error
-				errors, err = json.Marshal(sliceutil.Map(jobParams.Errors, func(e []byte) json.RawMessage { return json.RawMessage(e) }))
-				if err != nil {
-					return err
-				}
-			}
-
-			tags, err := json.Marshal(jobParams.Tags)
-			if err != nil {
-				return err
-			}
-
-			var uniqueStates *int64
-			if jobParams.UniqueStates != 0 {
-				uniqueStates = ptrutil.Ptr(int64(jobParams.UniqueStates))
-			}
-
-			job, err := dbsqlc.New().JobInsertFull(ctx, dbtx, &dbsqlc.JobInsertFullParams{
-				Attempt:      int64(jobParams.Attempt),
-				AttemptedAt:  timeStringNullable(jobParams.AttemptedAt),
-				AttemptedBy:  attemptedBy,
-				Args:         jobParams.EncodedArgs,
-				CreatedAt:    timeStringNullable(jobParams.CreatedAt),
-				Errors:       errors,
-				FinalizedAt:  timeStringNullable(jobParams.FinalizedAt),
-				Kind:         jobParams.Kind,
-				MaxAttempts:  int64(jobParams.MaxAttempts),
-				Metadata:     sliceutil.FirstNonEmpty(jobParams.Metadata, []byte("{}")),
-				Priority:     int64(jobParams.Priority),
-				Queue:        jobParams.Queue,
-				ScheduledAt:  timeStringNullable(jobParams.ScheduledAt),
-				State:        string(jobParams.State),
-				Tags:         tags,
-				UniqueKey:    jobParams.UniqueKey,
-				UniqueStates: uniqueStates,
-			})
-			if err != nil {
-				return interpretError(err)
-			}
-
-			insertRes[i], err = jobRowFromInternal(job)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}); err != nil {
+	jobsParam, err := sqliteJobInsertFullManyJobsParam(params.Jobs)
+	if err != nil {
 		return nil, err
 	}
 
-	return insertRes, nil
+	jobs, err := dbsqlc.New().JobInsertFullMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, jobsParam)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return sliceutil.MapError(jobs, jobRowFromInternal)
 }
 
 func (e *Executor) JobKindList(ctx context.Context, params *riverdriver.JobKindListParams) ([]string, error) {
@@ -965,7 +829,7 @@ func (e *Executor) JobSetStateIfRunningMany(ctx context.Context, params *riverdr
 		ctx = schemaTemplateParam(ctx, params.Schema)
 		dbtx := templateReplaceWrapper{dbtx: e.driver.UnwrapTx(execTx), replacer: &e.driver.replacer}
 
-		// Should be a batch insert, but that's currently impossible with SQLite/sqlc. https://github.com/sqlc-dev/sqlc/issues/3802
+		// Should be a batch update, but that's currently impossible with SQLite/sqlc. https://github.com/sqlc-dev/sqlc/issues/3802
 		for i := range params.ID {
 			setStateParams := &dbsqlc.JobSetStateIfRunningParams{
 				ID:              params.ID[i],
@@ -1214,59 +1078,38 @@ func (e *Executor) MigrationGetByLine(ctx context.Context, params *riverdriver.M
 }
 
 func (e *Executor) MigrationInsertMany(ctx context.Context, params *riverdriver.MigrationInsertManyParams) ([]*riverdriver.Migration, error) {
-	migrations := make([]*riverdriver.Migration, len(params.Versions))
-
-	if err := dbutil.WithTx(ctx, e, func(ctx context.Context, execTx riverdriver.ExecutorTx) error {
-		dbtx := templateReplaceWrapper{dbtx: e.driver.UnwrapTx(execTx), replacer: &e.driver.replacer}
-
-		// Should be a batch insert, but that's currently impossible with SQLite/sqlc. https://github.com/sqlc-dev/sqlc/issues/3802
-		for i, version := range params.Versions {
-			migration, err := dbsqlc.New().RiverMigrationInsert(schemaTemplateParam(ctx, params.Schema), dbtx, &dbsqlc.RiverMigrationInsertParams{
-				Line:    params.Line,
-				Version: int64(version),
-			})
-			if err != nil {
-				return interpretError(err)
-			}
-
-			migrations[i] = migrationFromInternal(migration)
-		}
-
-		return nil
-	}); err != nil {
+	versions, err := json.Marshal(params.Versions)
+	if err != nil {
 		return nil, err
 	}
 
-	return migrations, nil
+	migrations, err := dbsqlc.New().RiverMigrationInsertMany(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.RiverMigrationInsertManyParams{
+		Line:     params.Line,
+		Versions: versions,
+	})
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return sliceutil.Map(migrations, migrationFromInternal), nil
 }
 
 func (e *Executor) MigrationInsertManyAssumingMain(ctx context.Context, params *riverdriver.MigrationInsertManyAssumingMainParams) ([]*riverdriver.Migration, error) {
-	migrations := make([]*riverdriver.Migration, len(params.Versions))
-
-	if err := dbutil.WithTx(ctx, e, func(ctx context.Context, execTx riverdriver.ExecutorTx) error {
-		ctx = schemaTemplateParam(ctx, params.Schema)
-		dbtx := templateReplaceWrapper{dbtx: e.driver.UnwrapTx(execTx), replacer: &e.driver.replacer}
-
-		// Should be a batch insert, but that's currently impossible with SQLite/sqlc. https://github.com/sqlc-dev/sqlc/issues/3802
-		for i, version := range params.Versions {
-			internal, err := dbsqlc.New().RiverMigrationInsertAssumingMain(ctx, dbtx, int64(version))
-			if err != nil {
-				return interpretError(err)
-			}
-
-			migrations[i] = &riverdriver.Migration{
-				CreatedAt: internal.CreatedAt.UTC(),
-				Line:      riverdriver.MigrationLineMain,
-				Version:   int(internal.Version),
-			}
-		}
-
-		return nil
-	}); err != nil {
+	versions, err := json.Marshal(params.Versions)
+	if err != nil {
 		return nil, err
 	}
 
-	return migrations, nil
+	migrations, err := dbsqlc.New().RiverMigrationInsertManyAssumingMain(schemaTemplateParam(ctx, params.Schema), e.dbtx, versions)
+	if err != nil {
+		return nil, interpretError(err)
+	}
+	return sliceutil.Map(migrations, func(internal *dbsqlc.RiverMigrationInsertManyAssumingMainRow) *riverdriver.Migration {
+		return &riverdriver.Migration{
+			CreatedAt: internal.CreatedAt.UTC(),
+			Line:      riverdriver.MigrationLineMain,
+			Version:   int(internal.Version),
+		}
+	}), nil
 }
 
 func (e *Executor) NotifyMany(ctx context.Context, params *riverdriver.NotifyManyParams) error {
@@ -1594,6 +1437,95 @@ func (w templateReplaceWrapper) QueryRowContext(ctx context.Context, sql string,
 
 func durationAsString(duration time.Duration) string {
 	return strconv.FormatFloat(duration.Seconds(), 'f', 3, 64) + " seconds"
+}
+
+func sqliteJobInsertFastManyJobsParam(jobs []*riverdriver.JobInsertFastParams, uniqueNonce string) ([]byte, error) {
+	jobsParam := make([]map[string]any, len(jobs))
+
+	for i, job := range jobs {
+		metadata := sliceutil.FirstNonEmpty(job.Metadata, []byte("{}"))
+		if uniqueNonce != "" {
+			var err error
+			metadata, err = sjson.SetBytes(metadata, rivercommon.MetadataKeyUniqueNonce, uniqueNonce)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		tags, err := json.Marshal(job.Tags)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling tags: %w", err)
+		}
+
+		jobsParam[i] = map[string]any{
+			"args":          json.RawMessage(job.EncodedArgs),
+			"created_at":    timeStringNullable(job.CreatedAt),
+			"id":            job.ID,
+			"kind":          job.Kind,
+			"max_attempts":  int64(job.MaxAttempts),
+			"metadata":      json.RawMessage(metadata),
+			"priority":      int64(job.Priority),
+			"queue":         job.Queue,
+			"scheduled_at":  timeStringNullable(job.ScheduledAt),
+			"state":         string(job.State),
+			"tags":          json.RawMessage(tags),
+			"unique_key":    hex.EncodeToString(job.UniqueKey),
+			"unique_states": int64(job.UniqueStates),
+		}
+	}
+
+	return json.Marshal(jobsParam)
+}
+
+func sqliteJobInsertFullManyJobsParam(jobs []*riverdriver.JobInsertFullParams) ([]byte, error) {
+	jobsParam := make([]map[string]any, len(jobs))
+
+	for i, job := range jobs {
+		var attemptedBy json.RawMessage
+		if job.AttemptedBy != nil {
+			attemptedByBytes, err := json.Marshal(job.AttemptedBy)
+			if err != nil {
+				return nil, err
+			}
+			attemptedBy = attemptedByBytes
+		}
+
+		var errors json.RawMessage
+		if len(job.Errors) > 0 {
+			errorsBytes, err := json.Marshal(sliceutil.Map(job.Errors, func(e []byte) json.RawMessage { return json.RawMessage(e) }))
+			if err != nil {
+				return nil, err
+			}
+			errors = errorsBytes
+		}
+
+		tags, err := json.Marshal(job.Tags)
+		if err != nil {
+			return nil, err
+		}
+
+		jobsParam[i] = map[string]any{
+			"args":          json.RawMessage(job.EncodedArgs),
+			"attempt":       int64(job.Attempt),
+			"attempted_at":  timeStringNullable(job.AttemptedAt),
+			"attempted_by":  attemptedBy,
+			"created_at":    timeStringNullable(job.CreatedAt),
+			"errors":        errors,
+			"finalized_at":  timeStringNullable(job.FinalizedAt),
+			"kind":          job.Kind,
+			"max_attempts":  int64(job.MaxAttempts),
+			"metadata":      json.RawMessage(sliceutil.FirstNonEmpty(job.Metadata, []byte("{}"))),
+			"priority":      int64(job.Priority),
+			"queue":         job.Queue,
+			"scheduled_at":  timeStringNullable(job.ScheduledAt),
+			"state":         string(job.State),
+			"tags":          json.RawMessage(tags),
+			"unique_key":    hex.EncodeToString(job.UniqueKey),
+			"unique_states": int64(job.UniqueStates),
+		}
+	}
+
+	return json.Marshal(jobsParam)
 }
 
 func jobRowFromInternal(internal *dbsqlc.RiverJob) (*rivertype.JobRow, error) {


### PR DESCRIPTION
Back when I was first implementing SQLite, the sqlc support was so
catastrophically bad that many, many basic utilities just could not be
used in queries. I tried like a half dozen different ways, but couldn't
find anything that was both supported by SQLite and sqlc, so I ended up
making a number of batch inserts into single inserts that get looped
over in the driver. This isn't as bad in SQLite because usually your
inserting to a local database (i.e. no network connections), but it's
still not ideal in that it's probably somewhat slower, and deviates from
the Postgres implementation.

Sqlc's made some SQLite improvements since then, and I found that I'm
now able to get a batch insert working `json_each` and `json_extract`.

Here, go through the existing SQLite driver function and update things
to use batch inserts wherever possible. Fixed operations:

* `JobInsertFastMany`
* `JobInsertFastManyNoReturning`
* `JobInsertFullMany`
* `MigrationInsertMany`
* `MigrationInsertManyAssumingMain`