### PR TITLE
Add back more non-listener coverage for `riverdatabasesql`

### DIFF
--- a/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
+++ b/riverdriver/riverdatabasesql/river_database_sql_driver_test.go
@@ -20,7 +20,7 @@ var _ riverdriver.Driver[*sql.Tx] = New(nil)
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	t.Run("AllowsNilDatabasePool", func(t *testing.T) {
+	t.Run("DatabasePool", func(t *testing.T) {
 		t.Parallel()
 
 		dbPool := &sql.DB{}
@@ -28,11 +28,23 @@ func TestNew(t *testing.T) {
 		require.Equal(t, dbPool, driver.dbPool)
 	})
 
-	t.Run("AllowsNilDatabasePool", func(t *testing.T) {
+	t.Run("NoDatabasePool", func(t *testing.T) {
 		t.Parallel()
 
 		driver := New(nil)
 		require.Nil(t, driver.dbPool)
+	})
+
+	t.Run("PollOnly", func(t *testing.T) {
+		t.Parallel()
+
+		driver := New(&sql.DB{})
+		require.Nil(t, driver.listenerDriver)
+		require.False(t, driver.SupportsListener())
+		require.True(t, driver.SupportsListenNotify())
+		require.PanicsWithValue(t, riverdriver.ErrNotImplemented, func() {
+			driver.GetListener(&riverdriver.GetListenenerParams{})
+		})
 	})
 }
 

--- a/riverdriver/riverdrivertest/driver_client_test.go
+++ b/riverdriver/riverdrivertest/driver_client_test.go
@@ -58,6 +58,26 @@ func TestClientWithDriverRiverDatabaseSQLPgx(t *testing.T) {
 		ctx     = context.Background()
 		dbPool  = riversharedtest.DBPool(ctx, t)
 		stdPool = stdlib.OpenDBFromPool(dbPool)
+		driver  = riverdatabasesql.New(stdPool)
+	)
+	t.Cleanup(func() { require.NoError(t, stdPool.Close()) })
+
+	ExerciseClient(ctx, t,
+		func(ctx context.Context, t *testing.T) (riverdriver.Driver[*sql.Tx], string) {
+			t.Helper()
+
+			return driver, riverdbtest.TestSchema(ctx, t, driver, nil)
+		},
+	)
+}
+
+func TestClientWithDriverRiverDatabaseSQLPgxWithPgxListener(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx     = context.Background()
+		dbPool  = riversharedtest.DBPool(ctx, t)
+		stdPool = stdlib.OpenDBFromPool(dbPool)
 		driver  = riverdatabasesql.NewWithPgxListener(stdPool, dbPool)
 	)
 	t.Cleanup(func() { require.NoError(t, stdPool.Close()) })
@@ -71,7 +91,7 @@ func TestClientWithDriverRiverDatabaseSQLPgx(t *testing.T) {
 	)
 }
 
-func TestClientWithDriverRiverDatabaseSQLPgxJobCompleteTx(t *testing.T) {
+func TestClientWithDriverRiverDatabaseSQLPgxWithPgxListenerJobCompleteTx(t *testing.T) {
 	t.Parallel()
 
 	var (

--- a/riverdriver/riverdrivertest/driver_test.go
+++ b/riverdriver/riverdrivertest/driver_test.go
@@ -61,7 +61,37 @@ func TestDriverRiverDatabaseSQLLibPQ(t *testing.T) {
 		})
 }
 
-func TestDriverRiverDatabaseSQLPgx(t *testing.T) {
+func TestDriverRiverDatabaseSQLPgxNoListener(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx     = context.Background()
+		dbPool  = riversharedtest.DBPool(ctx, t)
+		stdPool = stdlib.OpenDBFromPool(dbPool)
+		driver  = riverdatabasesql.New(stdPool)
+	)
+	t.Cleanup(func() { require.NoError(t, stdPool.Close()) })
+
+	riverdrivertest.Exercise(ctx, t,
+		func(ctx context.Context, t *testing.T, opts *riverdbtest.TestSchemaOpts) (riverdriver.Driver[*sql.Tx], string) {
+			t.Helper()
+
+			return driver, riverdbtest.TestSchema(ctx, t, driver, opts)
+		},
+		func(ctx context.Context, t *testing.T) (riverdriver.Executor, riverdriver.Driver[*sql.Tx]) {
+			t.Helper()
+
+			tx, schema := riverdbtest.TestTx(ctx, t, driver, nil)
+
+			// The same thing as the built-in riverdbtest.TestTxPgx does.
+			_, err := tx.ExecContext(ctx, "SET search_path TO '"+schema+"'")
+			require.NoError(t, err)
+
+			return driver.UnwrapExecutor(tx), driver
+		})
+}
+
+func TestDriverRiverDatabaseSQLPgxWithPgxListener(t *testing.T) {
 	t.Parallel()
 
 	var (


### PR DESCRIPTION
Small follow up to #1366 in which we add back non-listener test coverage
for `riverdatabasesql`. In #1366 the driver tests replaced the
non-listener driver initialization with the listener version which is
probably largely okay since most code is going to get shared, but it's
not a bad idea to also make sure the driver is fully operable without a
listener.