### PR TITLE
Periodic job next_run_at advances on insert failure — missing return after error log

### DIFF
--- a/internal/maintenance/periodic_job_enqueuer.go
+++ b/internal/maintenance/periodic_job_enqueuer.go
@@ -537,6 +537,7 @@ func (s *PeriodicJobEnqueuer) insertBatch(ctx context.Context, insertParamsMany 
 		if _, err := s.Config.Insert(ctx, tx, insertParamsMany); err != nil {
 			s.Logger.ErrorContext(ctx, s.Name+": Error inserting periodic jobs",
 				"error", err.Error(), "num_jobs", len(insertParamsMany))
+			return
 		}
 	}
 


### PR DESCRIPTION
Add `return` after insert-error log in `insertBatch` to prevent `PeriodicJobUpsertMany` from advancing `next_run_at` when job insertion fails

Found via automated repo scanning, fix written and reviewed before opening.
