### PR TITLE
Upgrade to Go 1.27 + golangci-lint 2.13.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.26"
+          - "1.27"
         postgres-version: [17]
       fail-fast: false
     timeout-minutes: 5
@@ -75,21 +75,21 @@ jobs:
       matrix:
         include:
           # Run the latest Go version against all supported Postgres versions:
-          - go-version: "1.26"
+          - go-version: "1.27"
             postgres-version: 18
-          - go-version: "1.26"
+          - go-version: "1.27"
             postgres-version: 17
-          - go-version: "1.26"
+          - go-version: "1.27"
             postgres-version: 16
-          - go-version: "1.26"
+          - go-version: "1.27"
             postgres-version: 15
-          - go-version: "1.26"
+          - go-version: "1.27"
             postgres-version: 14
 
           # Also run the previous Go version (the Go version previous to current
           # is the only other officially supported Go version) against the
           # latest Postgres version:
-          - go-version: "1.25"
+          - go-version: "1.26"
             postgres-version: 18
       fail-fast: false
     timeout-minutes: 5
@@ -299,7 +299,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     env:
-      GOLANGCI_LINT_VERSION: v2.12.2
+      GOLANGCI_LINT_VERSION: v2.13.1
     permissions:
       contents: read
       # allow read access to pull request. Use with `only-new-issues` option.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters:
 
     # disabled because we're not compliant, but which we should think about
     - exhaustruct # checks that properties in structs are exhaustively defined; may be a good idea
+    - exhaustruct_v5 # they actually did another one
     - testpackage # requires tests in test packages like `river_test`
 
     # disabled because it's deprecated, and `default: all` already enables its
@@ -91,6 +92,13 @@ linters:
     gosec:
       excludes:
         - G404 # use of non-crypto random; overly broad for our use case
+
+    modernize:
+      disable:
+        # Keep the Go 1.26 upgrade focused; apply its modernizations separately.
+        - errorsastype
+        - newexpr
+        - stditerators
 
     revive:
       rules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade supported Go versions to 1.26 and 1.27. [PR #1356](https://github.com/riverqueue/river/pull/1356).
+
 ## [0.44.1] - 2026-08-21
 
 ### Fixed

--- a/cmd/river/go.mod
+++ b/cmd/river/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/cmd/river
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/jackc/pgerrcode v0.0.0-20240316143900-6e2875d9b438

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 use (
 	.

--- a/riverdriver/go.mod
+++ b/riverdriver/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/riverqueue/river/rivertype v0.44.1

--- a/riverdriver/riverdatabasesql/go.mod
+++ b/riverdriver/riverdatabasesql/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riverdatabasesql
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0

--- a/riverdriver/riverdatabasesql/river_database_sql_driver.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver.go
@@ -65,6 +65,7 @@ func (d *Driver) GetListener(params *riverdriver.GetListenenerParams) riverdrive
 }
 
 func (d *Driver) GetMigrationDefaultLines() []string { return []string{riverdriver.MigrationLineMain} }
+
 func (d *Driver) GetMigrationFS(line string) fs.FS {
 	if line == riverdriver.MigrationLineMain {
 		return migrationFS

--- a/riverdriver/riverdrivertest/go.mod
+++ b/riverdriver/riverdrivertest/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riverdrivertest
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/riverdriver/riverdrivertest/queue.go
+++ b/riverdriver/riverdrivertest/queue.go
@@ -361,14 +361,14 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 			})
 			require.NoError(t, err)
 			require.NotNil(t, queue1Fetched.PausedAt)
-			require.WithinDuration(t, now, *(queue1Fetched.PausedAt), 500*time.Millisecond)
+			require.WithinDuration(t, now, *queue1Fetched.PausedAt, 500*time.Millisecond)
 
 			queue2Fetched, err := exec.QueueGet(ctx, &riverdriver.QueueGetParams{
 				Name: queue2.Name,
 			})
 			require.NoError(t, err)
 			require.NotNil(t, queue2Fetched.PausedAt)
-			require.WithinDuration(t, now, *(queue2Fetched.PausedAt), 500*time.Millisecond)
+			require.WithinDuration(t, now, *queue2Fetched.PausedAt, 500*time.Millisecond)
 		})
 
 		t.Run("AllQueuesNoQueues", func(t *testing.T) {

--- a/riverdriver/riverpgxv5/go.mod
+++ b/riverdriver/riverpgxv5/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riverpgxv5
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0

--- a/riverdriver/riverpgxv5/river_pgx_v5_driver.go
+++ b/riverdriver/riverpgxv5/river_pgx_v5_driver.go
@@ -75,6 +75,7 @@ func (d *Driver) GetListener(params *riverdriver.GetListenenerParams) riverdrive
 }
 
 func (d *Driver) GetMigrationDefaultLines() []string { return []string{riverdriver.MigrationLineMain} }
+
 func (d *Driver) GetMigrationFS(line string) fs.FS {
 	if line == riverdriver.MigrationLineMain {
 		return migrationFS

--- a/riverdriver/riversqlite/go.mod
+++ b/riverdriver/riversqlite/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/riverdriver/riversqlite
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/riverqueue/river v0.44.1

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -94,6 +94,7 @@ func (d *Driver) GetListener(params *riverdriver.GetListenenerParams) riverdrive
 }
 
 func (d *Driver) GetMigrationDefaultLines() []string { return []string{riverdriver.MigrationLineMain} }
+
 func (d *Driver) GetMigrationFS(line string) fs.FS {
 	if line == riverdriver.MigrationLineMain {
 		return migrationFS

--- a/rivershared/go.mod
+++ b/rivershared/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/rivershared
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require (
 	github.com/jackc/pgx/v5 v5.10.0

--- a/rivershared/testfactory/test_factory.go
+++ b/rivershared/testfactory/test_factory.go
@@ -52,12 +52,12 @@ func Job_Build(tb testing.TB, opts *JobOpts) *riverdriver.JobInsertFullParams {
 	tb.Helper()
 
 	attemptedAt := opts.AttemptedAt
-	if attemptedAt == nil && (opts.State != nil && (slices.Contains([]rivertype.JobState{
+	if attemptedAt == nil && (opts.State != nil && slices.Contains([]rivertype.JobState{
 		rivertype.JobStateCompleted,
 		rivertype.JobStateDiscarded,
 		rivertype.JobStateRetryable,
 		rivertype.JobStateRunning,
-	}, *opts.State))) {
+	}, *opts.State)) {
 		attemptedAt = ptrutil.Ptr(time.Now())
 	}
 
@@ -67,11 +67,11 @@ func Job_Build(tb testing.TB, opts *JobOpts) *riverdriver.JobInsertFullParams {
 	}
 
 	finalizedAt := opts.FinalizedAt
-	if finalizedAt == nil && (opts.State != nil && (slices.Contains([]rivertype.JobState{
+	if finalizedAt == nil && (opts.State != nil && slices.Contains([]rivertype.JobState{
 		rivertype.JobStateCompleted,
 		rivertype.JobStateCancelled,
 		rivertype.JobStateDiscarded,
-	}, *opts.State))) {
+	}, *opts.State)) {
 		finalizedAt = ptrutil.Ptr(time.Now())
 	}
 

--- a/rivertype/go.mod
+++ b/rivertype/go.mod
@@ -1,8 +1,8 @@
 module github.com/riverqueue/river/rivertype
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.7
+toolchain go1.26.6
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
Just since everything's fully available in Homebrew etc. now, here
take the opportunity upgrade Go to 1.27 and golangci-lint  to 2.13.1 so
we can get our lint CI fully passing again.