### PR TITLE
Fix small lint problem in `metadata_test.go`

### DIFF
--- a/metadata_test.go
+++ b/metadata_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/riverqueue/river/internal/jobexecutor"
 	"github.com/stretchr/testify/require"
+
+	"github.com/riverqueue/river/internal/jobexecutor"
 )
 
 func TestMetadataSet(t *testing.T) {


### PR DESCRIPTION
I'm not sure how this snuck through CI originally, but it keeps showing
up in all my branches. I figure fix it once so we won't have to deal
with it everywhere else.