### PR TITLE
Fix SQLite timestamp millisecond formatting to always include 3 digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jobs that didn't finish in time organically while a client was stopping and had to have their context cancelled no longer have this cancellation counted as an error. `attempt` is reset to the number it was before the job started working, `errors` is left unchanged, and `state` is made `available` so jobs are eligible to be retried immediately. [PR #1290](https://github.com/riverqueue/river/pull/1290)
 
+### Fixed
+
+- Write timestamps in SQLite to always include three digits after the second like `.000`. Previously, they may have been truncated down to just `.0` in the case of trailing zeroes. [PR #1349](https://github.com/riverqueue/river/pull/1349)
+
 ## [0.43.0] - 2026-08-05
 
 ### Added

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -1717,7 +1717,7 @@ func timeString(t time.Time) string {
 	// looking more common formats like RFC3339). They'll store fine, produce no
 	// warnings, and then just won't compare properly against built-ins, causing
 	// everything to fail in non-obvious ways.
-	const sqliteFormat = "2006-01-02 15:04:05.999"
+	const sqliteFormat = "2006-01-02 15:04:05.000"
 
 	return t.UTC().Round(time.Millisecond).Format(sqliteFormat)
 }

--- a/riverdriver/riversqlite/river_sqlite_driver_test.go
+++ b/riverdriver/riversqlite/river_sqlite_driver_test.go
@@ -36,6 +36,7 @@ func TestInterpretError(t *testing.T) {
 func TestTimeString(t *testing.T) {
 	t.Parallel()
 
+	require.Equal(t, "2025-04-30 13:26:39.100", timeString(time.Date(2025, 4, 30, 13, 26, 39, 100000000, time.UTC)))
 	require.Equal(t, "2025-04-30 13:26:39.123", timeString(time.Date(2025, 4, 30, 13, 26, 39, 123456789, time.UTC)))
 	require.Equal(t, "2025-04-30 13:26:39.124", timeString(time.Date(2025, 4, 30, 13, 26, 39, 123800000, time.UTC))) // test rounding
 }
@@ -44,6 +45,7 @@ func TestTimeStringNullable(t *testing.T) {
 	t.Parallel()
 
 	require.Nil(t, timeStringNullable(nil))
+	require.Equal(t, "2025-04-30 13:26:39.100", *timeStringNullable(ptrutil.Ptr(time.Date(2025, 4, 30, 13, 26, 39, 100000000, time.UTC))))
 	require.Equal(t, "2025-04-30 13:26:39.123", *timeStringNullable(ptrutil.Ptr(time.Date(2025, 4, 30, 13, 26, 39, 123456789, time.UTC))))
 	require.Equal(t, "2025-04-30 13:26:39.124", *timeStringNullable(ptrutil.Ptr(time.Date(2025, 4, 30, 13, 26, 39, 123800000, time.UTC)))) // test rounding
 }


### PR DESCRIPTION
Use a .000 Go time layout so SQLite timestamps always contain exactly
three fractional digits. This matches `datetime('now', 'subsec')` and
prevents equal instants from being represented differently as .1 and
.100.

In Go, time layouts work like this:

- .999 omits trailing zeros, producing values like .1
- .000 always emits three digits, producing .100

This was always a preexisting problem, but Codex happened to catch it
while implementing SQLite support in River Pro, and we may as well fix
it here too.