### PR TITLE
Promote `JobGetStuck` into the pilot

### DIFF
--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -194,7 +194,8 @@ func (s *JobRescuer) runOnce(ctx context.Context) (*rescuerRunOnceResult, error)
 	res := &rescuerRunOnceResult{}
 
 	for {
-		stuckJobs, err := s.getStuckJobs(ctx)
+		stuckHorizon := time.Now().Add(-s.Config.RescueAfter)
+		stuckJobs, err := s.getStuckJobs(ctx, stuckHorizon)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				s.reducedBatchSizeBreaker.Trip()
@@ -210,12 +211,13 @@ func (s *JobRescuer) runOnce(ctx context.Context) (*rescuerRunOnceResult, error)
 		now := time.Now().UTC()
 
 		rescueManyParams := riverdriver.JobRescueManyParams{
-			ID:          make([]int64, 0, len(stuckJobs)),
-			Error:       make([][]byte, 0, len(stuckJobs)),
-			FinalizedAt: make([]*time.Time, 0, len(stuckJobs)),
-			ScheduledAt: make([]time.Time, 0, len(stuckJobs)),
-			Schema:      s.Config.Schema,
-			State:       make([]string, 0, len(stuckJobs)),
+			ID:           make([]int64, 0, len(stuckJobs)),
+			Error:        make([][]byte, 0, len(stuckJobs)),
+			FinalizedAt:  make([]*time.Time, 0, len(stuckJobs)),
+			ScheduledAt:  make([]time.Time, 0, len(stuckJobs)),
+			Schema:       s.Config.Schema,
+			State:        make([]string, 0, len(stuckJobs)),
+			StuckHorizon: stuckHorizon,
 		}
 
 		for _, job := range stuckJobs {
@@ -285,11 +287,9 @@ func (s *JobRescuer) runOnce(ctx context.Context) (*rescuerRunOnceResult, error)
 	return res, nil
 }
 
-func (s *JobRescuer) getStuckJobs(ctx context.Context) ([]*rivertype.JobRow, error) {
+func (s *JobRescuer) getStuckJobs(ctx context.Context, stuckHorizon time.Time) ([]*rivertype.JobRow, error) {
 	ctx, cancelFunc := context.WithTimeout(ctx, riversharedmaintenance.TimeoutDefault)
 	defer cancelFunc()
-
-	stuckHorizon := time.Now().Add(-s.Config.RescueAfter)
 
 	return s.Config.Pilot.JobGetStuck(ctx, s.exec, &riverdriver.JobGetStuckParams{
 		Max:          s.batchSize(),

--- a/internal/maintenance/job_rescuer.go
+++ b/internal/maintenance/job_rescuer.go
@@ -291,7 +291,7 @@ func (s *JobRescuer) getStuckJobs(ctx context.Context) ([]*rivertype.JobRow, err
 
 	stuckHorizon := time.Now().Add(-s.Config.RescueAfter)
 
-	return s.exec.JobGetStuck(ctx, &riverdriver.JobGetStuckParams{
+	return s.Config.Pilot.JobGetStuck(ctx, s.exec, &riverdriver.JobGetStuckParams{
 		Max:          s.batchSize(),
 		Schema:       s.Config.Schema,
 		StuckHorizon: stuckHorizon,

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -59,16 +59,24 @@ func (p *SimpleClientRetryPolicy) NextRetry(job *rivertype.JobRow) time.Time {
 	return job.AttemptedAt.Add(timeutil.SecondsAsDuration(retrySeconds))
 }
 
-type jobRescueManyPilotSpy struct {
+type jobRescuerPilotSpy struct {
 	riverpilot.StandardPilot
 
-	calls  atomic.Int64
-	params *riverdriver.JobRescueManyParams
+	jobGetStuckCalls    atomic.Int64
+	jobGetStuckParams   *riverdriver.JobGetStuckParams
+	jobRescueManyCalls  atomic.Int64
+	jobRescueManyParams *riverdriver.JobRescueManyParams
 }
 
-func (p *jobRescueManyPilotSpy) JobRescueMany(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobRescueManyParams) (*struct{}, error) {
-	p.calls.Add(1)
-	p.params = params
+func (p *jobRescuerPilotSpy) JobGetStuck(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobGetStuckParams) ([]*rivertype.JobRow, error) {
+	p.jobGetStuckCalls.Add(1)
+	p.jobGetStuckParams = params
+	return p.StandardPilot.JobGetStuck(ctx, exec, params)
+}
+
+func (p *jobRescuerPilotSpy) JobRescueMany(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobRescueManyParams) (*struct{}, error) {
+	p.jobRescueManyCalls.Add(1)
+	p.jobRescueManyParams = params
 	return p.StandardPilot.JobRescueMany(ctx, exec, params)
 }
 
@@ -328,11 +336,11 @@ func TestJobRescuer(t *testing.T) {
 		riversharedtest.WaitOrTimeout(t, stopped)
 	})
 
-	t.Run("UsesPilotJobRescueMany", func(t *testing.T) {
+	t.Run("UsesPilot", func(t *testing.T) {
 		t.Parallel()
 
 		rescuer, bundle := setup(t)
-		pilot := &jobRescueManyPilotSpy{}
+		pilot := &jobRescuerPilotSpy{}
 		rescuer.Config.Pilot = pilot
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
@@ -340,8 +348,10 @@ func TestJobRescuer(t *testing.T) {
 		_, err := rescuer.runOnce(ctx)
 		require.NoError(t, err)
 
-		require.Equal(t, int64(1), pilot.calls.Load())
-		require.Equal(t, []int64{job.ID}, pilot.params.ID)
+		require.Equal(t, int64(1), pilot.jobGetStuckCalls.Load())
+		require.Equal(t, rescuer.Config.Default, pilot.jobGetStuckParams.Max)
+		require.Equal(t, int64(1), pilot.jobRescueManyCalls.Load())
+		require.Equal(t, []int64{job.ID}, pilot.jobRescueManyParams.ID)
 	})
 
 	t.Run("CanRunMultipleTimes", func(t *testing.T) {

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -352,6 +352,7 @@ func TestJobRescuer(t *testing.T) {
 		require.Equal(t, rescuer.Config.Default, pilot.jobGetStuckParams.Max)
 		require.Equal(t, int64(1), pilot.jobRescueManyCalls.Load())
 		require.Equal(t, []int64{job.ID}, pilot.jobRescueManyParams.ID)
+		require.Equal(t, pilot.jobGetStuckParams.StuckHorizon, pilot.jobRescueManyParams.StuckHorizon)
 	})
 
 	t.Run("CanRunMultipleTimes", func(t *testing.T) {

--- a/riverdriver/river_driver_interface.go
+++ b/riverdriver/river_driver_interface.go
@@ -516,12 +516,13 @@ type JobListParams struct {
 }
 
 type JobRescueManyParams struct {
-	ID          []int64
-	Error       [][]byte
-	FinalizedAt []*time.Time
-	ScheduledAt []time.Time
-	Schema      string
-	State       []string
+	ID           []int64
+	Error        [][]byte
+	FinalizedAt  []*time.Time
+	ScheduledAt  []time.Time
+	Schema       string
+	State        []string
+	StuckHorizon time.Time
 }
 
 type JobRetryParams struct {

--- a/rivershared/riverpilot/pilot.go
+++ b/rivershared/riverpilot/pilot.go
@@ -35,6 +35,8 @@ type Pilot interface {
 		params *riverdriver.JobGetAvailableParams,
 	) ([]*rivertype.JobRow, error)
 
+	JobGetStuck(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobGetStuckParams) ([]*rivertype.JobRow, error)
+
 	JobInsertMany(
 		ctx context.Context,
 		exec riverdriver.Executor,

--- a/rivershared/riverpilot/standard_pilot.go
+++ b/rivershared/riverpilot/standard_pilot.go
@@ -27,6 +27,10 @@ func (p *StandardPilot) JobGetAvailable(ctx context.Context, exec riverdriver.Ex
 	return exec.JobGetAvailable(ctx, params)
 }
 
+func (p *StandardPilot) JobGetStuck(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobGetStuckParams) ([]*rivertype.JobRow, error) {
+	return exec.JobGetStuck(ctx, params)
+}
+
 func (p *StandardPilot) JobCancel(ctx context.Context, exec riverdriver.Executor, params *riverdriver.JobCancelParams) (*rivertype.JobRow, error) {
 	return exec.JobCancel(ctx, params)
 }


### PR DESCRIPTION
While fixing up some bugs in the active rescue feature, I found that we
need to have slightly divergent variations of `JobGetStuck` for when the
rescuer is using the feature versus not.

It's possible to implement the variation entirely on the pro executor by
overriding `JobGetStuck` there, but doing so makes the code more
roundabout because you need to fetch an extra parameter off the pro
pilot. Things become more direct by instead making `JobGetStuck` a pilot
function and having two separate implementations, and this is also more
conventional elsewhere too.