### PR TITLE
Fix insert-only clients link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,8 +121,8 @@ if err := riverClient.Stop(ctx); err != nil {
 }
 ```
 
-[Insert-only clients](/docs/insert-only-clients) will insert jobs, but not work
-them, and don't need to be started or stopped.
+[Insert-only clients](https://riverqueue.com/docs/insert-only-clients) will
+insert jobs, but not work them, and don't need to be started or stopped.
 
 ## Inserting jobs
 


### PR DESCRIPTION
This was meant to go to the riverqueue.com website as opposed to be
relative link in GitHub. As pointed out here [1].

[1] https://github.com/riverqueue/river/pull/1237#issuecomment-4911740258