### PR TITLE
A couple tweaks to `HookMetricEmit` documentation

### DIFF
--- a/hook_defaults_funcs.go
+++ b/hook_defaults_funcs.go
@@ -29,6 +29,11 @@ func (f HookInsertBeginFunc) IsPlugin() bool { return true }
 
 // HookMetricEmitFunc is a convenience helper for implementing
 // rivertype.HookMetricEmit using a simple function instead of a struct.
+//
+// Notably, this function is invoked each time River emits a metric. Metrics are
+// emitted in very hot paths like job fetching, and should therefore not block
+// on network I/O or anything else, and should usually pass metrics through to
+// an asynchronous instrumentation package like OpenTelemetry.
 type HookMetricEmitFunc func(ctx context.Context, params *rivertype.HookMetricEmitParams)
 
 func (f HookMetricEmitFunc) IsHook() bool { return true }

--- a/rivertype/river_type.go
+++ b/rivertype/river_type.go
@@ -354,8 +354,8 @@ type HookInsertBegin interface {
 type HookMetricEmit interface {
 	Hook
 
-	// MetricEmit is invoked each time River emits a metric. This is invoked in
-	// very hot paths like job fetching, and should therefore not block on
+	// MetricEmit is invoked each time River emits a metric. Metrics are emitted
+	// in very hot paths like job fetching, and should therefore not block on
 	// network I/O or anything else, and should usually pass metrics through to
 	// an asynchronous instrumentation package like OpenTelemetry.
 	MetricEmit(ctx context.Context, params *HookMetricEmitParams)


### PR DESCRIPTION
A couple minor tweaks to `HookMetricEmit` documentation:

* Noticed we were previously reusing the word "invoked" twice in quick
  succession. Reworded to read better.

* I copied some of the docs to `HookMetricEmitFunc`. The note about how
  stats are emitted in the hot path so stats should be consumed async is
  quite important, so worth repeating.