### PR TITLE
Have SQLite driver always return non-null errors to match Postgres

### DIFF
--- a/riverdriver/riverdrivertest/job_insert.go
+++ b/riverdriver/riverdrivertest/job_insert.go
@@ -602,6 +602,7 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 			require.Nil(t, job.AttemptedAt)
 			require.WithinDuration(t, time.Now().UTC(), job.CreatedAt, 2*time.Second)
 			require.JSONEq(t, `{"encoded": "args"}`, string(job.EncodedArgs))
+			require.NotNil(t, job.Errors)
 			require.Empty(t, job.Errors)
 			require.Nil(t, job.FinalizedAt)
 			require.Equal(t, "test_kind", job.Kind)

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -1622,7 +1622,7 @@ func jobRowFromInternal(internal *dbsqlc.RiverJob) (*rivertype.JobRow, error) {
 		}
 	}
 
-	var errors []rivertype.AttemptError
+	errors := make([]rivertype.AttemptError, 0)
 	if internal.Errors != nil {
 		if err := json.Unmarshal(internal.Errors, &errors); err != nil {
 			return nil, fmt.Errorf("error unmarshaling `errors`: %w", err)


### PR DESCRIPTION
This one's related to [1]. Have the SQLite driver always return a
non-null errors property to match the Postgres behavior.

[1] https://github.com/riverqueue/riverui/pull/657#discussion_r3822027754