### PR TITLE
Don't allow `testsignal` to pick up non-stdlib dependencies

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,6 +52,28 @@ linters:
             - desc: Don't use `riverinternaltest` package outside of test environments.
               pkg: github.com/riverqueue/river/internal/riverinternaltest
 
+        # The next two blocks have the same intent: don't allow testsignal,
+        # which is used in non-test code, to have non-stdlib dependencies.
+        # Previously, we ran into a problem where it was accidentally importing
+        # riversharedtest, which was importing Goleak, Testify, YAML (through
+        # Testify), etc. which added 10 kB overhead to all binaries built with
+        # River. testsignal does use testutil, so the second block makes sure
+        # that testutil has no stdlib dependencies so that testsignal doesn't
+        # pick one up transitively.
+        testsignal-no-test-deps:
+          files:
+            - "**/testsignal/*.go"
+            - "!$test"
+          allow:
+            - $gostd
+            - "github.com/riverqueue/river/rivershared/util/testutil$"
+        testutil-no-test-deps:
+          files:
+            - "**/util/testutil/*.go"
+            - "!$test"
+          allow:
+            - $gostd
+
     forbidigo:
       forbid:
         - msg: Use `require` variants instead.


### PR DESCRIPTION
This one's aimed at producing a more permanent structural fix for #1342
by keeping an eye out for the same problematic condition using the
depguard lint. As a summary of the problem corrected by #1342:

* We use the `testsignal` package in all kinds of non-test code, so
  packages including River always build against it.

* `testsignal` was importing `riversharedtest`, which imports Testify,
  Goleak, YAML (through Testify).

* This was causing all packages built against River to pick up an extra
  ~10 kB worth of dependencies in their production builds, which is bad.

Here, add some new rules for depguard:

* Don't allow test packages like Goleak or Testify to be imported by any
  non-test Go files. We make an exception for internal test support
  packages like `riverdbtest` and `riverdrivertest`.

* Don't allow `testsignal` to have any dependencies beyond stdlib and
  `testutil`.

* Don't allow `testutil` to have any non-stdlib dependencies. This rule
  is so that `testsignal` doesn't pick up unexpected dependencies
  transitively through `testutil`.