### PR TITLE
Update producer keep alive interval to 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added `Config.Plugins` for extensions that should be installed as both hooks and middleware. `Config.Hooks` and `Config.Middleware` remain available for hook-only and middleware-only registration. [PR #1284](https://github.com/riverqueue/river/pull/1284).
+- Reduce producer keep alive interval from 1 minute to 30 seconds. [PR #1319](https://github.com/riverqueue/river/pull/1319).
 
 ### Fixed
 

--- a/producer.go
+++ b/producer.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	producerReportIntervalDefault = time.Minute
+	producerReportIntervalDefault = 30 * time.Second
 	queuePollIntervalDefault      = 2 * time.Second
 	queueReportIntervalDefault    = 10 * time.Minute
 )


### PR DESCRIPTION
Halve the producer keep alive interval from 1 minute to 30 seconds. This
is still a long enough duration that it shouldn't significantly impact
database health in any way, but since producers are reporting a little
more often, makes it a bit less likely that we accidentally rescue a
running job with the active job rescue feature.