### PR TITLE
Modernize for Go 1.26

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,13 +93,6 @@ linters:
       excludes:
         - G404 # use of non-crypto random; overly broad for our use case
 
-    modernize:
-      disable:
-        # Keep the Go 1.26 upgrade focused; apply its modernizations separately.
-        - errorsastype
-        - newexpr
-        - stditerators
-
     revive:
       rules:
         - name: unused-parameter

--- a/client_test.go
+++ b/client_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/riverqueue/river/rivershared/testfactory"
 	"github.com/riverqueue/river/rivershared/testsignal"
 	"github.com/riverqueue/river/rivershared/util/dbutil"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/serviceutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
@@ -3358,9 +3357,9 @@ func Test_Client_JobDeleteMany(t *testing.T) {
 		client, bundle := setup(t)
 
 		var (
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: ptrutil.Ptr("special_kind"), Priority: ptrutil.Ptr(1)})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: ptrutil.Ptr("special_kind"), Priority: ptrutil.Ptr(2)})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: ptrutil.Ptr("other_kind"), Priority: ptrutil.Ptr(1)})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: new("special_kind"), Priority: new(1)})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: new("special_kind"), Priority: new(2)})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: new("other_kind"), Priority: new(1)})
 		)
 
 		deleteRes, err := client.JobDeleteMany(ctx, NewJobDeleteManyParams().IDs(job1.ID, job2.ID, job3.ID).Priorities(1, 2).Kinds("special_kind"))
@@ -3377,9 +3376,9 @@ func Test_Client_JobDeleteMany(t *testing.T) {
 		client, bundle := setup(t)
 
 		var (
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: ptrutil.Ptr(1)})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: ptrutil.Ptr(2)})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: ptrutil.Ptr(3)})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: new(1)})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: new(2)})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: new(3)})
 		)
 
 		deleteRes, err := client.JobDeleteMany(ctx, NewJobDeleteManyParams().Priorities(1))
@@ -3402,9 +3401,9 @@ func Test_Client_JobDeleteMany(t *testing.T) {
 		client, bundle := setup(t)
 
 		var (
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_1"), Schema: bundle.schema})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_1"), Schema: bundle.schema})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_2"), Schema: bundle.schema})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("test_kind_1"), Schema: bundle.schema})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("test_kind_1"), Schema: bundle.schema})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("test_kind_2"), Schema: bundle.schema})
 		)
 
 		deleteRes, err := client.JobDeleteMany(ctx, NewJobDeleteManyParams().Kinds("test_kind_1"))
@@ -3426,9 +3425,9 @@ func Test_Client_JobDeleteMany(t *testing.T) {
 		client, bundle := setup(t)
 
 		var (
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_1"), Schema: bundle.schema})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_1"), Schema: bundle.schema})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_2"), Schema: bundle.schema})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: new("queue_1"), Schema: bundle.schema})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: new("queue_1"), Schema: bundle.schema})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: new("queue_2"), Schema: bundle.schema})
 		)
 
 		deleteRes, err := client.JobDeleteMany(ctx, NewJobDeleteManyParams().Queues("queue_1"))
@@ -3450,10 +3449,10 @@ func Test_Client_JobDeleteMany(t *testing.T) {
 		client, bundle := setup(t)
 
 		var (
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), Schema: bundle.schema})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), Schema: bundle.schema})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), Schema: bundle.schema})
-			job4 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStatePending), Schema: bundle.schema})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable), Schema: bundle.schema})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable), Schema: bundle.schema})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), Schema: bundle.schema})
+			job4 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStatePending), Schema: bundle.schema})
 		)
 
 		deleteRes, err := client.JobDeleteMany(ctx, NewJobDeleteManyParams().States(rivertype.JobStateAvailable))
@@ -3485,9 +3484,9 @@ func Test_Client_JobDeleteMany(t *testing.T) {
 
 		var (
 			now  = time.Now().UTC()
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: &now})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), ScheduledAt: ptrutil.Ptr(now.Add(-2 * time.Second))})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable), ScheduledAt: &now})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable), ScheduledAt: new(now.Add(-5 * time.Second))})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), ScheduledAt: new(now.Add(-2 * time.Second))})
 		)
 
 		deleteRes, err := client.JobDeleteMany(ctx, NewJobDeleteManyParams().UnsafeAll())
@@ -3512,7 +3511,7 @@ func Test_Client_JobDeleteMany(t *testing.T) {
 
 		var (
 			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 		)
 
 		deleteRes, err := client.JobDeleteMany(ctx, NewJobDeleteManyParams().IDs(job1.ID, job2.ID))
@@ -5148,9 +5147,9 @@ func Test_Client_JobList(t *testing.T) {
 
 		client, bundle := setup(t)
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: ptrutil.Ptr("special_kind"), Priority: ptrutil.Ptr(1)})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: ptrutil.Ptr("special_kind"), Priority: ptrutil.Ptr(2)})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: ptrutil.Ptr("other_kind"), Priority: ptrutil.Ptr(1)})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: new("special_kind"), Priority: new(1)})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: new("special_kind"), Priority: new(2)})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Kind: new("other_kind"), Priority: new(1)})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().IDs(job1.ID, job2.ID, job3.ID).Priorities(1, 2).Kinds("special_kind"))
 		require.NoError(t, err)
@@ -5162,9 +5161,9 @@ func Test_Client_JobList(t *testing.T) {
 
 		client, bundle := setup(t)
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: ptrutil.Ptr(1)})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: ptrutil.Ptr(2)})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: ptrutil.Ptr(3)})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: new(1)})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: new(2)})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, Priority: new(3)})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().Priorities(1))
 		require.NoError(t, err)
@@ -5180,9 +5179,9 @@ func Test_Client_JobList(t *testing.T) {
 
 		client, bundle := setup(t)
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_1"), Schema: bundle.schema})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_1"), Schema: bundle.schema})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind_2"), Schema: bundle.schema})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("test_kind_1"), Schema: bundle.schema})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("test_kind_1"), Schema: bundle.schema})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("test_kind_2"), Schema: bundle.schema})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().Kinds("test_kind_1"))
 		require.NoError(t, err)
@@ -5199,9 +5198,9 @@ func Test_Client_JobList(t *testing.T) {
 
 		client, bundle := setup(t)
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_1"), Schema: bundle.schema})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_1"), Schema: bundle.schema})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue_2"), Schema: bundle.schema})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: new("queue_1"), Schema: bundle.schema})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: new("queue_1"), Schema: bundle.schema})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Queue: new("queue_2"), Schema: bundle.schema})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().Queues("queue_1"))
 		require.NoError(t, err)
@@ -5218,10 +5217,10 @@ func Test_Client_JobList(t *testing.T) {
 
 		client, bundle := setup(t)
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), Schema: bundle.schema})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable), Schema: bundle.schema})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), Schema: bundle.schema})
-		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStatePending), Schema: bundle.schema})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable), Schema: bundle.schema})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable), Schema: bundle.schema})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning), Schema: bundle.schema})
+		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStatePending), Schema: bundle.schema})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().States(rivertype.JobStateAvailable))
 		require.NoError(t, err)
@@ -5268,8 +5267,8 @@ func Test_Client_JobList(t *testing.T) {
 			rivertype.JobStateScheduled,
 		}
 		for _, state := range states {
-			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(state), ScheduledAt: &now, Schema: bundle.schema})
-			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(state), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second)), Schema: bundle.schema})
+			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(state), ScheduledAt: &now, Schema: bundle.schema})
+			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(state), ScheduledAt: new(now.Add(-5 * time.Second)), Schema: bundle.schema})
 
 			listRes, err := client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByTime, SortOrderAsc).States(state))
 			require.NoError(t, err)
@@ -5294,8 +5293,8 @@ func Test_Client_JobList(t *testing.T) {
 			rivertype.JobStateDiscarded,
 		}
 		for _, state := range states {
-			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(state), FinalizedAt: ptrutil.Ptr(now.Add(-10 * time.Second))})
-			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(state), FinalizedAt: ptrutil.Ptr(now.Add(-15 * time.Second))})
+			job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(state), FinalizedAt: new(now.Add(-10 * time.Second))})
+			job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(state), FinalizedAt: new(now.Add(-15 * time.Second))})
 
 			listRes, err := client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByTime, SortOrderAsc).States(state))
 			require.NoError(t, err)
@@ -5313,8 +5312,8 @@ func Test_Client_JobList(t *testing.T) {
 		client, bundle := setup(t)
 
 		now := time.Now().UTC()
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: &now})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning), AttemptedAt: &now})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning), AttemptedAt: new(now.Add(-5 * time.Second))})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByTime, SortOrderAsc).States(rivertype.JobStateRunning))
 		require.NoError(t, err)
@@ -5332,9 +5331,9 @@ func Test_Client_JobList(t *testing.T) {
 		client, bundle := setup(t)
 
 		now := time.Now().UTC()
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: &now})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), ScheduledAt: ptrutil.Ptr(now.Add(-2 * time.Second))})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable), ScheduledAt: &now})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable), ScheduledAt: new(now.Add(-5 * time.Second))})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning), ScheduledAt: new(now.Add(-2 * time.Second))})
 
 		listRes, err := client.JobList(ctx, nil)
 		require.NoError(t, err)
@@ -5378,8 +5377,8 @@ func Test_Client_JobList(t *testing.T) {
 
 		now := time.Now().UTC()
 		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, ScheduledAt: &now})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, ScheduledAt: ptrutil.Ptr(now.Add(1 * time.Second))})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, ScheduledAt: ptrutil.Ptr(now.Add(2 * time.Second))})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, ScheduledAt: new(now.Add(1 * time.Second))})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, ScheduledAt: new(now.Add(2 * time.Second))})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByScheduledAt, SortOrderAsc).After(JobListCursorFromJob(job1)))
 		require.NoError(t, err)
@@ -5407,12 +5406,12 @@ func Test_Client_JobList(t *testing.T) {
 		client, bundle := setup(t)
 
 		now := time.Now().UTC()
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable), ScheduledAt: &now})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second)), AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), ScheduledAt: ptrutil.Ptr(now.Add(-6 * time.Second)), AttemptedAt: &now})
-		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), ScheduledAt: ptrutil.Ptr(now.Add(-7 * time.Second)), FinalizedAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		job6 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), ScheduledAt: ptrutil.Ptr(now.Add(-7 * time.Second)), FinalizedAt: &now})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable), ScheduledAt: new(now.Add(-5 * time.Second))})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable), ScheduledAt: &now})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning), ScheduledAt: new(now.Add(-5 * time.Second)), AttemptedAt: new(now.Add(-5 * time.Second))})
+		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning), ScheduledAt: new(now.Add(-6 * time.Second)), AttemptedAt: &now})
+		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), ScheduledAt: new(now.Add(-7 * time.Second)), FinalizedAt: new(now.Add(-5 * time.Second))})
+		job6 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), ScheduledAt: new(now.Add(-7 * time.Second)), FinalizedAt: &now})
 
 		listRes, err := client.JobList(ctx, NewJobListParams().OrderBy(JobListOrderByTime, SortOrderAsc).States(rivertype.JobStateAvailable).After(JobListCursorFromJob(job1)))
 		require.NoError(t, err)
@@ -5515,10 +5514,10 @@ func Test_Client_JobList(t *testing.T) {
 
 		var (
 			job = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-				MaxAttempts: ptrutil.Ptr(27),
-				Queue:       ptrutil.Ptr("custom_queue"),
+				MaxAttempts: new(27),
+				Queue:       new("custom_queue"),
 				Schema:      bundle.schema,
-				State:       ptrutil.Ptr(rivertype.JobStateDiscarded),
+				State:       new(rivertype.JobStateDiscarded),
 			})
 			_ = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema})
 		)
@@ -5979,18 +5978,18 @@ func Test_Client_Maintenance(t *testing.T) {
 		// Take care to insert jobs before starting the client because otherwise
 		// there's a race condition where the cleaner could run its initial
 		// pass before our insertion is complete.
-		ineligibleJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-		ineligibleJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		ineligibleJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateScheduled)})
+		ineligibleJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable)})
+		ineligibleJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+		ineligibleJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateScheduled)})
 
-		jobBeyondHorizon1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
-		jobBeyondHorizon2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
-		jobBeyondHorizon3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
+		jobBeyondHorizon1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCancelled), FinalizedAt: new(deleteHorizon.Add(-1 * time.Hour))})
+		jobBeyondHorizon2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), FinalizedAt: new(deleteHorizon.Add(-1 * time.Hour))})
+		jobBeyondHorizon3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateDiscarded), FinalizedAt: new(deleteHorizon.Add(-1 * time.Hour))})
 
 		// Will not be deleted.
-		jobWithinHorizon1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(1 * time.Hour))})
-		jobWithinHorizon2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(1 * time.Hour))})
-		jobWithinHorizon3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(1 * time.Hour))})
+		jobWithinHorizon1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCancelled), FinalizedAt: new(deleteHorizon.Add(1 * time.Hour))})
+		jobWithinHorizon2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), FinalizedAt: new(deleteHorizon.Add(1 * time.Hour))})
+		jobWithinHorizon3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateDiscarded), FinalizedAt: new(deleteHorizon.Add(1 * time.Hour))})
 
 		startAndWaitForQueueMaintainer(ctx, t, client)
 
@@ -6036,9 +6035,9 @@ func Test_Client_Maintenance(t *testing.T) {
 		// Take care to insert jobs before starting the client because otherwise
 		// there's a race condition where the cleaner could run its initial
 		// pass before our insertion is complete.
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCancelled), FinalizedAt: new(deleteHorizon.Add(-1 * time.Hour))})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), FinalizedAt: new(deleteHorizon.Add(-1 * time.Hour))})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateDiscarded), FinalizedAt: new(deleteHorizon.Add(-1 * time.Hour))})
 
 		startAndWaitForQueueMaintainer(ctx, t, client)
 
@@ -6068,25 +6067,25 @@ func Test_Client_Maintenance(t *testing.T) {
 		// Take care to insert jobs before starting the client because otherwise
 		// there's a race condition where the rescuer could run its initial
 		// pass before our insertion is complete.
-		ineligibleJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(time.Minute))})
-		ineligibleJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(time.Minute))})
-		ineligibleJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(now.Add(-time.Minute))})
+		ineligibleJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(time.Minute))})
+		ineligibleJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(time.Minute))})
+		ineligibleJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateCompleted), FinalizedAt: new(now.Add(-time.Minute))})
 
 		// large attempt number ensures these don't immediately start executing again:
-		jobStuckToRetry1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), Attempt: ptrutil.Ptr(20), AttemptedAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
-		jobStuckToRetry2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), Attempt: ptrutil.Ptr(20), AttemptedAt: ptrutil.Ptr(now.Add(-30 * time.Minute))})
+		jobStuckToRetry1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateRunning), Attempt: new(20), AttemptedAt: new(now.Add(-1 * time.Hour))})
+		jobStuckToRetry2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateRunning), Attempt: new(20), AttemptedAt: new(now.Add(-30 * time.Minute))})
 		jobStuckToDiscard := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State:       ptrutil.Ptr(rivertype.JobStateRunning),
-			Attempt:     ptrutil.Ptr(20),
-			AttemptedAt: ptrutil.Ptr(now.Add(-5*time.Minute - time.Second)),
-			MaxAttempts: ptrutil.Ptr(1),
+			State:       new(rivertype.JobStateRunning),
+			Attempt:     new(20),
+			AttemptedAt: new(now.Add(-5*time.Minute - time.Second)),
+			MaxAttempts: new(1),
 			Schema:      bundle.schema,
 		})
 
 		// Will not be rescued.
-		jobNotYetStuck1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(now.Add(-4 * time.Minute))})
-		jobNotYetStuck2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(now.Add(-1 * time.Minute))})
-		jobNotYetStuck3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(now.Add(-10 * time.Second))})
+		jobNotYetStuck1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateRunning), AttemptedAt: new(now.Add(-4 * time.Minute))})
+		jobNotYetStuck2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateRunning), AttemptedAt: new(now.Add(-1 * time.Minute))})
+		jobNotYetStuck3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateRunning), AttemptedAt: new(now.Add(-10 * time.Second))})
 
 		startAndWaitForQueueMaintainer(ctx, t, client)
 
@@ -6131,7 +6130,7 @@ func Test_Client_Maintenance(t *testing.T) {
 
 		client, bundle := setup(t, config)
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("noOp"), Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(time.Now().Add(-time.Hour))})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new("noOp"), Schema: bundle.schema, State: new(rivertype.JobStateRunning), AttemptedAt: new(time.Now().Add(-time.Hour))})
 
 		startAndWaitForQueueMaintainer(ctx, t, client)
 
@@ -6157,18 +6156,18 @@ func Test_Client_Maintenance(t *testing.T) {
 		// Take care to insert jobs before starting the client because otherwise
 		// there's a race condition where the scheduler could run its initial
 		// pass before our insertion is complete.
-		ineligibleJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-		ineligibleJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		ineligibleJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
+		ineligibleJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateAvailable)})
+		ineligibleJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+		ineligibleJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), FinalizedAt: new(now.Add(-1 * time.Hour))})
 
-		jobInPast1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
-		jobInPast2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Minute))})
-		jobInPast3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
+		jobInPast1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(-1 * time.Hour))})
+		jobInPast2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(-1 * time.Minute))})
+		jobInPast3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(-5 * time.Second))})
 
 		// Will not be scheduled.
-		jobInFuture1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(now.Add(1 * time.Hour))})
-		jobInFuture2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(now.Add(1 * time.Minute))})
-		jobInFuture3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(now.Add(10 * time.Second))})
+		jobInFuture1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCancelled), FinalizedAt: new(now.Add(1 * time.Hour))})
+		jobInFuture2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateCompleted), FinalizedAt: new(now.Add(1 * time.Minute))})
+		jobInFuture3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateDiscarded), FinalizedAt: new(now.Add(10 * time.Second))})
 
 		startAndWaitForQueueMaintainer(ctx, t, client)
 
@@ -6625,14 +6624,14 @@ func Test_Client_Maintenance(t *testing.T) {
 		// Take care to insert queues before starting the client because otherwise
 		// there's a race condition where the cleaner could run its initial
 		// pass before our insertion is complete.
-		queueBeyondHorizon1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
-		queueBeyondHorizon2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
-		queueBeyondHorizon3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: ptrutil.Ptr(deleteHorizon.Add(-1 * time.Hour))})
+		queueBeyondHorizon1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: new(deleteHorizon.Add(-1 * time.Hour))})
+		queueBeyondHorizon2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: new(deleteHorizon.Add(-1 * time.Hour))})
+		queueBeyondHorizon3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: new(deleteHorizon.Add(-1 * time.Hour))})
 
 		// Will not be deleted.
-		queueWithinHorizon1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: ptrutil.Ptr(deleteHorizon.Add(1 * time.Hour))})
-		queueWithinHorizon2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: ptrutil.Ptr(deleteHorizon.Add(1 * time.Hour))})
-		queueWithinHorizon3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: ptrutil.Ptr(deleteHorizon.Add(1 * time.Hour))})
+		queueWithinHorizon1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: new(deleteHorizon.Add(1 * time.Hour))})
+		queueWithinHorizon2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: new(deleteHorizon.Add(1 * time.Hour))})
+		queueWithinHorizon3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Schema: schema, UpdatedAt: new(deleteHorizon.Add(1 * time.Hour))})
 
 		startClient(ctx, t, client)
 

--- a/cmd/river/rivercli/command.go
+++ b/cmd/river/rivercli/command.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "modernc.org/sqlite"
-
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 )
 
 // Command is an interface to a River CLI subcommand. Commands generally only
@@ -68,7 +66,7 @@ func RunCommand[TOpts CommandOpts](ctx context.Context, bundle *RunCommandBundle
 			urlWithoutProtocol string
 		)
 		if pgEnvConfigured() {
-			databaseURL = ptrutil.Ptr("")
+			databaseURL = new("")
 			protocol = "postgres"
 		} else if bundle.DatabaseURL != nil {
 			databaseURL = bundle.DatabaseURL

--- a/internal/dblist/db_list_test.go
+++ b/internal/dblist/db_list_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -93,11 +92,11 @@ func TestJobListWithJobs(t *testing.T) {
 			exec   = driver.UnwrapExecutor(tx)
 		)
 
-		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("priority"), Priority: ptrutil.Ptr(1)})
-		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{EncodedArgs: []byte(`{"job_num": 2}`), Priority: ptrutil.Ptr(2)})
-		job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Metadata: []byte(`{"some_key": "some_value"}`), Priority: ptrutil.Ptr(3)})
-		job4 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning), Priority: ptrutil.Ptr(1)})
-		job5 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("alternate_kind"), Priority: ptrutil.Ptr(2)})
+		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("priority"), Priority: new(1)})
+		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{EncodedArgs: []byte(`{"job_num": 2}`), Priority: new(2)})
+		job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Metadata: []byte(`{"some_key": "some_value"}`), Priority: new(3)})
+		job4 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning), Priority: new(1)})
+		job5 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("alternate_kind"), Priority: new(2)})
 
 		return &testBundle{
 			baselineTime: time.Now(),

--- a/internal/dbunique/db_unique_test.go
+++ b/internal/dbunique/db_unique_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/uniquestates"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -420,7 +419,7 @@ func TestUniqueKey(t *testing.T) {
 				}
 			},
 			modifyInsertParamsFunc: func(insertParams *rivertype.JobInsertParams) {
-				insertParams.ScheduledAt = ptrutil.Ptr(now.Add(time.Hour))
+				insertParams.ScheduledAt = new(now.Add(time.Hour))
 			},
 			uniqueOpts:   UniqueOpts{ByPeriod: time.Hour},
 			expectedJSON: "&kind=worker_4&period=" + now.Add(time.Hour).Truncate(time.Hour).Format(time.RFC3339),

--- a/internal/jobcompleter/job_completer_test.go
+++ b/internal/jobcompleter/job_completer_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstop"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -905,9 +904,9 @@ func testCompleter[TCompleter JobCompleter](
 			finalizedAt2 = time.Now().UTC().Add(-2 * time.Minute)
 			finalizedAt3 = time.Now().UTC().Add(-3 * time.Minute)
 
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 		)
 
 		require.NoError(t, completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job1.ID, finalizedAt1, nil)))
@@ -1036,14 +1035,14 @@ func testCompleter[TCompleter JobCompleter](
 		completer, bundle := setup(t)
 
 		var (
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job4 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job5 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job6 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job7 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job8 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job4 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job5 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job6 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job7 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job8 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 		)
 
 		require.NoError(t, completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCancelled(job1.ID, time.Now(), []byte("{}"), nil)))
@@ -1073,9 +1072,9 @@ func testCompleter[TCompleter JobCompleter](
 		completer, bundle := setup(t)
 
 		var (
-			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
+			job3 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 		)
 
 		require.NoError(t, completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job1.ID, time.Now(), nil)))
@@ -1123,7 +1122,7 @@ func testCompleter[TCompleter JobCompleter](
 		completer, bundle := setup(t)
 
 		{
-			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 
 			require.NoError(t, completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job.ID, time.Now(), nil)))
 
@@ -1138,7 +1137,7 @@ func testCompleter[TCompleter JobCompleter](
 		{
 			require.NoError(t, completer.Start(ctx))
 
-			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 
 			require.NoError(t, completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job.ID, time.Now(), nil)))
 
@@ -1178,7 +1177,7 @@ func testCompleter[TCompleter JobCompleter](
 		}
 		setExec(completer, execMock)
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 
 		require.NoError(t, completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job.ID, time.Now(), nil)))
 
@@ -1206,7 +1205,7 @@ func testCompleter[TCompleter JobCompleter](
 		}
 		setExec(completer, execMock)
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 
 		err := completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job.ID, time.Now(), nil))
 
@@ -1239,7 +1238,7 @@ func testCompleter[TCompleter JobCompleter](
 		}
 		setExec(completer, execMock)
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Schema: bundle.schema, State: new(rivertype.JobStateRunning)})
 
 		err := completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job.ID, time.Now(), nil))
 
@@ -1455,7 +1454,7 @@ func doContinuousInsertionInterval(ctx context.Context, t *testing.T, completer 
 		}()
 
 		for {
-			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Schema: schema, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Schema: schema, State: new(rivertype.JobStateRunning)})
 			require.NoError(t, completer.JobSetStateIfRunning(ctx, &jobstats.JobStatistics{}, riverdriver.JobSetStateCompleted(job.ID, time.Now(), nil)))
 			numInserted.Add(1)
 

--- a/internal/jobexecutor/job_executor_test.go
+++ b/internal/jobexecutor/job_executor_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/riverqueue/river/rivershared/riverpilot"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -152,7 +151,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 					// Needs to be explicitly set to a "now" horizon that's aligned with the
 					// JobGetAvailable call. InsertMany applies a default scheduled_at in Go
 					// so it can't pick up the Postgres-level `now()` default.
-					ScheduledAt: ptrutil.Ptr(now),
+					ScheduledAt: new(now),
 					State:       rivertype.JobStateAvailable,
 				},
 			},
@@ -162,7 +161,7 @@ func TestJobExecutor_Execute(t *testing.T) {
 		// Fetch the job to make sure it's marked as running:
 		jobs, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
 			MaxToLock: 1,
-			Now:       ptrutil.Ptr(now),
+			Now:       new(now),
 			Queue:     rivercommon.QueueDefault,
 		})
 		require.NoError(t, err)
@@ -664,9 +663,9 @@ func TestJobExecutor_Execute(t *testing.T) {
 			now := time.Now().UTC()
 			_, err := exec.JobInsertFullMany(ctx, &riverdriver.JobInsertFullManyParams{
 				Jobs: []*riverdriver.JobInsertFullParams{
-					testfactory.Job_Build(t, &testfactory.JobOpts{Kind: ptrutil.Ptr("jobexecutor_test"), ScheduledAt: &now}),
-					testfactory.Job_Build(t, &testfactory.JobOpts{Kind: ptrutil.Ptr("jobexecutor_test"), ScheduledAt: &now}),
-					testfactory.Job_Build(t, &testfactory.JobOpts{Kind: ptrutil.Ptr("jobexecutor_test"), ScheduledAt: &now}),
+					testfactory.Job_Build(t, &testfactory.JobOpts{Kind: new("jobexecutor_test"), ScheduledAt: &now}),
+					testfactory.Job_Build(t, &testfactory.JobOpts{Kind: new("jobexecutor_test"), ScheduledAt: &now}),
+					testfactory.Job_Build(t, &testfactory.JobOpts{Kind: new("jobexecutor_test"), ScheduledAt: &now}),
 				},
 			})
 			require.NoError(t, err)

--- a/internal/leadership/elector_test.go
+++ b/internal/leadership/elector_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
 	"github.com/riverqueue/river/rivershared/util/dbutil"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -275,9 +274,9 @@ func TestElectorRunLeaderState(t *testing.T) {
 		elector.publishLeadershipState(true)
 
 		leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-			ElectedAt: ptrutil.Ptr(initialNow),
-			ExpiresAt: ptrutil.Ptr(initialNow.Add(elector.leaderTTL())),
-			LeaderID:  ptrutil.Ptr(elector.config.ClientID),
+			ElectedAt: new(initialNow),
+			ExpiresAt: new(initialNow.Add(elector.leaderTTL())),
+			LeaderID:  new(elector.config.ClientID),
 		})
 
 		elector.exec = &leaderReelectExecutorMock{
@@ -318,9 +317,9 @@ func TestElectorRunLeaderState(t *testing.T) {
 		elector.publishLeadershipState(true)
 
 		leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-			ElectedAt: ptrutil.Ptr(initialNow),
-			ExpiresAt: ptrutil.Ptr(initialNow.Add(elector.leaderTTL())),
-			LeaderID:  ptrutil.Ptr(elector.config.ClientID),
+			ElectedAt: new(initialNow),
+			ExpiresAt: new(initialNow.Add(elector.leaderTTL())),
+			LeaderID:  new(elector.config.ClientID),
 		})
 
 		var numAttempts int

--- a/internal/maintenance/job_cleaner_test.go
+++ b/internal/maintenance/job_cleaner_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -80,21 +79,21 @@ func TestJobCleaner(t *testing.T) {
 		cleaner, bundle := setup(t)
 
 		// none of these get removed
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled)})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning)})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateScheduled)})
 
-		cancelledJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
-		cancelledJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(-1 * time.Minute))})
-		cancelledJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(1 * time.Minute))}) // won't be deleted
+		cancelledJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
+		cancelledJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(-1 * time.Minute))})
+		cancelledJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(1 * time.Minute))}) // won't be deleted
 
-		completedJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
-		completedJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Minute))})
-		completedJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(1 * time.Minute))}) // won't be deleted
+		completedJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+		completedJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Minute))})
+		completedJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(1 * time.Minute))}) // won't be deleted
 
-		discardedJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
-		discardedJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(-1 * time.Minute))})
-		discardedJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(1 * time.Minute))}) // won't be deleted
+		discardedJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
+		discardedJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(-1 * time.Minute))})
+		discardedJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(1 * time.Minute))}) // won't be deleted
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -138,9 +137,9 @@ func TestJobCleaner(t *testing.T) {
 		cleaner.Config.CompletedJobRetentionPeriod = -1
 		cleaner.Config.DiscardedJobRetentionPeriod = -1
 
-		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
-		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
-		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
+		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
+		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -162,9 +161,9 @@ func TestJobCleaner(t *testing.T) {
 		cleaner, bundle := setup(t)
 		cleaner.Config.CancelledJobRetentionPeriod = -1
 
-		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
-		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
-		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
+		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
+		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -186,9 +185,9 @@ func TestJobCleaner(t *testing.T) {
 		cleaner, bundle := setup(t)
 		cleaner.Config.CompletedJobRetentionPeriod = -1
 
-		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
-		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
-		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
+		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
+		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -210,9 +209,9 @@ func TestJobCleaner(t *testing.T) {
 		cleaner, bundle := setup(t)
 		cleaner.Config.DiscardedJobRetentionPeriod = -1
 
-		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
-		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
-		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
+		cancelledJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
+		completedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+		discardedJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -241,7 +240,7 @@ func TestJobCleaner(t *testing.T) {
 		jobs := make([]*rivertype.JobRow, numJobs)
 
 		for i := range numJobs {
-			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
 			jobs[i] = job
 		}
 
@@ -307,7 +306,7 @@ func TestJobCleaner(t *testing.T) {
 		cleaner, bundle := setup(t)
 		cleaner.Config.Interval = time.Minute // should only trigger once for the initial run
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -315,7 +314,7 @@ func TestJobCleaner(t *testing.T) {
 
 		cleaner.Stop()
 
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Minute))})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Minute))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -334,16 +333,16 @@ func TestJobCleaner(t *testing.T) {
 		cleaner, bundle := setup(t)
 
 		var (
-			cancelledJob = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
-			completedJob = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
-			discardedJob = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded), FinalizedAt: ptrutil.Ptr(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
+			cancelledJob = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(bundle.cancelledDeleteHorizon.Add(-1 * time.Hour))})
+			completedJob = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour))})
+			discardedJob = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded), FinalizedAt: new(bundle.discardedDeleteHorizon.Add(-1 * time.Hour))})
 
 			omittedQueue1 = "omitted1"
 			omittedQueue2 = "omitted1"
 
 			// Not deleted because in an omitted queue.
-			omittedQueueJob1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour)), Queue: &omittedQueue1, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-			omittedQueueJob2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: ptrutil.Ptr(bundle.completedDeleteHorizon.Add(-1 * time.Hour)), Queue: &omittedQueue2, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
+			omittedQueueJob1 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour)), Queue: &omittedQueue1, State: new(rivertype.JobStateCompleted)})
+			omittedQueueJob2 = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: new(bundle.completedDeleteHorizon.Add(-1 * time.Hour)), Queue: &omittedQueue2, State: new(rivertype.JobStateCompleted)})
 		)
 
 		cleaner.Config.QueuesExcluded = []string{omittedQueue1, omittedQueue2}

--- a/internal/maintenance/job_rescuer_test.go
+++ b/internal/maintenance/job_rescuer_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/timeutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -162,7 +161,7 @@ func TestJobRescuer(t *testing.T) {
 		rescuer, bundle := setup(t)
 		rescuer.Config.ClientJobTimeout = -1
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-24 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-24 * time.Hour)), MaxAttempts: new(5)})
 
 		_, err := rescuer.runOnce(ctx)
 		require.NoError(t, err)
@@ -203,32 +202,32 @@ func TestJobRescuer(t *testing.T) {
 
 		rescuer, bundle := setup(t)
 
-		stuckToRetryJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
-		stuckToRetryJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)})
-		stuckToRetryJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(1 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)}) // won't be rescued
+		stuckToRetryJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
+		stuckToRetryJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: new(5)})
+		stuckToRetryJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(1 * time.Minute)), MaxAttempts: new(5)}) // won't be rescued
 
 		// Already at max attempts:
-		stuckToDiscardJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), Attempt: ptrutil.Ptr(5), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
-		stuckToDiscardJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), Attempt: ptrutil.Ptr(5), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(1 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)}) // won't be rescued
+		stuckToDiscardJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), Attempt: new(5), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
+		stuckToDiscardJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), Attempt: new(5), AttemptedAt: new(bundle.rescueHorizon.Add(1 * time.Minute)), MaxAttempts: new(5)}) // won't be rescued
 
 		// Marked as cancelled by query:
 		cancelTime := time.Now().UTC().Format(time.RFC3339Nano)
-		stuckToCancelJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), Metadata: fmt.Appendf(nil, `{"cancel_attempted_at": %q}`, cancelTime), MaxAttempts: ptrutil.Ptr(5)})
-		stuckToCancelJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(1 * time.Minute)), Metadata: fmt.Appendf(nil, `{"cancel_attempted_at": %q}`, cancelTime), MaxAttempts: ptrutil.Ptr(5)}) // won't be rescued
+		stuckToCancelJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), Metadata: fmt.Appendf(nil, `{"cancel_attempted_at": %q}`, cancelTime), MaxAttempts: new(5)})
+		stuckToCancelJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(1 * time.Minute)), Metadata: fmt.Appendf(nil, `{"cancel_attempted_at": %q}`, cancelTime), MaxAttempts: new(5)}) // won't be rescued
 
 		// these aren't touched because they're in ineligible states
-		notRunningJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), FinalizedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), State: ptrutil.Ptr(rivertype.JobStateCompleted), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
-		notRunningJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), FinalizedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), State: ptrutil.Ptr(rivertype.JobStateDiscarded), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
-		notRunningJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), FinalizedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), State: ptrutil.Ptr(rivertype.JobStateCancelled), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+		notRunningJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), FinalizedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), State: new(rivertype.JobStateCompleted), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
+		notRunningJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), FinalizedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), State: new(rivertype.JobStateDiscarded), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
+		notRunningJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), FinalizedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), State: new(rivertype.JobStateCancelled), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
 
 		// Jobs with worker-specific long timeouts. The first isn't rescued
 		// because the difference between its `attempted_at` and now is still
 		// within the timeout threshold. The second _is_ rescued because it
 		// started earlier and even with the longer timeout, has still timed out.
-		longTimeOutJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKindLongTimeout), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)})
-		longTimeOutJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKindLongTimeout), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-6 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)})
+		longTimeOutJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKindLongTimeout), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: new(5)})
+		longTimeOutJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKindLongTimeout), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-6 * time.Minute)), MaxAttempts: new(5)})
 
-		noTimeoutJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKindNoTimeout), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-24 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+		noTimeoutJob := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKindNoTimeout), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-24 * time.Hour)), MaxAttempts: new(5)})
 
 		require.NoError(t, rescuer.Start(ctx))
 
@@ -312,7 +311,7 @@ func TestJobRescuer(t *testing.T) {
 		jobs := make([]*rivertype.JobRow, numJobs)
 
 		for i := range numJobs {
-			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
 			jobs[i] = job
 		}
 
@@ -339,9 +338,9 @@ func TestJobRescuer(t *testing.T) {
 
 		noTimeoutJobs := make([]*rivertype.JobRow, rescuer.Config.Default+1)
 		for i := range noTimeoutJobs {
-			noTimeoutJobs[i] = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKindNoTimeout), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-24 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+			noTimeoutJobs[i] = testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKindNoTimeout), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-24 * time.Hour)), MaxAttempts: new(5)})
 		}
-		jobToRescue := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+		jobToRescue := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
 
 		_, err := rescuer.runOnce(ctx)
 		require.NoError(t, err)
@@ -459,7 +458,7 @@ func TestJobRescuer(t *testing.T) {
 		pilot := &jobRescuerPilotSpy{}
 		rescuer.Config.Pilot = pilot
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
 
 		_, err := rescuer.runOnce(ctx)
 		require.NoError(t, err)
@@ -480,7 +479,7 @@ func TestJobRescuer(t *testing.T) {
 		_, implementsJobRescuer := rescuer.Config.Pilot.(riverpilot.PilotJobRescuer)
 		require.False(t, implementsJobRescuer)
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
 
 		_, err := rescuer.runOnce(ctx)
 		require.NoError(t, err)
@@ -496,7 +495,7 @@ func TestJobRescuer(t *testing.T) {
 		rescuer, bundle := setup(t)
 		rescuer.Config.Interval = time.Minute // should only trigger once for the initial run
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), Attempt: ptrutil.Ptr(5), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: ptrutil.Ptr(5)})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), Attempt: new(5), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Hour)), MaxAttempts: new(5)})
 
 		require.NoError(t, rescuer.Start(ctx))
 
@@ -505,7 +504,7 @@ func TestJobRescuer(t *testing.T) {
 
 		rescuer.Stop()
 
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: ptrutil.Ptr(rescuerJobKind), State: ptrutil.Ptr(rivertype.JobStateRunning), Attempt: ptrutil.Ptr(5), AttemptedAt: ptrutil.Ptr(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: ptrutil.Ptr(5)})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{Kind: new(rescuerJobKind), State: new(rivertype.JobStateRunning), Attempt: new(5), AttemptedAt: new(bundle.rescueHorizon.Add(-1 * time.Minute)), MaxAttempts: new(5)})
 
 		require.NoError(t, rescuer.Start(ctx))
 

--- a/internal/maintenance/job_scheduler_test.go
+++ b/internal/maintenance/job_scheduler_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
 	"github.com/riverqueue/river/rivershared/uniquestates"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -122,20 +121,20 @@ func TestJobScheduler(t *testing.T) {
 		now := time.Now().UTC()
 
 		// none of these should get updated
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: ptrutil.Ptr(now), State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: ptrutil.Ptr(now), State: ptrutil.Ptr(rivertype.JobStateCancelled)})
-		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: ptrutil.Ptr(now), State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
-		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: new(now), State: new(rivertype.JobStateCompleted)})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning)})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: new(now), State: new(rivertype.JobStateCancelled)})
+		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{FinalizedAt: new(now), State: new(rivertype.JobStateDiscarded)})
+		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
 
-		scheduledJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
-		scheduledJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		scheduledJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(scheduler.config.Interval - time.Millisecond))}) // won't be scheduled
-		scheduledJob4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(30 * time.Second))})                             // won't be scheduled
+		scheduledJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(-1 * time.Hour))})
+		scheduledJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(-5 * time.Second))})
+		scheduledJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(scheduler.config.Interval - time.Millisecond))}) // won't be scheduled
+		scheduledJob4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(30 * time.Second))})                             // won't be scheduled
 
-		retryableJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
-		retryableJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		retryableJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(30 * time.Second))}) // won't be scheduled
+		retryableJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-1 * time.Hour))})
+		retryableJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-5 * time.Second))})
+		retryableJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(30 * time.Second))}) // won't be scheduled
 
 		require.NoError(t, scheduler.Start(ctx))
 
@@ -173,20 +172,20 @@ func TestJobScheduler(t *testing.T) {
 		}
 		uniqueMap := uniquestates.UniqueStatesToBitmask(uniqueStates)
 
-		retryableJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("1"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
-		retryableJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("2"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))})
-		retryableJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("3"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))}) // dupe
-		retryableJob4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("4"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))}) // dupe
-		retryableJob5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("5"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))}) // dupe
-		retryableJob6 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("6"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))}) // dupe
-		retryableJob7 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("7"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-5 * time.Second))}) // dupe
+		retryableJob1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("1"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-1 * time.Hour))})
+		retryableJob2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("2"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-5 * time.Second))})
+		retryableJob3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("3"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-5 * time.Second))}) // dupe
+		retryableJob4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("4"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-5 * time.Second))}) // dupe
+		retryableJob5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("5"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-5 * time.Second))}) // dupe
+		retryableJob6 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("6"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-5 * time.Second))}) // dupe
+		retryableJob7 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("7"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-5 * time.Second))}) // dupe
 
 		// Will cause conflicts with above jobs when retried:
-		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("3"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("4"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("5"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStatePending)})
-		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("6"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("7"), UniqueStates: uniqueMap, State: ptrutil.Ptr(rivertype.JobStateScheduled)})
+		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("3"), UniqueStates: uniqueMap, State: new(rivertype.JobStateAvailable)})
+		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("4"), UniqueStates: uniqueMap, State: new(rivertype.JobStateCompleted)})
+		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("5"), UniqueStates: uniqueMap, State: new(rivertype.JobStatePending)})
+		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("6"), UniqueStates: uniqueMap, State: new(rivertype.JobStateRunning)})
+		testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{UniqueKey: []byte("7"), UniqueStates: uniqueMap, State: new(rivertype.JobStateScheduled)})
 
 		require.NoError(t, scheduler.Start(ctx))
 
@@ -221,9 +220,9 @@ func TestJobScheduler(t *testing.T) {
 				jobState = rivertype.JobStateRetryable
 			}
 			job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-				Queue:       ptrutil.Ptr("scheduler_test"),
+				Queue:       new("scheduler_test"),
 				State:       &jobState,
-				ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour)),
+				ScheduledAt: new(now.Add(-1 * time.Hour)),
 			})
 			jobs[i] = job
 		}
@@ -290,7 +289,7 @@ func TestJobScheduler(t *testing.T) {
 		scheduler.config.Interval = time.Minute // should only trigger once for the initial run
 		now := time.Now().UTC()
 
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour))})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateScheduled), ScheduledAt: new(now.Add(-1 * time.Hour))})
 
 		require.NoError(t, scheduler.Start(ctx))
 
@@ -298,7 +297,7 @@ func TestJobScheduler(t *testing.T) {
 
 		scheduler.Stop()
 
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRetryable), ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Minute))})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRetryable), ScheduledAt: new(now.Add(-1 * time.Minute))})
 
 		require.NoError(t, scheduler.Start(ctx))
 
@@ -333,14 +332,14 @@ func TestJobScheduler(t *testing.T) {
 			switch state {
 			case rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRetryable, rivertype.JobStateRunning, rivertype.JobStateScheduled:
 			case rivertype.JobStateCompleted, rivertype.JobStateCancelled, rivertype.JobStateDiscarded:
-				finalizedAt = ptrutil.Ptr(now.Add(fromNow))
+				finalizedAt = new(now.Add(fromNow))
 			}
 			testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				FinalizedAt: finalizedAt,
 				Queue:       &queue,
 				Schema:      schema,
 				State:       &state,
-				ScheduledAt: ptrutil.Ptr(now.Add(fromNow)),
+				ScheduledAt: new(now.Add(fromNow)),
 			})
 		}
 

--- a/internal/maintenance/queue_cleaner_test.go
+++ b/internal/maintenance/queue_cleaner_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -78,13 +77,13 @@ func TestQueueCleaner(t *testing.T) {
 
 		now := time.Now()
 		// None of these should get removed:
-		queue1 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue1"), UpdatedAt: ptrutil.Ptr(now)})
-		queue2 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue2"), UpdatedAt: ptrutil.Ptr(now.Add(-23 * time.Hour))})
+		queue1 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: new("queue1"), UpdatedAt: new(now)})
+		queue2 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: new("queue2"), UpdatedAt: new(now.Add(-23 * time.Hour))})
 
 		// These get deleted:
-		queue3 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue3"), UpdatedAt: ptrutil.Ptr(now.Add(-25 * time.Hour))})
-		queue4 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue4"), UpdatedAt: ptrutil.Ptr(now.Add(-26 * time.Hour))})
-		queue5 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue5"), UpdatedAt: ptrutil.Ptr(now.Add(-48 * time.Hour))})
+		queue3 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: new("queue3"), UpdatedAt: new(now.Add(-25 * time.Hour))})
+		queue4 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: new("queue4"), UpdatedAt: new(now.Add(-26 * time.Hour))})
+		queue5 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: new("queue5"), UpdatedAt: new(now.Add(-48 * time.Hour))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -133,8 +132,8 @@ func TestQueueCleaner(t *testing.T) {
 
 		for i := range numQueues {
 			queue := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{
-				Name:      ptrutil.Ptr(fmt.Sprintf("queue%d", i)),
-				UpdatedAt: ptrutil.Ptr(bundle.deleteHorizon.Add(-25 * time.Hour)),
+				Name:      new(fmt.Sprintf("queue%d", i)),
+				UpdatedAt: new(bundle.deleteHorizon.Add(-25 * time.Hour)),
 			})
 			queues[i] = queue
 		}
@@ -204,7 +203,7 @@ func TestQueueCleaner(t *testing.T) {
 		cleaner, bundle := setup(t)
 		cleaner.Config.Interval = time.Minute // should only trigger once for the initial run
 
-		queue1 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue1"), UpdatedAt: ptrutil.Ptr(bundle.deleteHorizon.Add(-1 * time.Hour))})
+		queue1 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: new("queue1"), UpdatedAt: new(bundle.deleteHorizon.Add(-1 * time.Hour))})
 
 		require.NoError(t, cleaner.Start(ctx))
 
@@ -212,7 +211,7 @@ func TestQueueCleaner(t *testing.T) {
 
 		cleaner.Stop()
 
-		queue2 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue2"), UpdatedAt: ptrutil.Ptr(bundle.deleteHorizon.Add(-1 * time.Minute))})
+		queue2 := testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{Name: new("queue2"), UpdatedAt: new(bundle.deleteHorizon.Add(-1 * time.Minute))})
 
 		require.NoError(t, cleaner.Start(ctx))
 

--- a/job_complete_tx_test.go
+++ b/job_complete_tx_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -59,7 +58,7 @@ func TestJobCompleteTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t)
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateRunning),
+			State: new(rivertype.JobStateRunning),
 		})
 
 		completedJob, err := JobCompleteTx[*riverpgxv5.Driver](ctx, bundle.tx, &Job[JobArgs]{JobRow: job})
@@ -85,7 +84,7 @@ func TestJobCompleteTx(t *testing.T) {
 		ctx = context.WithValue(ctx, jobexecutor.ContextKeyMetadataUpdates, metadataUpdates)
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateRunning),
+			State: new(rivertype.JobStateRunning),
 		})
 
 		completedJob, err := JobCompleteTx[*riverpgxv5.Driver](ctx, bundle.tx, &Job[JobArgs]{JobRow: job})
@@ -109,7 +108,7 @@ func TestJobCompleteTx(t *testing.T) {
 		ctx = context.WithValue(ctx, jobexecutor.ContextKeyMetadataUpdates, map[string]any{"foo": make(chan int)})
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateRunning),
+			State: new(rivertype.JobStateRunning),
 		})
 
 		_, err := JobCompleteTx[*riverpgxv5.Driver](ctx, bundle.tx, &Job[JobArgs]{JobRow: job})
@@ -133,7 +132,7 @@ func TestJobCompleteTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t)
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateAvailable),
+			State: new(rivertype.JobStateAvailable),
 		})
 
 		// delete the job
@@ -152,7 +151,7 @@ func TestJobCompleteTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t)
 		ctx = context.WithValue(ctx, execution.ContextKeyInsideTestWorker{}, true)
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
 		// delete the job as though it was never inserted:
 		_, err := bundle.client.JobDeleteTx(ctx, bundle.tx, job.ID)
 		require.NoError(t, err)

--- a/job_list_params.go
+++ b/job_list_params.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/riverqueue/river/internal/dblist"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -38,9 +37,9 @@ func jobListCursorFromJobAndParams(job *rivertype.JobRow, listParams *JobListPar
 	// Don't include a `default` so `exhaustive` lint can detect omissions.
 	switch listParams.sortField {
 	case JobListOrderByID:
-		cursorTime = ptrutil.Ptr(time.Time{})
+		cursorTime = new(time.Time{})
 	case JobListOrderByTime:
-		cursorTime = ptrutil.Ptr(jobListTimeValue(job))
+		cursorTime = new(jobListTimeValue(job))
 	case JobListOrderByFinalizedAt:
 		if job.FinalizedAt != nil {
 			cursorTime = job.FinalizedAt

--- a/job_list_params_test.go
+++ b/job_list_params_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -87,9 +86,9 @@ func Test_JobListCursor_jobListCursorFromJobAndParams(t *testing.T) {
 
 			now := time.Now().UTC()
 			jobRow := &rivertype.JobRow{
-				AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second)),
+				AttemptedAt: new(now.Add(-5 * time.Second)),
 				CreatedAt:   now.Add(-11 * time.Second),
-				FinalizedAt: ptrutil.Ptr(now.Add(-1 * time.Second)),
+				FinalizedAt: new(now.Add(-1 * time.Second)),
 				ID:          int64(i),
 				Kind:        "test_kind",
 				Queue:       "test_queue",
@@ -110,7 +109,7 @@ func Test_JobListCursor_jobListCursorFromJobAndParams(t *testing.T) {
 
 		now := time.Now().UTC()
 		jobRow := &rivertype.JobRow{
-			AttemptedAt: ptrutil.Ptr(now.Add(-5 * time.Second)),
+			AttemptedAt: new(now.Add(-5 * time.Second)),
 			CreatedAt:   now.Add(-11 * time.Second),
 			ID:          4,
 			Kind:        "test",

--- a/producer_test.go
+++ b/producer_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
@@ -829,8 +828,8 @@ func testProducer(t *testing.T, makeProducer func(ctx context.Context, t *testin
 		AddWorker(bundle.workers, &noOpWorker{})
 
 		testfactory.Queue(ctx, t, bundle.exec, &testfactory.QueueOpts{
-			Name:     ptrutil.Ptr(producer.config.Queue),
-			PausedAt: ptrutil.Ptr(time.Now()),
+			Name:     new(producer.config.Queue),
+			PausedAt: new(time.Now()),
 			Schema:   producer.config.Schema,
 		})
 

--- a/resumable_step_tx_test.go
+++ b/resumable_step_tx_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/testutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -65,7 +64,7 @@ func TestResumableSetStepTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t, "step1")
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateRunning),
+			State: new(rivertype.JobStateRunning),
 		})
 
 		updatedJob, err := ResumableSetStepTx[*riverpgxv5.Driver](ctx, bundle.tx, &Job[JobArgs]{JobRow: job})
@@ -86,7 +85,7 @@ func TestResumableSetStepTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t, "step2")
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateRunning),
+			State: new(rivertype.JobStateRunning),
 		})
 
 		type Cursor struct {
@@ -127,7 +126,7 @@ func TestResumableSetStepTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t, "") // empty step name
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateRunning),
+			State: new(rivertype.JobStateRunning),
 		})
 
 		_, err := ResumableSetStepTx[*riverpgxv5.Driver](ctx, bundle.tx, &Job[JobArgs]{JobRow: job})
@@ -140,7 +139,7 @@ func TestResumableSetStepTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t, "step1")
 
 		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateAvailable),
+			State: new(rivertype.JobStateAvailable),
 		})
 		_, err := bundle.exec.JobDelete(ctx, &riverdriver.JobDeleteParams{ID: job.ID})
 		require.NoError(t, err)
@@ -156,7 +155,7 @@ func TestResumableSetStepTx(t *testing.T) {
 		ctx, bundle := setup(ctx, t, "step1")
 		ctx = context.WithValue(ctx, execution.ContextKeyInsideTestWorker{}, true)
 
-		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		job := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
 		_, err := bundle.client.JobDeleteTx(ctx, bundle.tx, job.ID)
 		require.NoError(t, err)
 		job.State = rivertype.JobStateRunning

--- a/riverdbtest/riverdbtest_test.go
+++ b/riverdbtest/riverdbtest_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -47,8 +46,8 @@ func TestTestSchema(t *testing.T) {
 
 		require.NotEqual(t, schema1, schema2)
 
-		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("schema1_job"), Schema: schema1})
-		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("schema2_job"), Schema: schema2})
+		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("schema1_job"), Schema: schema1})
+		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("schema2_job"), Schema: schema2})
 
 		// Each job is found in its appropriate schema. Make sure to check kind
 		// because for many test runs IDs will be identical across schemas

--- a/riverdriver/riverdrivertest/benchmark.go
+++ b/riverdriver/riverdrivertest/benchmark.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -116,7 +115,7 @@ func Benchmark[TTx any](ctx context.Context, b *testing.B,
 				params.State[j] = rivertype.JobStateCompleted
 			case 2:
 				// Snooze the job
-				params.Attempt[j] = ptrutil.Ptr(1)
+				params.Attempt[j] = new(1)
 				params.ScheduledAt[j] = &now
 				params.State[j] = rivertype.JobStateScheduled
 			default:

--- a/riverdriver/riverdrivertest/job_delete.go
+++ b/riverdriver/riverdrivertest/job_delete.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -42,7 +41,7 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 			exec, _ := setup(ctx, t)
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State: ptrutil.Ptr(rivertype.JobStateRunning),
+				State: new(rivertype.JobStateRunning),
 			})
 
 			jobAfter, err := exec.JobDelete(ctx, &riverdriver.JobDeleteParams{
@@ -85,7 +84,7 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 				job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 					FinalizedAt: finalizedAt,
-					ScheduledAt: ptrutil.Ptr(now.Add(1 * time.Hour)),
+					ScheduledAt: new(now.Add(1 * time.Hour)),
 					State:       &state,
 				})
 
@@ -143,16 +142,16 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			exec, _ := setup(ctx, t)
 
-			deletedJob1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateCancelled)})
-			deletedJob2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-			deletedJob3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
+			deletedJob1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateCancelled)})
+			deletedJob2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateCompleted)})
+			deletedJob3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateDiscarded)})
 
 			// Not deleted because not appropriate state.
-			notDeletedJob1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			notDeletedJob2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			notDeletedJob1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
+			notDeletedJob2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning)})
 
 			// Not deleted because after the delete horizon.
-			notDeletedJob3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &afterHorizon, State: ptrutil.Ptr(rivertype.JobStateCancelled)})
+			notDeletedJob3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &afterHorizon, State: new(rivertype.JobStateCancelled)})
 
 			// Max two deleted on the first pass.
 			numDeleted, err := exec.JobDeleteBefore(ctx, &riverdriver.JobDeleteBeforeParams{
@@ -202,17 +201,17 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			exec, _ := setup(ctx, t)
 
-			var ( //nolint:dupl
-				cancelledJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateCancelled)})
-				completedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-				discardedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
+			var (
+				cancelledJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateCancelled)})
+				completedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateCompleted)})
+				discardedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateDiscarded)})
 
 				excludedQueue1 = "excluded1"
 				excludedQueue2 = "excluded2"
 
 				// Not deleted because in an omitted queue.
-				notDeletedJob1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &excludedQueue1, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-				notDeletedJob2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &excludedQueue2, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
+				notDeletedJob1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &excludedQueue1, State: new(rivertype.JobStateCompleted)})
+				notDeletedJob2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &excludedQueue2, State: new(rivertype.JobStateCompleted)})
 			)
 
 			numDeleted, err := exec.JobDeleteBefore(ctx, &riverdriver.JobDeleteBeforeParams{
@@ -266,17 +265,17 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 				return
 			}
 
-			var ( //nolint:dupl
-				cancelledJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateCancelled)})
-				completedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-				discardedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
+			var (
+				cancelledJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateCancelled)})
+				completedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateCompleted)})
+				discardedJob = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, State: new(rivertype.JobStateDiscarded)})
 
 				includedQueue1 = "included1"
 				includedQueue2 = "included2"
 
 				// Not deleted because in an omitted queue.
-				deletedJob1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &includedQueue1, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-				deletedJob2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &includedQueue2, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
+				deletedJob1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &includedQueue1, State: new(rivertype.JobStateCompleted)})
+				deletedJob2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, Queue: &includedQueue2, State: new(rivertype.JobStateCompleted)})
 			)
 
 			numDeleted, err := exec.JobDeleteBefore(ctx, &riverdriver.JobDeleteBeforeParams{
@@ -319,7 +318,7 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := time.Now().UTC()
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				Attempt:      ptrutil.Ptr(3),
+				Attempt:      new(3),
 				AttemptedAt:  &now,
 				CreatedAt:    &now,
 				EncodedArgs:  []byte(`{"encoded": "args"}`),
@@ -327,7 +326,7 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 				FinalizedAt:  &now,
 				Metadata:     []byte(`{"meta": "data"}`),
 				ScheduledAt:  &now,
-				State:        ptrutil.Ptr(rivertype.JobStateCompleted),
+				State:        new(rivertype.JobStateCompleted),
 				Tags:         []string{"tag"},
 				UniqueKey:    []byte("unique-key"),
 				UniqueStates: 0xFF,
@@ -377,7 +376,7 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			exec, _ := setup(ctx, t)
 
-			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning)})
 
 			deletedJobs, err := exec.JobDeleteMany(ctx, &riverdriver.JobDeleteManyParams{
 				Max:           100,
@@ -399,8 +398,8 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			{
 				var (
-					job1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind1")})
-					job2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind2")})
+					job1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("test_kind1")})
+					job2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("test_kind2")})
 				)
 
 				deletedJobs, err := exec.JobDeleteMany(ctx, &riverdriver.JobDeleteManyParams{
@@ -419,8 +418,8 @@ func exerciseJobDelete[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			{
 				var (
-					job1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind3")})
-					job2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind4")})
+					job1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("test_kind3")})
+					job2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("test_kind4")})
 				)
 
 				deletedJobs, err := exec.JobDeleteMany(ctx, &riverdriver.JobDeleteManyParams{

--- a/riverdriver/riverdrivertest/job_insert.go
+++ b/riverdriver/riverdrivertest/job_insert.go
@@ -20,7 +20,6 @@ import (
 	"github.com/riverqueue/river/riverdbtest"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -60,15 +59,15 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 			insertParams := make([]*riverdriver.JobInsertFastParams, 10)
 			for i := range insertParams {
 				insertParams[i] = &riverdriver.JobInsertFastParams{
-					ID:           ptrutil.Ptr(idStart + int64(i)),
-					CreatedAt:    ptrutil.Ptr(now.Add(time.Duration(i) * 5 * time.Second)),
+					ID:           new(idStart + int64(i)),
+					CreatedAt:    new(now.Add(time.Duration(i) * 5 * time.Second)),
 					EncodedArgs:  []byte(`{"encoded": "args"}`),
 					Kind:         "test_kind",
 					MaxAttempts:  rivercommon.MaxAttemptsDefault,
 					Metadata:     []byte(`{"meta": "data"}`),
 					Priority:     rivercommon.PriorityDefault,
 					Queue:        rivercommon.QueueDefault,
-					ScheduledAt:  ptrutil.Ptr(now.Add(time.Duration(i) * time.Minute)),
+					ScheduledAt:  new(now.Add(time.Duration(i) * time.Minute)),
 					State:        rivertype.JobStateAvailable,
 					Tags:         []string{"tag"},
 					UniqueKey:    []byte("unique-key-fast-many-" + strconv.Itoa(i)),
@@ -279,7 +278,7 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 			insertParams := make([]*riverdriver.JobInsertFastParams, 10)
 			for i := range insertParams {
 				insertParams[i] = &riverdriver.JobInsertFastParams{
-					CreatedAt:    ptrutil.Ptr(now.Add(time.Duration(i) * 5 * time.Second)),
+					CreatedAt:    new(now.Add(time.Duration(i) * 5 * time.Second)),
 					EncodedArgs:  []byte(`{"encoded": "args"}`),
 					Kind:         "test_kind",
 					MaxAttempts:  rivercommon.MaxAttemptsDefault,
@@ -471,7 +470,7 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 					Metadata:    []byte(`{"meta": "data"}`),
 					Priority:    rivercommon.PriorityDefault,
 					Queue:       rivercommon.QueueDefault,
-					ScheduledAt: ptrutil.Ptr(time.Now().UTC()),
+					ScheduledAt: new(time.Now().UTC()),
 					State:       rivertype.JobStateAvailable,
 					Tags:        []string{"tag"},
 				}
@@ -550,7 +549,7 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 			insertParams := make([]*riverdriver.JobInsertFastParams, 10)
 			for i := range insertParams {
 				insertParams[i] = &riverdriver.JobInsertFastParams{
-					CreatedAt:    ptrutil.Ptr(now.Add(time.Duration(i) * 5 * time.Second)),
+					CreatedAt:    new(now.Add(time.Duration(i) * 5 * time.Second)),
 					EncodedArgs:  []byte(`{"encoded": "args"}`),
 					Kind:         "test_kind",
 					MaxAttempts:  rivercommon.MaxAttemptsDefault,
@@ -711,7 +710,7 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 					// Create a job with the target state but with a finalized_at, expect
 					// no error:
 					_, err := exec.JobInsertFull(ctx, testfactory.Job_Build(t, &testfactory.JobOpts{
-						FinalizedAt: ptrutil.Ptr(time.Now()),
+						FinalizedAt: new(time.Now()),
 						State:       &state,
 					}))
 					require.NoError(t, err)
@@ -745,7 +744,7 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 					// Create a job with the target state but with a finalized_at, expect
 					// an error:
 					_, err := exec.JobInsertFull(ctx, testfactory.Job_Build(t, &testfactory.JobOpts{
-						FinalizedAt: ptrutil.Ptr(time.Now()),
+						FinalizedAt: new(time.Now()),
 						State:       &state,
 					}))
 					require.Error(t, err)
@@ -762,10 +761,10 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 		exec, bundle := setup(ctx, t)
 
 		jobParams1 := testfactory.Job_Build(t, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateCompleted),
+			State: new(rivertype.JobStateCompleted),
 		})
 		jobParams2 := testfactory.Job_Build(t, &testfactory.JobOpts{
-			State: ptrutil.Ptr(rivertype.JobStateRunning),
+			State: new(rivertype.JobStateRunning),
 		})
 
 		results, err := exec.JobInsertFullMany(ctx, &riverdriver.JobInsertFullManyParams{
@@ -849,7 +848,7 @@ func exerciseJobInsert[TTx any](ctx context.Context, t *testing.T,
 			Jobs: []*riverdriver.JobInsertFastParams{
 				{
 					EncodedArgs: []byte(`{"encoded": "fast-many"}`),
-					ID:          ptrutil.Ptr(idStart),
+					ID:          new(idStart),
 					Kind:        "test_kind",
 					MaxAttempts: rivercommon.MaxAttemptsDefault,
 					Metadata:    []byte(`{"meta": "fast-many"}`),

--- a/riverdriver/riverdrivertest/job_read.go
+++ b/riverdriver/riverdrivertest/job_read.go
@@ -13,7 +13,6 @@ import (
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
 	"github.com/riverqueue/river/rivertype"
 )
@@ -43,11 +42,11 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateDiscarded)})
 
 			countsByState, err := exec.JobCountByAllStates(ctx, &riverdriver.JobCountByAllStatesParams{
 				Schema: "",
@@ -91,15 +90,15 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue1"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue3"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue3"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue1"), State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue1"), State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue1"), State: new(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue1"), State: new(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue1"), State: new(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue2"), State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue2"), State: new(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue3"), State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue3"), State: new(rivertype.JobStateRunning)})
 
 			countsByQueue, err := exec.JobCountByQueueAndState(ctx, &riverdriver.JobCountByQueueAndStateParams{
 				QueueNames: []string{"queue1", "queue2"},
@@ -122,8 +121,8 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue2"), State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue2"), State: new(rivertype.JobStateRunning)})
 
 			countsByQueue, err := exec.JobCountByQueueAndState(ctx, &riverdriver.JobCountByQueueAndStateParams{
 				QueueNames: []string{"queue1", "queue2"},
@@ -147,8 +146,8 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: ptrutil.Ptr("queue2"), State: ptrutil.Ptr(rivertype.JobStateRunning)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue2"), State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Queue: new("queue2"), State: new(rivertype.JobStateRunning)})
 
 			countsByQueue, err := exec.JobCountByQueueAndState(ctx, &riverdriver.JobCountByQueueAndStateParams{
 				QueueNames: []string{"queue2", "queue1", "queue1"},
@@ -177,14 +176,14 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 			exec, _ := setup(ctx, t)
 
 			// Included because they're the queried state.
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
 
 			// Excluded because they're not.
-			finalizedAt := ptrutil.Ptr(time.Now())
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: finalizedAt, State: ptrutil.Ptr(rivertype.JobStateCancelled)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: finalizedAt, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: finalizedAt, State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
+			finalizedAt := new(time.Now())
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: finalizedAt, State: new(rivertype.JobStateCancelled)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: finalizedAt, State: new(rivertype.JobStateCompleted)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: finalizedAt, State: new(rivertype.JobStateDiscarded)})
 
 			numJobs, err := exec.JobCountByState(ctx, &riverdriver.JobCountByStateParams{
 				State: rivertype.JobStateAvailable,
@@ -259,7 +258,7 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 			exec, _ := setup(ctx, t)
 
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				Queue: ptrutil.Ptr("other-queue"),
+				Queue: new("other-queue"),
 			})
 
 			// Job is in a non-default queue so it's not found.
@@ -281,7 +280,7 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 			now := time.Now().UTC()
 
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				ScheduledAt: ptrutil.Ptr(now.Add(1 * time.Minute)),
+				ScheduledAt: new(now.Add(1 * time.Minute)),
 			})
 
 			// Job is scheduled a while from now so it's not found.
@@ -304,18 +303,18 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 			now := time.Now().Add(1 * time.Minute)
 			// Job 1 is scheduled after now so it's not found:
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				ScheduledAt: ptrutil.Ptr(now.Add(1 * time.Minute)),
+				ScheduledAt: new(now.Add(1 * time.Minute)),
 			})
 			// Job 2 is scheduled just before now so it's found:
 			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Microsecond)),
+				ScheduledAt: new(now.Add(-1 * time.Microsecond)),
 			})
 
 			jobRows, err := exec.JobGetAvailable(ctx, &riverdriver.JobGetAvailableParams{
 				ClientID:       testClientID,
 				MaxAttemptedBy: maxAttemptedBy,
 				MaxToLock:      maxToLock,
-				Now:            ptrutil.Ptr(now),
+				Now:            new(now),
 				Queue:          rivercommon.QueueDefault,
 			})
 			require.NoError(t, err)
@@ -494,11 +493,11 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 		exec, _ := setup(ctx, t)
 
-		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("kind1")})
-		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("kind2")})
+		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("kind1")})
+		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("kind2")})
 
 		// Not returned.
-		_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("kind3")})
+		_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("kind3")})
 
 		jobs, err := exec.JobGetByKindMany(ctx, &riverdriver.JobGetByKindManyParams{
 			Kind: []string{job1.Kind, job2.Kind},
@@ -519,8 +518,8 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 			afterHorizon  = horizon.Add(1 * time.Minute)
 		)
 
-		stuckJob1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		stuckJob2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		stuckJob1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &beforeHorizon, State: new(rivertype.JobStateRunning)})
+		stuckJob2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &beforeHorizon, State: new(rivertype.JobStateRunning)})
 
 		t.Logf("horizon   = %s", horizon)
 		t.Logf("stuckJob1 = %s", stuckJob1.AttemptedAt)
@@ -529,13 +528,13 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 		t.Logf("stuckJob1 full = %s", spew.Sdump(stuckJob1))
 
 		// Not returned on the first page because we put a maximum of two.
-		stuckJob3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		stuckJob3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &beforeHorizon, State: new(rivertype.JobStateRunning)})
 
 		// Not stuck because not in running state.
-		_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
 
 		// Not stuck because after queried horizon.
-		_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &afterHorizon, State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{AttemptedAt: &afterHorizon, State: new(rivertype.JobStateRunning)})
 
 		// Max two stuck
 		stuckJobs, err := exec.JobGetStuck(ctx, &riverdriver.JobGetStuckParams{
@@ -564,10 +563,10 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("job_zzz")})
-			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("job_aaa")})
-			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("job_bbb")})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("different_prefix_job")})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("job_zzz")})
+			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("job_aaa")})
+			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("job_bbb")})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("different_prefix_job")})
 
 			jobKinds, err := exec.JobKindList(ctx, &riverdriver.JobKindListParams{
 				After:   "job2",
@@ -585,9 +584,9 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("job_zzz")})
-			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("job_aaa")})
-			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("job_bbb")})
+			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("job_zzz")})
+			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("job_aaa")})
+			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("job_bbb")})
 
 			jobKinds, err := exec.JobKindList(ctx, &riverdriver.JobKindListParams{
 				After:   "job2",
@@ -605,10 +604,10 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("mid_job_kind")})
-			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("prefix_job")})
-			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("suffix_job")})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("nojobhere")})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("mid_job_kind")})
+			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("prefix_job")})
+			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("suffix_job")})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("nojobhere")})
 
 			jobKinds, err := exec.JobKindList(ctx, &riverdriver.JobKindListParams{
 				After:   "",
@@ -633,7 +632,7 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 			now := time.Now().UTC()
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				Attempt:      ptrutil.Ptr(3),
+				Attempt:      new(3),
 				AttemptedAt:  &now,
 				CreatedAt:    &now,
 				EncodedArgs:  []byte(`{"encoded": "args"}`),
@@ -641,7 +640,7 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 				FinalizedAt:  &now,
 				Metadata:     []byte(`{"meta": "data"}`),
 				ScheduledAt:  &now,
-				State:        ptrutil.Ptr(rivertype.JobStateCompleted),
+				State:        new(rivertype.JobStateCompleted),
 				Tags:         []string{"tag"},
 				UniqueKey:    []byte("unique-key"),
 				UniqueStates: 0xFF,
@@ -684,8 +683,8 @@ func exerciseJobRead[TTx any](ctx context.Context, t *testing.T, executorWithTx 
 
 			exec, _ := setup(ctx, t)
 
-			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind1")})
-			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("test_kind2")})
+			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("test_kind1")})
+			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("test_kind2")})
 
 			{
 				fetchedJobs, err := exec.JobList(ctx, &riverdriver.JobListParams{

--- a/riverdriver/riverdrivertest/job_update.go
+++ b/riverdriver/riverdrivertest/job_update.go
@@ -16,7 +16,6 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
 	"github.com/riverqueue/river/rivershared/uniquestates"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -86,7 +85,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			nowStr := now.Format(time.RFC3339Nano)
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State:     ptrutil.Ptr(rivertype.JobStateRunning),
+				State:     new(rivertype.JobStateRunning),
 				UniqueKey: []byte("unique-key"),
 			})
 			require.Equal(t, rivertype.JobStateRunning, job.State)
@@ -115,7 +114,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 				exec, _ := setup(ctx, t)
 
 				job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-					FinalizedAt: ptrutil.Ptr(time.Now()),
+					FinalizedAt: new(time.Now()),
 					State:       &startingState,
 				})
 
@@ -155,11 +154,11 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 			Metadata: []byte(`{"river:rescue_count": 5, "something": "else"}`),
-			State:    ptrutil.Ptr(rivertype.JobStateRunning),
+			State:    new(rivertype.JobStateRunning),
 		})
 		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 			Metadata: []byte(`{}`),
-			State:    ptrutil.Ptr(rivertype.JobStateRunning),
+			State:    new(rivertype.JobStateRunning),
 		})
 
 		_, err := exec.JobRescueMany(ctx, &riverdriver.JobRescueManyParams{
@@ -213,7 +212,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			exec, _ := setup(ctx, t)
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State: ptrutil.Ptr(rivertype.JobStateRunning),
+				State: new(rivertype.JobStateRunning),
 			})
 
 			jobAfter, err := exec.JobRetry(ctx, &riverdriver.JobRetryParams{
@@ -257,7 +256,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 				job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 					FinalizedAt: finalizedAt,
-					ScheduledAt: ptrutil.Ptr(now.Add(1 * time.Hour)),
+					ScheduledAt: new(now.Add(1 * time.Hour)),
 					State:       &state,
 				})
 
@@ -290,8 +289,8 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				FinalizedAt: &now,
-				ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour)),
-				State:       ptrutil.Ptr(rivertype.JobStateCompleted),
+				ScheduledAt: new(now.Add(-1 * time.Hour)),
+				State:       new(rivertype.JobStateCompleted),
 			})
 
 			jobAfter, err := exec.JobRetry(ctx, &riverdriver.JobRetryParams{
@@ -313,7 +312,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := time.Now().UTC()
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				ScheduledAt: ptrutil.Ptr(now.Add(-1 * time.Hour)),
+				ScheduledAt: new(now.Add(-1 * time.Hour)),
 			})
 
 			jobAfter, err := exec.JobRetry(ctx, &riverdriver.JobRetryParams{
@@ -354,18 +353,18 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 				afterHorizon  = horizon.Add(1 * time.Minute)
 			)
 
-			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateRetryable)})
-			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateScheduled)})
-			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateScheduled)})
+			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: new(rivertype.JobStateRetryable)})
+			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: new(rivertype.JobStateScheduled)})
+			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: new(rivertype.JobStateScheduled)})
 
 			// States that aren't scheduled.
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateAvailable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, ScheduledAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateCompleted)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, ScheduledAt: &beforeHorizon, State: ptrutil.Ptr(rivertype.JobStateDiscarded)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &beforeHorizon, State: new(rivertype.JobStateAvailable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, ScheduledAt: &beforeHorizon, State: new(rivertype.JobStateCompleted)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{FinalizedAt: &beforeHorizon, ScheduledAt: &beforeHorizon, State: new(rivertype.JobStateDiscarded)})
 
 			// Right state, but after horizon.
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &afterHorizon, State: ptrutil.Ptr(rivertype.JobStateRetryable)})
-			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &afterHorizon, State: ptrutil.Ptr(rivertype.JobStateScheduled)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &afterHorizon, State: new(rivertype.JobStateRetryable)})
+			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{ScheduledAt: &afterHorizon, State: new(rivertype.JobStateScheduled)})
 
 			// First two scheduled because of limit.
 			result, err := exec.JobSchedule(ctx, &riverdriver.JobScheduleParams{
@@ -429,13 +428,13 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
-				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
+				State:        new(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-1"),
 				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
-				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
+				State:        new(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-2"),
 				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
@@ -443,7 +442,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			// scheduled.
 			job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
-				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
+				State:        new(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-3"),
 				UniqueStates: uniquestates.UniqueStatesToBitmask(defaultUniqueStates),
 			})
@@ -452,7 +451,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			// the same unique properties:
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
-				State:        ptrutil.Ptr(rivertype.JobStateRunning),
+				State:        new(rivertype.JobStateRunning),
 				UniqueKey:    []byte("unique-key-1"),
 				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
@@ -460,7 +459,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			// isn't in the unique states:
 			_ = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
-				State:        ptrutil.Ptr(rivertype.JobStateCompleted),
+				State:        new(rivertype.JobStateCompleted),
 				UniqueKey:    []byte("unique-key-2"),
 				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
@@ -508,13 +507,13 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
-				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
+				State:        new(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-1"),
 				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
 			job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				ScheduledAt:  &beforeHorizon,
-				State:        ptrutil.Ptr(rivertype.JobStateRetryable),
+				State:        new(rivertype.JobStateRetryable),
 				UniqueKey:    []byte("unique-key-1"),
 				UniqueStates: uniquestates.UniqueStatesToBitmask(nonRetryableUniqueStates),
 			})
@@ -594,7 +593,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := precisionTestTime
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State:     ptrutil.Ptr(rivertype.JobStateRunning),
+				State:     new(rivertype.JobStateRunning),
 				UniqueKey: []byte("unique-key"),
 			})
 
@@ -618,7 +617,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := time.Now().UTC()
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State:     ptrutil.Ptr(rivertype.JobStateRetryable),
+				State:     new(rivertype.JobStateRetryable),
 				UniqueKey: []byte("unique-key"),
 			})
 
@@ -643,7 +642,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				Metadata:  []byte(`{"foo":"baz", "something":"else"}`),
-				State:     ptrutil.Ptr(rivertype.JobStateRunning),
+				State:     new(rivertype.JobStateRunning),
 				UniqueKey: []byte("unique-key"),
 			})
 
@@ -679,7 +678,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := precisionTestTime
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State:     ptrutil.Ptr(rivertype.JobStateRunning),
+				State:     new(rivertype.JobStateRunning),
 				UniqueKey: []byte("unique-key"),
 			})
 
@@ -711,9 +710,9 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			attempt := 2
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				Attempt:     ptrutil.Ptr(3),
-				MaxAttempts: ptrutil.Ptr(3),
-				State:       ptrutil.Ptr(rivertype.JobStateRunning),
+				Attempt:     new(3),
+				MaxAttempts: new(3),
+				State:       new(rivertype.JobStateRunning),
 				UniqueKey:   []byte("unique-key"),
 			})
 
@@ -744,8 +743,8 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := time.Now().UTC()
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State:       ptrutil.Ptr(rivertype.JobStateRetryable),
-				ScheduledAt: ptrutil.Ptr(now.Add(10 * time.Second)),
+				State:       new(rivertype.JobStateRetryable),
+				ScheduledAt: new(now.Add(10 * time.Second)),
 			})
 
 			jobsAfter, err := exec.JobSetStateIfRunningMany(ctx, setStateManyParams(riverdriver.JobSetStateErrorRetryable(job.ID, now, makeErrPayload(t, now), nil)))
@@ -769,8 +768,8 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 
 			job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 				Metadata:    []byte(`{"baz":"qux", "foo":"bar"}`),
-				State:       ptrutil.Ptr(rivertype.JobStateRetryable),
-				ScheduledAt: ptrutil.Ptr(now.Add(10 * time.Second)),
+				State:       new(rivertype.JobStateRetryable),
+				ScheduledAt: new(now.Add(10 * time.Second)),
 			})
 
 			jobsAfter, err := exec.JobSetStateIfRunningMany(ctx, setStateManyParams(
@@ -815,8 +814,8 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 					now := time.Now().UTC()
 					job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
 						Metadata:    fmt.Appendf(nil, `{"cancel_attempted_at":"%s"}`, time.Now().UTC().Format(time.RFC3339)),
-						State:       ptrutil.Ptr(rivertype.JobStateRunning),
-						ScheduledAt: ptrutil.Ptr(now.Add(-10 * time.Second)),
+						State:       new(rivertype.JobStateRunning),
+						ScheduledAt: new(now.Add(-10 * time.Second)),
 					})
 
 					jobsAfter, err := exec.JobSetStateIfRunningMany(ctx, setStateManyParams(test.setStateFunc(job.ID, now, makeErrPayload(t, now), nil)))
@@ -850,7 +849,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := time.Now().UTC()
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State:        ptrutil.Ptr(rivertype.JobStateRunning),
+				State:        new(rivertype.JobStateRunning),
 				UniqueKey:    []byte("unique-key"),
 				UniqueStates: 0xFF,
 			})
@@ -879,7 +878,7 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			now := time.Now().UTC()
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				State:        ptrutil.Ptr(rivertype.JobStateRunning),
+				State:        new(rivertype.JobStateRunning),
 				UniqueKey:    []byte("unique-key"),
 				UniqueStates: 0xFF,
 			})
@@ -910,8 +909,8 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			snoozeUntil := now.Add(1 * time.Minute)
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				Attempt:   ptrutil.Ptr(5),
-				State:     ptrutil.Ptr(rivertype.JobStateRunning),
+				Attempt:   new(5),
+				State:     new(rivertype.JobStateRunning),
 				UniqueKey: []byte("unique-key"),
 			})
 
@@ -942,8 +941,8 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 			snoozeUntil := now.Add(1 * time.Minute)
 
 			job := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{
-				Attempt:   ptrutil.Ptr(5),
-				State:     ptrutil.Ptr(rivertype.JobStateRunning),
+				Attempt:   new(5),
+				State:     new(rivertype.JobStateRunning),
 				UniqueKey: []byte("unique-key"),
 				Metadata:  []byte(`{"foo": "bar", "snoozes": 5}`),
 			})
@@ -975,9 +974,9 @@ func exerciseJobUpdate[TTx any](ctx context.Context, t *testing.T, executorWithT
 		now := time.Now().UTC()
 		future := now.Add(10 * time.Second)
 
-		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
-		job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRunning)})
+		job1 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning)})
+		job2 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning)})
+		job3 := testfactory.Job(ctx, t, exec, &testfactory.JobOpts{State: new(rivertype.JobStateRunning)})
 
 		jobsAfter, err := exec.JobSetStateIfRunningMany(ctx, setStateManyParams(
 			riverdriver.JobSetStateCompleted(0, now, nil),

--- a/riverdriver/riverdrivertest/leader.go
+++ b/riverdriver/riverdrivertest/leader.go
@@ -10,7 +10,6 @@ import (
 	"github.com/riverqueue/river/internal/notifier"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -72,7 +71,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			exec, _ := setup(ctx, t)
 
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				LeaderID: ptrutil.Ptr(testClientID),
+				LeaderID: new(testClientID),
 			})
 
 			leaderAttempt, err := exec.LeaderAttemptElect(ctx, &riverdriver.LeaderElectParams{
@@ -118,7 +117,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			exec, _ := setup(ctx, t)
 
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				LeaderID: ptrutil.Ptr("other-client-id"),
+				LeaderID: new("other-client-id"),
 			})
 
 			updatedLeader, err := exec.LeaderAttemptReelect(ctx, &riverdriver.LeaderReelectParams{
@@ -141,7 +140,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			exec, bundle := setup(ctx, t)
 
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				LeaderID: ptrutil.Ptr(testClientID),
+				LeaderID: new(testClientID),
 			})
 
 			// Re-elect the same leader. Use a larger TTL to see if time is updated,
@@ -171,9 +170,9 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 
 			now := time.Now().UTC()
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				ElectedAt: ptrutil.Ptr(now.Add(-2 * time.Hour)),
-				ExpiresAt: ptrutil.Ptr(now.Add(-1 * time.Hour)),
-				LeaderID:  ptrutil.Ptr(testClientID),
+				ElectedAt: new(now.Add(-2 * time.Hour)),
+				ExpiresAt: new(now.Add(-1 * time.Hour)),
+				LeaderID:  new(testClientID),
 			})
 
 			updatedLeader, err := exec.LeaderAttemptReelect(ctx, &riverdriver.LeaderReelectParams{
@@ -196,7 +195,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			exec, _ := setup(ctx, t)
 
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				LeaderID: ptrutil.Ptr(testClientID),
+				LeaderID: new(testClientID),
 			})
 
 			updatedLeader, err := exec.LeaderAttemptReelect(ctx, &riverdriver.LeaderReelectParams{
@@ -218,7 +217,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			exec, bundle := setup(ctx, t)
 
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				LeaderID: ptrutil.Ptr(testClientID),
+				LeaderID: new(testClientID),
 			})
 
 			updatedLeader, err := exec.LeaderAttemptReelect(ctx, &riverdriver.LeaderReelectParams{
@@ -254,9 +253,9 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			}
 
 			_ = testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				ElectedAt: ptrutil.Ptr(now.Add(-2 * time.Hour)),
-				ExpiresAt: ptrutil.Ptr(now.Add(-1 * time.Hour)),
-				LeaderID:  ptrutil.Ptr(testClientID),
+				ElectedAt: new(now.Add(-2 * time.Hour)),
+				ExpiresAt: new(now.Add(-1 * time.Hour)),
+				LeaderID:  new(testClientID),
 			})
 
 			{
@@ -275,13 +274,13 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 
 			// Elected in the future.
 			_ = testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				ElectedAt: ptrutil.Ptr(now.Add(1 * time.Hour)),
-				ExpiresAt: ptrutil.Ptr(now.Add(2 * time.Hour)),
-				LeaderID:  ptrutil.Ptr(testClientID),
+				ElectedAt: new(now.Add(1 * time.Hour)),
+				ExpiresAt: new(now.Add(2 * time.Hour)),
+				LeaderID:  new(testClientID),
 			})
 
 			numDeleted, err := exec.LeaderDeleteExpired(ctx, &riverdriver.LeaderDeleteExpiredParams{
-				Now: ptrutil.Ptr(now.Add(2*time.Hour + 1*time.Second)),
+				Now: new(now.Add(2*time.Hour + 1*time.Second)),
 			})
 			require.NoError(t, err)
 			require.Equal(t, 1, numDeleted)
@@ -337,7 +336,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 		now := time.Now().UTC()
 
 		_ = testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-			LeaderID: ptrutil.Ptr(testClientID),
+			LeaderID: new(testClientID),
 			Now:      &now,
 		})
 
@@ -367,7 +366,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			}
 
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				LeaderID: ptrutil.Ptr(testClientID),
+				LeaderID: new(testClientID),
 			})
 
 			{
@@ -387,7 +386,7 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			exec, _ := setup(ctx, t)
 
 			leader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				LeaderID: ptrutil.Ptr("other-client-id"),
+				LeaderID: new("other-client-id"),
 			})
 
 			resigned, err := exec.LeaderResign(ctx, &riverdriver.LeaderResignParams{
@@ -407,9 +406,9 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			now := time.Now().UTC()
 
 			oldLeader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				ElectedAt: ptrutil.Ptr(now.Add(-2 * time.Hour)),
-				ExpiresAt: ptrutil.Ptr(now.Add(-1 * time.Hour)),
-				LeaderID:  ptrutil.Ptr(testClientID),
+				ElectedAt: new(now.Add(-2 * time.Hour)),
+				ExpiresAt: new(now.Add(-1 * time.Hour)),
+				LeaderID:  new(testClientID),
 			})
 
 			numDeleted, err := exec.LeaderDeleteExpired(ctx, &riverdriver.LeaderDeleteExpiredParams{Now: &now})
@@ -417,8 +416,8 @@ func exerciseLeader[TTx any](ctx context.Context, t *testing.T, executorWithTx f
 			require.Equal(t, 1, numDeleted)
 
 			newLeader := testfactory.Leader(ctx, t, exec, &testfactory.LeaderOpts{
-				ElectedAt: ptrutil.Ptr(now),
-				LeaderID:  ptrutil.Ptr(testClientID),
+				ElectedAt: new(now),
+				LeaderID:  new(testClientID),
 			})
 
 			resigned, err := exec.LeaderResign(ctx, &riverdriver.LeaderResignParams{

--- a/riverdriver/riverdrivertest/migration.go
+++ b/riverdriver/riverdrivertest/migration.go
@@ -14,7 +14,6 @@ import (
 	"github.com/riverqueue/river/rivermigrate"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 )
 
 func exerciseMigration[TTx any](ctx context.Context, t *testing.T,
@@ -189,7 +188,7 @@ func exerciseMigration[TTx any](ctx context.Context, t *testing.T,
 		}
 
 		_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{
-			Name:   ptrutil.Ptr("default"),
+			Name:   new("default"),
 			Schema: schema,
 		})
 
@@ -291,8 +290,8 @@ func exerciseMigration[TTx any](ctx context.Context, t *testing.T,
 		// not touched
 		_ = testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{})
 
-		migration1 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: ptrutil.Ptr("alternate")})
-		migration2 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: ptrutil.Ptr("alternate")})
+		migration1 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: new("alternate")})
+		migration2 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: new("alternate")})
 
 		migrations, err := exec.MigrationDeleteByLineAndVersionMany(ctx, &riverdriver.MigrationDeleteByLineAndVersionManyParams{
 			Line: "alternate",
@@ -371,8 +370,8 @@ func exerciseMigration[TTx any](ctx context.Context, t *testing.T,
 		// not returned
 		_ = testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{})
 
-		migration1 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: ptrutil.Ptr("alternate")})
-		migration2 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: ptrutil.Ptr("alternate")})
+		migration1 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: new("alternate")})
+		migration2 := testfactory.Migration(ctx, t, exec, &testfactory.MigrationOpts{Line: new("alternate")})
 
 		migrations, err := exec.MigrationGetByLine(ctx, &riverdriver.MigrationGetByLineParams{
 			Line: "alternate",

--- a/riverdriver/riverdrivertest/queue.go
+++ b/riverdriver/riverdrivertest/queue.go
@@ -11,7 +11,6 @@ import (
 	"github.com/riverqueue/river/internal/rivercommon"
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -71,7 +70,7 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 			now := time.Now().UTC().Add(-5 * time.Minute)
 			queue, err := exec.QueueCreateOrSetUpdatedAt(ctx, &riverdriver.QueueCreateOrSetUpdatedAtParams{
 				Name:     "new-queue",
-				PausedAt: ptrutil.Ptr(now),
+				PausedAt: new(now),
 			})
 			require.NoError(t, err)
 			require.Equal(t, "new-queue", queue.Name)
@@ -118,11 +117,11 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 		exec, _ := setup(ctx, t)
 
 		now := time.Now()
-		_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: ptrutil.Ptr(now)})
-		queue2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: ptrutil.Ptr(now.Add(-25 * time.Hour))})
-		queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: ptrutil.Ptr(now.Add(-26 * time.Hour))})
-		queue4 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: ptrutil.Ptr(now.Add(-48 * time.Hour))})
-		_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: ptrutil.Ptr(now.Add(-23 * time.Hour))})
+		_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: new(now)})
+		queue2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: new(now.Add(-25 * time.Hour))})
+		queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: new(now.Add(-26 * time.Hour))})
+		queue4 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: new(now.Add(-48 * time.Hour))})
+		_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{UpdatedAt: new(now.Add(-23 * time.Hour))})
 
 		horizon := now.Add(-24 * time.Hour)
 		deletedQueueNames, err := exec.QueueDeleteExpired(ctx, &riverdriver.QueueDeleteExpiredParams{Max: 2, UpdatedAtHorizon: horizon})
@@ -188,7 +187,7 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 		require.Empty(t, queues)
 
 		// Make queue1, already paused:
-		queue1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Metadata: []byte(`{"foo": "bar"}`), PausedAt: ptrutil.Ptr(time.Now())})
+		queue1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Metadata: []byte(`{"foo": "bar"}`), PausedAt: new(time.Now())})
 		require.NoError(t, err)
 
 		queue2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{})
@@ -220,10 +219,10 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 
 			exec, _ := setup(ctx, t)
 
-			_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue_zzz")})
-			queue2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue_aaa")})
-			queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue_bbb")})
-			_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("different_prefix_queue")})
+			_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("queue_zzz")})
+			queue2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("queue_aaa")})
+			queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("queue_bbb")})
+			_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("different_prefix_queue")})
 
 			queueNames, err := exec.QueueNameList(ctx, &riverdriver.QueueNameListParams{
 				After:   "queue2",
@@ -241,9 +240,9 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 
 			exec, _ := setup(ctx, t)
 
-			queue1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue_zzz")})
-			queue2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue_aaa")})
-			queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("queue_bbb")})
+			queue1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("queue_zzz")})
+			queue2 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("queue_aaa")})
+			queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("queue_bbb")})
 
 			queueNames, err := exec.QueueNameList(ctx, &riverdriver.QueueNameListParams{
 				After:   "queue2",
@@ -261,9 +260,9 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 
 			exec, _ := setup(ctx, t)
 
-			queue1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("prefix_queue")})
-			_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("another_queue")})
-			queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: ptrutil.Ptr("suffix_queue")})
+			queue1 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("prefix_queue")})
+			_ = testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("another_queue")})
+			queue3 := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{Name: new("suffix_queue")})
 
 			queueNames, err := exec.QueueNameList(ctx, &riverdriver.QueueNameListParams{
 				After:   "",
@@ -312,7 +311,7 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 			now := time.Now().UTC()
 
 			queue := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{
-				UpdatedAt: ptrutil.Ptr(now.Add(-5 * time.Minute)),
+				UpdatedAt: new(now.Add(-5 * time.Minute)),
 			})
 			require.Nil(t, queue.PausedAt)
 
@@ -393,8 +392,8 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 			now := time.Now().UTC()
 
 			queue := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{
-				PausedAt:  ptrutil.Ptr(now.Add(-5 * time.Minute)),
-				UpdatedAt: ptrutil.Ptr(now.Add(-5 * time.Minute)),
+				PausedAt:  new(now.Add(-5 * time.Minute)),
+				UpdatedAt: new(now.Add(-5 * time.Minute)),
 			})
 
 			require.NoError(t, exec.QueueResume(ctx, &riverdriver.QueueResumeParams{
@@ -418,7 +417,7 @@ func exerciseQueue[TTx any](ctx context.Context, t *testing.T, executorWithTx fu
 			now := time.Now().UTC()
 
 			queue := testfactory.Queue(ctx, t, exec, &testfactory.QueueOpts{
-				UpdatedAt: ptrutil.Ptr(now.Add(-5 * time.Minute)),
+				UpdatedAt: new(now.Add(-5 * time.Minute)),
 			})
 
 			require.NoError(t, exec.QueueResume(ctx, &riverdriver.QueueResumeParams{

--- a/riverdriver/riverdrivertest/riverdrivertest.go
+++ b/riverdriver/riverdrivertest/riverdrivertest.go
@@ -99,8 +99,7 @@ func exerciseDriverPool[TTx any](ctx context.Context, t *testing.T,
 func requireMissingRelation(t *testing.T, err error, schema, missingRelation string) {
 	t.Helper()
 
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		require.Equal(t, pgerrcode.UndefinedTable, pgErr.Code)
 		require.Equal(t, fmt.Sprintf(`relation "%s.%s" does not exist`, schema, missingRelation), pgErr.Message)
 	} else {

--- a/riverdriver/riverdrivertest/sql_fragments.go
+++ b/riverdriver/riverdrivertest/sql_fragments.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 )
 
 func exerciseSQLFragments[TTx any](ctx context.Context, t *testing.T, executorWithTx func(ctx context.Context, t *testing.T) (riverdriver.Executor, riverdriver.Driver[TTx])) {
@@ -102,9 +101,9 @@ func exerciseSQLFragments[TTx any](ctx context.Context, t *testing.T, executorWi
 			exec, driver := executorWithTx(ctx, t)
 
 			var (
-				job1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("kind1")})
-				job2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("kind2")})
-				_    = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: ptrutil.Ptr("kind3")})
+				job1 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("kind1")})
+				job2 = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("kind2")})
+				_    = testfactory.Job(ctx, t, exec, &testfactory.JobOpts{Kind: new("kind3")})
 			)
 
 			sqlFragment, arg, err := driver.SQLFragmentColumnIn("kind", []string{job1.Kind, job2.Kind})

--- a/riverdriver/riversqlite/river_sqlite_driver.go
+++ b/riverdriver/riversqlite/river_sqlite_driver.go
@@ -46,7 +46,6 @@ import (
 	"github.com/riverqueue/river/rivershared/sqlctemplate"
 	"github.com/riverqueue/river/rivershared/uniquestates"
 	"github.com/riverqueue/river/rivershared/util/dbutil"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivershared/util/randutil"
 	"github.com/riverqueue/river/rivershared/util/savepointutil"
 	"github.com/riverqueue/river/rivershared/util/sliceutil"
@@ -643,7 +642,7 @@ func (e *Executor) JobInsertFull(ctx context.Context, params *riverdriver.JobIns
 
 	var uniqueStates *int64
 	if params.UniqueStates != 0 {
-		uniqueStates = ptrutil.Ptr(int64(params.UniqueStates))
+		uniqueStates = new(int64(params.UniqueStates))
 	}
 
 	job, err := dbsqlc.New().JobInsertFull(schemaTemplateParam(ctx, params.Schema), e.dbtx, &dbsqlc.JobInsertFullParams{

--- a/riverdriver/riversqlite/river_sqlite_driver_test.go
+++ b/riverdriver/riversqlite/river_sqlite_driver_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/sqlctemplate"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -45,9 +44,9 @@ func TestTimeStringNullable(t *testing.T) {
 	t.Parallel()
 
 	require.Nil(t, timeStringNullable(nil))
-	require.Equal(t, "2025-04-30 13:26:39.100", *timeStringNullable(ptrutil.Ptr(time.Date(2025, 4, 30, 13, 26, 39, 100000000, time.UTC))))
-	require.Equal(t, "2025-04-30 13:26:39.123", *timeStringNullable(ptrutil.Ptr(time.Date(2025, 4, 30, 13, 26, 39, 123456789, time.UTC))))
-	require.Equal(t, "2025-04-30 13:26:39.124", *timeStringNullable(ptrutil.Ptr(time.Date(2025, 4, 30, 13, 26, 39, 123800000, time.UTC)))) // test rounding
+	require.Equal(t, "2025-04-30 13:26:39.100", *timeStringNullable(new(time.Date(2025, 4, 30, 13, 26, 39, 100000000, time.UTC))))
+	require.Equal(t, "2025-04-30 13:26:39.123", *timeStringNullable(new(time.Date(2025, 4, 30, 13, 26, 39, 123456789, time.UTC))))
+	require.Equal(t, "2025-04-30 13:26:39.124", *timeStringNullable(new(time.Date(2025, 4, 30, 13, 26, 39, 123800000, time.UTC)))) // test rounding
 }
 
 func TestSchemaTemplateParam(t *testing.T) {

--- a/rivershared/structtag/struct_tag.go
+++ b/rivershared/structtag/struct_tag.go
@@ -103,9 +103,7 @@ func sortedFieldsWithTagUncached(typ reflect.Type, tagValue string, path []strin
 	var uniqueFields []string
 
 	// Iterate over all fields
-	for i := range typ.NumField() {
-		field := typ.Field(i)
-
+	for field := range typ.Fields() {
 		if !field.IsExported() {
 			continue
 		}

--- a/rivershared/testfactory/test_factory.go
+++ b/rivershared/testfactory/test_factory.go
@@ -58,7 +58,7 @@ func Job_Build(tb testing.TB, opts *JobOpts) *riverdriver.JobInsertFullParams {
 		rivertype.JobStateRetryable,
 		rivertype.JobStateRunning,
 	}, *opts.State)) {
-		attemptedAt = ptrutil.Ptr(time.Now())
+		attemptedAt = new(time.Now())
 	}
 
 	encodedArgs := opts.EncodedArgs
@@ -72,7 +72,7 @@ func Job_Build(tb testing.TB, opts *JobOpts) *riverdriver.JobInsertFullParams {
 		rivertype.JobStateCancelled,
 		rivertype.JobStateDiscarded,
 	}, *opts.State)) {
-		finalizedAt = ptrutil.Ptr(time.Now())
+		finalizedAt = new(time.Now())
 	}
 
 	metadata := opts.Metadata

--- a/rivershared/util/ptrutil/ptr_util.go
+++ b/rivershared/util/ptrutil/ptr_util.go
@@ -1,8 +1,10 @@
 package ptrutil
 
 // Ptr returns a pointer to the given value.
+//
+// Deprecated: use new(value) instead.
 func Ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 // ValOrDefault returns the value of the given pointer as long as it's non-nil,

--- a/rivertest/worker.go
+++ b/rivertest/worker.go
@@ -18,7 +18,6 @@ import (
 	"github.com/riverqueue/river/riverdriver"
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -162,7 +161,7 @@ func (w *Worker[T, TTx]) workJob(ctx context.Context, tb testing.TB, tx TTx, job
 		ID:                  job.ID,
 		Attempt:             job.Attempt + 1,
 		AttemptDoUpdate:     true,
-		AttemptedAt:         ptrutil.Ptr(timeGen.Now()),
+		AttemptedAt:         new(timeGen.Now()),
 		AttemptedAtDoUpdate: true,
 		AttemptedBy:         append(job.AttemptedBy, w.config.ID),
 		AttemptedByDoUpdate: true,

--- a/rivertest/worker_test.go
+++ b/rivertest/worker_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/riverqueue/river/rivershared/baseservice"
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -619,8 +618,8 @@ func TestWorker_WorkJob(t *testing.T) {
 
 		job := testfactory.Job(ctx, t, bundle.driver.UnwrapExecutor(bundle.tx), &testfactory.JobOpts{
 			EncodedArgs: []byte(`{"value": "test"}`),
-			Kind:        ptrutil.Ptr("rivertest_work_test"),
-			State:       ptrutil.Ptr(rivertype.JobStateCompleted),
+			Kind:        new("rivertest_work_test"),
+			State:       new(rivertype.JobStateCompleted),
 		})
 
 		res, err := testWorker.WorkJob(ctx, t, bundle.tx, job)

--- a/subscription_manager_test.go
+++ b/subscription_manager_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/riverqueue/river/rivershared/riversharedtest"
 	"github.com/riverqueue/river/rivershared/startstoptest"
 	"github.com/riverqueue/river/rivershared/testfactory"
-	"github.com/riverqueue/river/rivershared/util/ptrutil"
 	"github.com/riverqueue/river/rivertype"
 )
 
@@ -64,11 +63,11 @@ func Test_SubscriptionManager(t *testing.T) {
 		t.Cleanup(cancelSub)
 
 		// Send some events
-		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCompleted), FinalizedAt: ptrutil.Ptr(time.Now())})
-		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateCancelled), FinalizedAt: ptrutil.Ptr(time.Now())})
-		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateRetryable)})
-		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateScheduled)})
-		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: ptrutil.Ptr(rivertype.JobStateAvailable)})
+		job1 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCompleted), FinalizedAt: new(time.Now())})
+		job2 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateCancelled), FinalizedAt: new(time.Now())})
+		job3 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateRetryable)})
+		job4 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateScheduled)})
+		job5 := testfactory.Job(ctx, t, bundle.exec, &testfactory.JobOpts{State: new(rivertype.JobStateAvailable)})
 
 		makeStats := func(complete, wait, run time.Duration) *jobstats.JobStatistics {
 			return &jobstats.JobStatistics{


### PR DESCRIPTION
Follows up #1356 to bring back in some modernizers that I'd disabled to
not make the diff for that original PR gigantic.

In particular:

* `errorsastype`: Requires the use of the new `errors.AsType` helper.
  This is a really nice one and turns this old code:

        var pgErr *pgconn.PgError
        if errors.As(err, &pgErr) {

    Into this much nicer generics variant:

        if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {

* `newexpr`: Converts pointer helpers like `ptrutil.Ptr(...)` to `new`.
  I remove all uses of `ptrutil.Ptr(...)`, but left its definition in
  `rivershared` for now because I think it'll allow a little more
  flexibility in what version of River a River Pro installation can use.
  For example, an older version of River Pro could potentially point to
  a newer version of River and still have compilation work (it has
  however been marked as deprecated). I doubt too many people are in
  this situation though so we can probably remove it soon.

* `stditerators`: Replaces some manual iteration patterns with newer
  standard library iterator APIs. For example this:

        for i := range typ.NumField() {
            field := typ.Field(i)

    Goes to this:

        for field := range typ.Fields() {[27;5;106~